### PR TITLE
First-run onboarding wizard (closes #22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,14 +34,19 @@ The built-in bitmap fonts (`src/fonts/FreeSans7pt7b.h`, `FreeMono5pt7b.h`) only 
 **printable ASCII 0x20..0x7E**. Any other codepoint renders as a `[]` missing-glyph box.
 
 This commonly bites when:
-- Using `·` (U+00B7 middle dot), `•` (U+2022 bullet), `…` (U+2026 ellipsis) as separators or decoration
+- Using em-dashes (`—`, U+2014), en-dashes (`–`, U+2013), `·` (U+00B7 middle dot), `•` (U+2022 bullet), `…` (U+2026 ellipsis), curly quotes (`"`, `"`, `'`, `'`), or arrows (`→`, `←`) as separators or decoration
 - Pulling display strings from external APIs (GPS names, channel names, contact names) without sanitizing
 - Copying UI conventions from web/desktop apps
 
 Safe substitutes:
+- Em/en-dash: `--` or ` - `
 - Separator: `|` or multiple spaces
 - Ellipsis: `...`
 - Bullet: `-` or `*`
+- Arrows: `->` or `<-`
+- Quotes: straight `"` and `'`
+
+**Applies equally to docs.** Markdown under `lua/docs/manual/` is embedded into firmware and rendered by the on-device markdown viewer (`lua/ezui/markdown.lua`), which uses the same fonts as everything else — non-ASCII characters render as `[]` boxes there too. Keep the source ASCII; the auto-generated `docs/manual/` and `docs/api/` trees served on GitHub Pages are tolerant either way, but the source the renderer reads must not be.
 
 If a new glyph is genuinely needed, extend the bitmap font (run the font generator with
 a wider range); otherwise stick to ASCII in any string that reaches `draw_text`.

--- a/lua/boot.lua
+++ b/lua/boot.lua
@@ -113,6 +113,17 @@ local function boot_sequence()
         ez.mesh.set_announce_interval(adv_ms)
     end
 
+    -- Apply the saved LoRa carrier frequency. The onboarding wizard
+    -- writes this on the region step; without persistence, every reboot
+    -- would fall back to whatever the radio driver defaults to, which
+    -- would silently take the device out of the user's chosen mesh.
+    -- The value is persisted as a string because set_pref(float) lands
+    -- in NVS as a blob with no matching float reader on the get side.
+    local freq_mhz = tonumber(ez.storage.get_pref("radio_freq_mhz", "")) or 0
+    if freq_mhz > 0 and ez.radio and ez.radio.set_frequency then
+        ez.radio.set_frequency(freq_mhz)
+    end
+
     local ui = require("ezui")
 
     ez.log("[Boot] Framework loaded")
@@ -194,8 +205,21 @@ local function boot_sequence()
     local desktop = ui.create_screen(Desktop, {})
     ui.push(desktop)
 
-    -- Start the framework main loop
-    ui.start({ theme = "dark" })
+    -- First-run gate: if the user hasn't completed onboarding yet,
+    -- push the wizard on top of the desktop. The wizard pops itself
+    -- after the done step so the user lands directly on the desktop.
+    local onboarding = require("screens.onboarding")
+    if not onboarding.is_onboarded() then
+        ez.log("[Boot] First run — entering onboarding wizard")
+        onboarding.start()
+    end
+
+    -- Start the framework main loop. Honour the saved theme so the
+    -- choice made in the wizard (or Settings → Display) survives a
+    -- reboot; default to dark when no pref has been written yet.
+    local theme_name = ez.storage.get_pref("theme", "dark")
+    if theme_name ~= "dark" and theme_name ~= "light" then theme_name = "dark" end
+    ui.start({ theme = theme_name })
 
     ez.log("[Boot] Boot complete")
 end

--- a/lua/docs/manual/getting-started.md
+++ b/lua/docs/manual/getting-started.md
@@ -6,8 +6,27 @@ common tasks: Messages, Contacts, Map, and More (the full app menu).
 ## First boot
 
 On first boot the device generates a fresh Ed25519 identity and joins
-the public mesh channel automatically. No setup is required to send
-or receive messages on the public channel.
+the public mesh channel automatically.
+
+A short onboarding wizard walks you through the must-set fields:
+
+1. **Welcome** -- a one-screen recap of what the device does.
+2. **Node name** -- how this device shows up on the mesh. Letters,
+   digits, and basic punctuation; ASCII only (32 characters max).
+3. **Region** -- the LoRa band that's legal in your country
+   (EU 869 / US 915 / AS 433 / AU 915). All nodes in your mesh must be
+   on the same band.
+4. **Timezone** -- the wall-clock region the status-bar clock uses.
+5. **Theme** -- dark or light, plus an accent colour.
+
+After step 5 the device is "onboarded" and every later boot lands
+straight on the desktop. Two optional screens follow before the
+desktop appears: an optional callsign for chat headers, and a readout
+of your public identity (short ID + hex public key) you can share
+with another node. Both can be skipped.
+
+To re-run the wizard later, open `Settings > System > Repeat
+onboarding`.
 
 If `!RF` shows in the status bar, the LoRa radio failed to initialize.
 Check the wiring and reboot. Until that clears, mesh features are

--- a/lua/docs/manual/settings.md
+++ b/lua/docs/manual/settings.md
@@ -38,3 +38,11 @@ Set the system clock. GPS supplies time when a fix is available.
 
 Pick a wallpaper from `/fs/wallpapers/`. Use the Files app to set
 any JPEG as wallpaper.
+
+## System
+
+Device-level operations.
+
+- Repeat onboarding: re-runs the first-run wizard from the welcome
+  screen. The flow over-writes prefs idempotently, so it's safe to
+  rerun on an already-onboarded device.

--- a/lua/screens/onboarding/callsign.lua
+++ b/lua/screens/onboarding/callsign.lua
@@ -1,0 +1,74 @@
+-- Onboarding optional — callsign.
+--
+-- Free-text, max 16 chars, ASCII only. Skipping clears the pref so a
+-- user who picked a callsign on a prior run, then ran "Repeat
+-- onboarding" and skipped this step, doesn't keep the stale value.
+
+local ui = require("ezui")
+local M  = require("screens.onboarding")
+
+local PATH = "screens.onboarding.callsign"
+local MAX_LEN = 16
+
+local Callsign = { title = "Callsign" }
+
+function Callsign.initial_state()
+    local current = ez.storage.get_pref("callsign", "")
+    return { value = M.ascii_only(current or "") }
+end
+
+function Callsign:_commit(raw)
+    local value = M.ascii_only(raw or "")
+    ez.storage.set_pref("callsign", value)
+    M.advance(PATH)
+end
+
+function Callsign:_skip()
+    ez.storage.set_pref("callsign", "")
+    M.advance(PATH)
+end
+
+function Callsign:build(state)
+    return ui.vbox({ gap = 0, bg = "BG" }, {
+        ui.title_bar("Callsign", { back = true, right = M.progress_label(PATH) }),
+        ui.scroll({ grow = 1 },
+            ui.padding({ 10, 12, 10, 12 },
+                ui.vbox({ gap = 6 }, {
+                    ui.text_widget("Optional: pick a callsign",
+                        { color = "TEXT", font = "small_aa", wrap = true }),
+                    ui.text_widget(
+                        "Some chat and DM screens show this next to your " ..
+                        "name. Leave blank to skip; you can set it later " ..
+                        "from Settings.",
+                        { color = "TEXT_MUTED", font = "tiny_aa", wrap = true }),
+                    ui.padding({ 4, 0, 0, 0 },
+                        ui.text_input({
+                            value = state.value or "",
+                            max_length = MAX_LEN,
+                            placeholder = "Callsign",
+                            on_change = function(v) state.value = v end,
+                            on_submit = function(v) self:_commit(v) end,
+                        })
+                    ),
+                    ui.padding({ 12, 0, 0, 0 },
+                        ui.hbox({ gap = 8 }, {
+                            ui.button("Continue", {
+                                on_press = function() self:_commit(state.value) end,
+                            }),
+                            ui.button("Skip", {
+                                on_press = function() self:_skip() end,
+                            }),
+                        })
+                    ),
+                })
+            )
+        ),
+    })
+end
+
+function Callsign:handle_key(key)
+    if key.special == "BACKSPACE" or key.special == "ESCAPE" then return "pop" end
+    return nil
+end
+
+return Callsign

--- a/lua/screens/onboarding/done.lua
+++ b/lua/screens/onboarding/done.lua
@@ -26,7 +26,7 @@ end
 
 function Done:build(state)
     return ui.vbox({ gap = 0, bg = "BG" }, {
-        ui.title_bar("All set!", { right = M.progress_label("done") }),
+        ui.title_bar("All set!", {}),
         ui.scroll({ grow = 1 },
             ui.padding({ 12, 14, 10, 14 },
                 ui.vbox({ gap = 6 }, {

--- a/lua/screens/onboarding/done.lua
+++ b/lua/screens/onboarding/done.lua
@@ -1,0 +1,64 @@
+-- Onboarding final step — set the onboarded pref and unwind.
+--
+-- Per the issue, the done screen is the only place that writes the
+-- onboarded flag. Earlier steps persist their own field on ENTER so a
+-- power loss mid-flow keeps that progress; the gate that says "skip
+-- the wizard at boot" only flips here, after the user has actually
+-- arrived at the final screen.
+
+local ui = require("ezui")
+local M  = require("screens.onboarding")
+
+local Done = { title = "All set!" }
+
+function Done:_finish()
+    ez.storage.set_pref(M.PREF_ONBOARDED, "1")
+    M.finish()
+end
+
+function Done:on_enter()
+    -- Mark onboarded as soon as the user reaches this screen — the
+    -- only thing left is dismissal, and that shouldn't be re-litigated
+    -- on a future boot if e.g. the battery dies before they press a
+    -- key. Idempotent on a "Repeat onboarding" run.
+    ez.storage.set_pref(M.PREF_ONBOARDED, "1")
+end
+
+function Done:build(state)
+    return ui.vbox({ gap = 0, bg = "BG" }, {
+        ui.title_bar("All set!", { right = M.progress_label("done") }),
+        ui.scroll({ grow = 1 },
+            ui.padding({ 12, 14, 10, 14 },
+                ui.vbox({ gap = 6 }, {
+                    ui.text_widget("You're ready to go.",
+                        { color = "ACCENT", font = "medium_aa" }),
+                    ui.text_widget(
+                        "Settings can fine-tune any of these later. " ..
+                        "Press ENTER to drop to the desktop.",
+                        { color = "TEXT", font = "small_aa", wrap = true }),
+                    ui.padding({ 12, 0, 0, 0 },
+                        ui.button("Open desktop", {
+                            on_press = function() self:_finish() end,
+                        })
+                    ),
+                })
+            )
+        ),
+    })
+end
+
+function Done:handle_key(key)
+    if key.special == "ENTER" then
+        self:_finish()
+        return "handled"
+    end
+    -- Don't let the user back out of "All set!" — the pref is already
+    -- written, so backing up would just take them to the optional
+    -- identity step from a state that's already complete. Swallow.
+    if key.special == "BACKSPACE" or key.special == "ESCAPE" then
+        return "handled"
+    end
+    return nil
+end
+
+return Done

--- a/lua/screens/onboarding/identity.lua
+++ b/lua/screens/onboarding/identity.lua
@@ -1,0 +1,85 @@
+-- Onboarding optional — identity readout.
+--
+-- Shows the node's public identity hash so the user can write it down
+-- or share it with another mesh participant. The full Ed25519 public
+-- key is also displayed for completeness; both values are derived from
+-- the keypair stored in NVS, which survives a reflash unless the user
+-- explicitly wipes prefs.
+--
+-- This screen does not back up the private key. SD-based identity
+-- backup/restore is tracked separately. A QR rendering of the pubkey
+-- is also out of scope here (no QR encoder is present in the firmware
+-- yet); a future change can add the QR overlay alongside the hex.
+
+local ui = require("ezui")
+local M  = require("screens.onboarding")
+
+local PATH = "screens.onboarding.identity"
+
+local Identity = { title = "Identity" }
+
+local function get_node_id()
+    if ez.mesh and ez.mesh.get_node_id then
+        local id = ez.mesh.get_node_id()
+        if id and id ~= "" then return id end
+    end
+    return "(radio not initialised)"
+end
+
+local function get_pub_key_hex()
+    if ez.mesh and ez.mesh.get_public_key_hex then
+        local k = ez.mesh.get_public_key_hex()
+        if k and k ~= "" then return k end
+    end
+    return nil
+end
+
+function Identity:build(state)
+    local rows = {
+        ui.text_widget("Your identity on the mesh",
+            { color = "TEXT", font = "small_aa", wrap = true }),
+        ui.text_widget(
+            "Other nodes recognise this device by the short ID below. " ..
+            "It's safe to share. The matching private key stays in NVS " ..
+            "and survives a reflash unless explicitly cleared.",
+            { color = "TEXT_MUTED", font = "tiny_aa", wrap = true }),
+        ui.padding({ 8, 0, 0, 0 },
+            ui.text_widget("Short ID",
+                { color = "ACCENT", font = "small_aa" })
+        ),
+        ui.text_widget(get_node_id(),
+            { color = "TEXT", font = "medium_aa" }),
+    }
+
+    local pub = get_pub_key_hex()
+    if pub then
+        rows[#rows + 1] = ui.padding({ 8, 0, 0, 0 },
+            ui.text_widget("Public key",
+                { color = "ACCENT", font = "small_aa" })
+        )
+        rows[#rows + 1] = ui.text_widget(pub,
+            { color = "TEXT_SEC", font = "tiny_aa", wrap = true })
+    end
+
+    rows[#rows + 1] = ui.padding({ 12, 0, 0, 0 },
+        ui.button("Continue", {
+            on_press = function() M.advance(PATH) end,
+        })
+    )
+
+    return ui.vbox({ gap = 0, bg = "BG" }, {
+        ui.title_bar("Identity", { back = true, right = M.progress_label(PATH) }),
+        ui.scroll({ grow = 1 },
+            ui.padding({ 10, 12, 10, 12 },
+                ui.vbox({ gap = 6 }, rows)
+            )
+        ),
+    })
+end
+
+function Identity:handle_key(key)
+    if key.special == "BACKSPACE" or key.special == "ESCAPE" then return "pop" end
+    return nil
+end
+
+return Identity

--- a/lua/screens/onboarding/init.lua
+++ b/lua/screens/onboarding/init.lua
@@ -1,0 +1,117 @@
+-- First-run onboarding wizard.
+--
+-- Each step is its own screen module under this directory; this file is
+-- the orchestrator. start() pushes the welcome screen on top of whatever
+-- is currently active (the desktop, on a fresh boot). Each step's ENTER
+-- handler calls advance() which pushes the next module; BACKSPACE pops.
+-- The welcome screen suppresses BACKSPACE so the user can't escape to
+-- the desktop until the required steps are committed.
+--
+-- The done step writes onboarded = "1" and pops every onboarding screen
+-- off, leaving the desktop on top. Onboarding screens are tagged with
+-- _onboarding = true on the screen module so the unwind loop knows where
+-- to stop without needing absolute stack indices.
+
+local M = {}
+
+-- Order of screens. Required first, then optional. The "Step N / 5"
+-- progress label is computed against #REQUIRED.
+M.REQUIRED = {
+    "screens.onboarding.welcome",
+    "screens.onboarding.node_name",
+    "screens.onboarding.region",
+    "screens.onboarding.timezone",
+    "screens.onboarding.theme",
+}
+
+M.OPTIONAL = {
+    "screens.onboarding.callsign",
+    "screens.onboarding.identity",
+}
+
+M.DONE = "screens.onboarding.done"
+
+-- Reverse map: module path → 1-based step number among REQUIRED. Keeps
+-- the title-bar progress indicator honest if step modules get reordered.
+M.REQUIRED_INDEX = {}
+for i, path in ipairs(M.REQUIRED) do M.REQUIRED_INDEX[path] = i end
+
+M.PREF_ONBOARDED = "onboarded"
+
+-- Strip non-ASCII bytes from a string. The on-device bitmap fonts only
+-- cover 0x20..0x7E, so non-ASCII would render as `[]` in chat/contact
+-- lists. Applied to free-text inputs before they're persisted.
+function M.ascii_only(s)
+    if not s then return "" end
+    return (s:gsub("[^\32-\126]", ""))
+end
+
+-- True when the user has completed onboarding at least once. Coerces a
+-- couple of historical truthy shapes since NVS can return strings.
+function M.is_onboarded()
+    local v = ez.storage.get_pref(M.PREF_ONBOARDED, nil)
+    if v == nil then return false end
+    if type(v) == "boolean" then return v end
+    if type(v) == "number"  then return v ~= 0 end
+    if type(v) == "string"  then return v == "1" or v == "true" end
+    return false
+end
+
+-- Push a step module by require path. Each push creates a fresh instance
+-- so initial_state() runs again — that re-reads any prefs the previous
+-- step wrote, which keeps "back, then forward" navigation idempotent.
+function M.push_step(path)
+    local screen = require("ezui.screen")
+    local def = require(path)
+    def._onboarding = true
+    local init = def.initial_state and def.initial_state() or {}
+    screen.push(screen.create(def, init))
+end
+
+-- Advance to the next step. The current step's module path is passed in
+-- so the navigation table doesn't need to live on the screen instance.
+function M.advance(current_path)
+    local order = {}
+    for _, p in ipairs(M.REQUIRED) do order[#order + 1] = p end
+    for _, p in ipairs(M.OPTIONAL) do order[#order + 1] = p end
+    order[#order + 1] = M.DONE
+
+    for i, p in ipairs(order) do
+        if p == current_path and order[i + 1] then
+            M.push_step(order[i + 1])
+            return
+        end
+    end
+end
+
+-- Tear down the wizard stack: pop every screen tagged with _onboarding
+-- so we land on whatever was underneath (the desktop on first boot, or
+-- Settings on a "Repeat onboarding" run).
+function M.finish()
+    local screen = require("ezui.screen")
+    while true do
+        local top = screen.peek()
+        if not top or not (top._def and top._def._onboarding) then break end
+        local depth = screen.depth()
+        screen.pop()
+        if screen.depth() == depth then break end  -- root guard hit
+    end
+end
+
+-- Public entry point. Used by boot.lua on first boot and by the
+-- "Repeat onboarding" entry under Settings → System.
+function M.start()
+    M.push_step(M.REQUIRED[1])
+end
+
+-- Build the title-bar `right` label for a given step path. Required
+-- steps show "Step N / total"; optional steps show "Optional".
+function M.progress_label(path)
+    local idx = M.REQUIRED_INDEX[path]
+    if idx then
+        return string.format("Step %d / %d", idx, #M.REQUIRED)
+    end
+    return "Optional"
+end
+
+return M

--- a/lua/screens/onboarding/node_name.lua
+++ b/lua/screens/onboarding/node_name.lua
@@ -1,0 +1,87 @@
+-- Onboarding step 2 of 5 — node name.
+--
+-- Free-text, max 32 chars, ASCII only (the on-device fonts only cover
+-- 0x20..0x7E — non-ASCII would render as `[]` boxes in the chat list).
+-- Pre-fills with the current node name (the chip-MAC default for a
+-- fresh device, or whatever a previous onboarding run wrote).
+
+local ui = require("ezui")
+local M  = require("screens.onboarding")
+
+local PATH = "screens.onboarding.node_name"
+local MAX_LEN = 32
+
+local NodeName = { title = "Node name" }
+
+function NodeName.initial_state()
+    local current = (ez.mesh and ez.mesh.get_node_name and ez.mesh.get_node_name()) or ""
+    return { value = M.ascii_only(current) }
+end
+
+function NodeName:_commit(raw)
+    local value = M.ascii_only(raw or "")
+    if value == "" then
+        self._state.error = "Node name can't be empty."
+        self:set_state({})
+        return
+    end
+    if ez.mesh and ez.mesh.set_node_name then
+        ez.mesh.set_node_name(value)
+    end
+    M.advance(PATH)
+end
+
+function NodeName:build(state)
+    local children = {
+        ui.padding({ 0, 0, 6, 0 },
+            ui.text_widget("What name should appear on the mesh?",
+                { color = "TEXT", font = "small_aa", wrap = true })
+        ),
+        ui.text_input({
+            value = state.value or "",
+            max_length = MAX_LEN,
+            placeholder = "Node name",
+            on_change = function(v)
+                state.value = v
+            end,
+            on_submit = function(v)
+                self:_commit(v)
+            end,
+        }),
+        ui.padding({ 4, 0, 0, 0 },
+            ui.text_widget(
+                "Letters, digits, spaces, basic punctuation. Max " ..
+                tostring(MAX_LEN) .. " characters.",
+                { color = "TEXT_MUTED", font = "tiny_aa", wrap = true })
+        ),
+    }
+
+    if state.error then
+        children[#children + 1] = ui.padding({ 6, 0, 0, 0 },
+            ui.text_widget(state.error,
+                { color = "ERROR", font = "tiny_aa" })
+        )
+    end
+
+    children[#children + 1] = ui.padding({ 12, 0, 0, 0 },
+        ui.button("Continue", {
+            on_press = function() self:_commit(state.value) end,
+        })
+    )
+
+    return ui.vbox({ gap = 0, bg = "BG" }, {
+        ui.title_bar("Node name", { back = true, right = M.progress_label(PATH) }),
+        ui.scroll({ grow = 1 },
+            ui.padding({ 10, 12, 10, 12 },
+                ui.vbox({ gap = 6 }, children)
+            )
+        ),
+    })
+end
+
+function NodeName:handle_key(key)
+    if key.special == "BACKSPACE" or key.special == "ESCAPE" then return "pop" end
+    return nil
+end
+
+return NodeName

--- a/lua/screens/onboarding/region.lua
+++ b/lua/screens/onboarding/region.lua
@@ -1,0 +1,93 @@
+-- Onboarding step 3 of 5 — radio region / frequency.
+--
+-- LoRa is regulated per region. Picking the wrong band is illegal in
+-- most countries and won't reach any neighbours anyway. The wizard
+-- offers four well-known presets; advanced users can fine-tune later
+-- via the radio API or the Settings → Radio screen.
+--
+-- The pick is persisted under `radio_freq_mhz` and re-applied at boot
+-- by lua/boot.lua. The hardware change happens immediately so the user
+-- gets feedback (mesh is_initialized flips off briefly while the radio
+-- re-tunes, then back on).
+
+local ui = require("ezui")
+local M  = require("screens.onboarding")
+
+local PATH = "screens.onboarding.region"
+
+local PRESETS = {
+    { label = "EU 869 MHz", mhz = 869.525 },
+    { label = "US 915 MHz", mhz = 906.875 },
+    { label = "AS 433 MHz", mhz = 433.000 },
+    { label = "AU 915 MHz", mhz = 915.000 },
+}
+
+local LABELS = {}
+for i, p in ipairs(PRESETS) do LABELS[i] = p.label end
+
+-- The MHz value is stored as a string (e.g. "869.525") rather than a
+-- number: ez.storage.set_pref routes lua floats through putFloat → blob,
+-- but the matching get_pref has no float decoder and returns "" for
+-- blobs. Stringifying side-steps the round-trip.
+local function default_index()
+    local raw = ez.storage.get_pref("radio_freq_mhz", "")
+    local saved = tonumber(raw) or 0
+    if saved > 0 then
+        for i, p in ipairs(PRESETS) do
+            if math.abs(p.mhz - saved) < 0.01 then return i end
+        end
+    end
+    return 1
+end
+
+local Region = { title = "Region" }
+
+function Region.initial_state()
+    return { idx = default_index() }
+end
+
+function Region:_commit(idx)
+    local preset = PRESETS[idx]
+    if not preset then return end
+    if ez.radio and ez.radio.set_frequency then
+        ez.radio.set_frequency(preset.mhz)
+    end
+    ez.storage.set_pref("radio_freq_mhz", tostring(preset.mhz))
+    M.advance(PATH)
+end
+
+function Region:build(state)
+    return ui.vbox({ gap = 0, bg = "BG" }, {
+        ui.title_bar("Region", { back = true, right = M.progress_label(PATH) }),
+        ui.scroll({ grow = 1 },
+            ui.padding({ 10, 12, 10, 12 },
+                ui.vbox({ gap = 6 }, {
+                    ui.text_widget("Which radio band are you using?",
+                        { color = "TEXT", font = "small_aa", wrap = true }),
+                    ui.text_widget(
+                        "Pick the legal band for your country. All nodes " ..
+                        "in your mesh must use the same band.",
+                        { color = "TEXT_MUTED", font = "tiny_aa", wrap = true }),
+                    ui.padding({ 6, 0, 0, 0 },
+                        ui.dropdown(LABELS, {
+                            value = state.idx,
+                            on_change = function(idx) state.idx = idx end,
+                        })
+                    ),
+                    ui.padding({ 12, 0, 0, 0 },
+                        ui.button("Continue", {
+                            on_press = function() self:_commit(state.idx) end,
+                        })
+                    ),
+                })
+            )
+        ),
+    })
+end
+
+function Region:handle_key(key)
+    if key.special == "BACKSPACE" or key.special == "ESCAPE" then return "pop" end
+    return nil
+end
+
+return Region

--- a/lua/screens/onboarding/theme.lua
+++ b/lua/screens/onboarding/theme.lua
@@ -1,0 +1,121 @@
+-- Onboarding step 5 of 5 — theme + accent.
+--
+-- Mirrors the controls in Settings → Display so the user gets the same
+-- palette they'd choose later. Toggle flips dark/light immediately so
+-- the rest of the wizard repaints in the chosen scheme; accent changes
+-- repaint the focus ring of the Continue button live.
+
+local ui        = require("ezui")
+local theme     = require("ezui.theme")
+local node_mod  = require("ezui.node")
+local focus_mod = require("ezui.focus")
+local M         = require("screens.onboarding")
+
+local PATH = "screens.onboarding.theme"
+
+-- Reuse the swatch node registered by display_settings.lua. If the user
+-- hasn't visited that screen yet this run, register it here too —
+-- node.register is idempotent on second registration via the guard
+-- below, matching the same pattern used in display_settings.lua.
+if not node_mod.handler("color_swatch") then
+    node_mod.register("color_swatch", {
+        focusable = true,
+        measure = function(n, max_w, max_h)
+            local size = n.size or 26
+            return size, size
+        end,
+        draw = function(n, d, x, y, w, h)
+            local color = n.color or 0xFFFF
+            d.fill_round_rect(x + 2, y + 2, w - 4, h - 4, 3, color)
+            if n._focused then
+                d.draw_round_rect(x, y, w, h, 4, theme.color("TEXT"))
+            elseif n.selected then
+                d.draw_round_rect(x + 1, y + 1, w - 2, h - 2, 3,
+                    theme.color("TEXT_SEC"))
+            end
+        end,
+        on_activate = function(n, key)
+            if n.on_press then n.on_press() end
+            return "handled"
+        end,
+        on_key = function(n, key)
+            if key.special == "LEFT" then focus_mod.prev(); return "handled"
+            elseif key.special == "RIGHT" then focus_mod.next(); return "handled"
+            elseif key.special == "UP" then
+                while focus_mod.index > 1 do
+                    focus_mod.prev()
+                    local cur = focus_mod.current()
+                    if not cur or cur.type ~= "color_swatch" then break end
+                end
+                return "handled"
+            elseif key.special == "DOWN" then
+                while focus_mod.index < #focus_mod.chain do
+                    focus_mod.next()
+                    local cur = focus_mod.current()
+                    if not cur or cur.type ~= "color_swatch" then break end
+                end
+                return "handled"
+            end
+            return nil
+        end,
+    })
+end
+
+local Theme = { title = "Theme" }
+
+function Theme:_commit()
+    M.advance(PATH)
+end
+
+function Theme:build(state)
+    local swatches = {}
+    local current_accent = theme.color("ACCENT")
+    for _, preset in ipairs(theme.ACCENT_PRESETS) do
+        swatches[#swatches + 1] = {
+            type = "color_swatch",
+            color = preset.color,
+            selected = (preset.color == current_accent),
+            on_press = function()
+                theme.save_accent(preset.color)
+                self:set_state({})
+            end,
+        }
+    end
+
+    return ui.vbox({ gap = 0, bg = "BG" }, {
+        ui.title_bar("Theme", { back = true, right = M.progress_label(PATH) }),
+        ui.scroll({ grow = 1 },
+            ui.padding({ 10, 12, 10, 12 },
+                ui.vbox({ gap = 8 }, {
+                    ui.text_widget("Pick a colour scheme",
+                        { color = "TEXT", font = "small_aa", wrap = true }),
+                    ui.toggle("Dark mode", theme.name == "dark", {
+                        on_change = function(on)
+                            local name = on and "dark" or "light"
+                            theme.set(name)
+                            ez.storage.set_pref("theme", name)
+                            self:set_state({})
+                        end,
+                    }),
+                    ui.padding({ 8, 0, 0, 0 },
+                        ui.text_widget("Accent colour",
+                            { color = "ACCENT", font = "small_aa" })
+                    ),
+                    ui.hbox({ gap = 4 }, swatches),
+                    ui.padding({ 12, 0, 0, 0 },
+                        ui.button("Continue", {
+                            on_press = function() self:_commit() end,
+                        })
+                    ),
+                })
+            )
+        ),
+    })
+end
+
+function Theme:handle_key(key)
+    if key.special == "BACKSPACE" or key.special == "ESCAPE" then return "pop" end
+    return nil
+end
+
+return Theme

--- a/lua/screens/onboarding/timezone.lua
+++ b/lua/screens/onboarding/timezone.lua
@@ -1,0 +1,58 @@
+-- Onboarding step 4 of 5 — timezone.
+--
+-- Reuses the shared util.timezones table so the same picker shows up
+-- here and in Settings → Time. Defaults to UTC (the firmware boot
+-- default) until the user picks a real region.
+
+local ui  = require("ezui")
+local M   = require("screens.onboarding")
+local tzs = require("util.timezones")
+
+local PATH = "screens.onboarding.timezone"
+
+local Timezone = { title = "Timezone" }
+
+function Timezone.initial_state()
+    return { idx = tzs.current_index() }
+end
+
+function Timezone:_commit(idx)
+    tzs.apply_index(idx)
+    M.advance(PATH)
+end
+
+function Timezone:build(state)
+    return ui.vbox({ gap = 0, bg = "BG" }, {
+        ui.title_bar("Timezone", { back = true, right = M.progress_label(PATH) }),
+        ui.scroll({ grow = 1 },
+            ui.padding({ 10, 12, 10, 12 },
+                ui.vbox({ gap = 6 }, {
+                    ui.text_widget("Which timezone are you in?",
+                        { color = "TEXT", font = "small_aa", wrap = true }),
+                    ui.text_widget(
+                        "DST transitions happen automatically. The GPS " ..
+                        "service can refine the clock once it has a fix.",
+                        { color = "TEXT_MUTED", font = "tiny_aa", wrap = true }),
+                    ui.padding({ 6, 0, 0, 0 },
+                        ui.dropdown(tzs.LABELS, {
+                            value = state.idx,
+                            on_change = function(idx) state.idx = idx end,
+                        })
+                    ),
+                    ui.padding({ 12, 0, 0, 0 },
+                        ui.button("Continue", {
+                            on_press = function() self:_commit(state.idx) end,
+                        })
+                    ),
+                })
+            )
+        ),
+    })
+end
+
+function Timezone:handle_key(key)
+    if key.special == "BACKSPACE" or key.special == "ESCAPE" then return "pop" end
+    return nil
+end
+
+return Timezone

--- a/lua/screens/onboarding/welcome.lua
+++ b/lua/screens/onboarding/welcome.lua
@@ -1,0 +1,53 @@
+-- Onboarding step 1 of 5 — welcome.
+--
+-- One screen of prose. ENTER advances. BACKSPACE/ESC are deliberately
+-- suppressed: until the user commits the required steps, this screen
+-- guards the desktop from being reached.
+
+local ui  = require("ezui")
+local M   = require("screens.onboarding")
+
+local PATH = "screens.onboarding.welcome"
+
+local Welcome = { title = "Welcome" }
+
+function Welcome:build(state)
+    local body =
+        "ezOS is the firmware on this T-Deck. It speaks MeshCore, a " ..
+        "long-range encrypted radio mesh -- your messages hop from " ..
+        "device to device without needing the internet.\n\n" ..
+        "The next few screens set the must-haves: your node name, the " ..
+        "radio band you're in, your timezone, and your colour scheme. " ..
+        "Nothing here is irreversible -- you can change every setting " ..
+        "later from the Settings menu.\n\n" ..
+        "Press ENTER to begin."
+
+    return ui.vbox({ gap = 0, bg = "BG" }, {
+        ui.title_bar("Welcome", { right = M.progress_label(PATH) }),
+        ui.scroll({ grow = 1 },
+            ui.padding({ 12, 10, 10, 10 },
+                ui.vbox({ gap = 6 }, {
+                    ui.text_widget("Welcome to ezOS",
+                        { color = "ACCENT", font = "medium_aa" }),
+                    ui.text_widget(body,
+                        { color = "TEXT", font = "small_aa", wrap = true }),
+                })
+            )
+        ),
+    })
+end
+
+function Welcome:handle_key(key)
+    if key.special == "ENTER" then
+        M.advance(PATH)
+        return "handled"
+    end
+    -- BACKSPACE / ESCAPE intentionally swallowed: the user must commit
+    -- the required steps before they can reach the desktop.
+    if key.special == "BACKSPACE" or key.special == "ESCAPE" then
+        return "handled"
+    end
+    return nil
+end
+
+return Welcome

--- a/lua/screens/settings/settings.lua
+++ b/lua/screens/settings/settings.lua
@@ -24,6 +24,7 @@ local CATEGORIES = {
     { title = "Time",      subtitle = "Timezone, 12 / 24h format",    icon = icons.info,          mod = "screens.settings.time_settings" },
     { title = "Radio",     subtitle = "Mesh advert, announce cadence",icon = icons.radio_tower,   mod = "screens.settings.radio_settings" },
     { title = "Sound",     subtitle = "UI feedback, volume",          icon = icons.radio_tower,   mod = "screens.settings.sound_settings" },
+    { title = "System",    subtitle = "Repeat onboarding",            icon = icons.settings,      mod = "screens.settings.system_settings" },
     { title = "About",     subtitle = "Version, credits",             icon = icons.info,          mod = "screens.about" },
 }
 

--- a/lua/screens/settings/system_settings.lua
+++ b/lua/screens/settings/system_settings.lua
@@ -1,0 +1,34 @@
+-- System settings: device-level operations.
+--
+-- "Repeat onboarding" pushes the wizard root again so a user who
+-- skimmed the first run can re-do it without manually clearing the
+-- onboarded pref. Future entries (factory reset, backup/restore) can
+-- live here too.
+
+local ui    = require("ezui")
+local icons = require("ezui.icons")
+
+local System = { title = "System" }
+
+function System:build(state)
+    return ui.vbox({ gap = 0, bg = "BG" }, {
+        ui.title_bar("System", { back = true }),
+        ui.scroll({ grow = 1 }, ui.vbox({ gap = 0 }, {
+            ui.list_item({
+                title    = "Repeat onboarding",
+                subtitle = "Walk through the first-run wizard again",
+                icon     = icons.settings,
+                on_press = function()
+                    require("screens.onboarding").start()
+                end,
+            }),
+        })),
+    })
+end
+
+function System:handle_key(key)
+    if key.special == "BACKSPACE" or key.special == "ESCAPE" then return "pop" end
+    return nil
+end
+
+return System

--- a/lua/screens/settings/time_settings.lua
+++ b/lua/screens/settings/time_settings.lua
@@ -4,43 +4,12 @@
 -- by a caller invoking ez.system.set_time directly — this screen only
 -- controls how that clock is interpreted and displayed.
 
-local ui = require("ezui")
+local ui  = require("ezui")
+local tzs = require("util.timezones")
 
 local Time = { title = "Time" }
 
--- Pref keys (NVS namespace: 15 char limit)
-local PREF_TZ           = "tz_posix"
 local PREF_TIME_FORMAT  = "time_format"   -- "12h" | "24h"
-
--- Common timezones as POSIX TZ strings. DST rules are baked in so the
--- displayed time flips automatically with the wall-clock change — no
--- need to re-sync or edit prefs twice a year. Order is rough "what
--- most users pick" rather than strictly alphabetical.
-local TZ_CHOICES = {
-    { label = "UTC",              tz = "UTC0" },
-    { label = "Amsterdam / CET",  tz = "CET-1CEST,M3.5.0,M10.5.0/3" },
-    { label = "London",           tz = "GMT0BST,M3.5.0/1,M10.5.0" },
-    { label = "Paris / Berlin",   tz = "CET-1CEST,M3.5.0,M10.5.0/3" },
-    { label = "Athens",           tz = "EET-2EEST,M3.5.0/3,M10.5.0/4" },
-    { label = "Moscow",           tz = "MSK-3" },
-    { label = "New York",         tz = "EST5EDT,M3.2.0,M11.1.0" },
-    { label = "Chicago",          tz = "CST6CDT,M3.2.0,M11.1.0" },
-    { label = "Denver",           tz = "MST7MDT,M3.2.0,M11.1.0" },
-    { label = "Los Angeles",      tz = "PST8PDT,M3.2.0,M11.1.0" },
-    { label = "Tokyo",            tz = "JST-9" },
-    { label = "Sydney",           tz = "AEST-10AEDT,M10.1.0,M4.1.0/3" },
-}
-
-local TZ_LABELS = {}
-for i, c in ipairs(TZ_CHOICES) do TZ_LABELS[i] = c.label end
-
-local function current_tz_index()
-    local cur = ez.storage.get_pref(PREF_TZ, "UTC0")
-    for i, c in ipairs(TZ_CHOICES) do
-        if c.tz == cur then return i end
-    end
-    return 1
-end
 
 local function pref_bool(key, default)
     local v = ez.storage.get_pref(key, nil)
@@ -52,7 +21,7 @@ end
 
 function Time.initial_state()
     return {
-        tz_index    = current_tz_index(),
+        tz_index    = tzs.current_index(),
         format_12h  = ez.storage.get_pref(PREF_TIME_FORMAT, "24h") == "12h",
     }
 end
@@ -135,16 +104,12 @@ function Time:build(state)
     )
 
     content[#content + 1] = ui.padding({ 2, 6, 2, 6 },
-        ui.dropdown(TZ_LABELS, {
+        ui.dropdown(tzs.LABELS, {
             label = "Region",
             value = state.tz_index,
             on_change = function(idx)
                 state.tz_index = idx
-                local entry = TZ_CHOICES[idx]
-                if entry then
-                    ez.storage.set_pref(PREF_TZ, entry.tz)
-                    ez.system.set_timezone(entry.tz)
-                end
+                tzs.apply_index(idx)
             end,
         })
     )

--- a/lua/util/timezones.lua
+++ b/lua/util/timezones.lua
@@ -11,11 +11,10 @@ local M = {}
 M.PREF_KEY = "tz_posix"
 
 M.CHOICES = {
-    { label = "UTC",              tz = "UTC0" },
-    { label = "Amsterdam / CET",  tz = "CET-1CEST,M3.5.0,M10.5.0/3" },
-    { label = "London",           tz = "GMT0BST,M3.5.0/1,M10.5.0" },
-    { label = "Paris / Berlin",   tz = "CET-1CEST,M3.5.0,M10.5.0/3" },
-    { label = "Athens",           tz = "EET-2EEST,M3.5.0/3,M10.5.0/4" },
+    { label = "UTC",                        tz = "UTC0" },
+    { label = "Amsterdam / Paris / Berlin", tz = "CET-1CEST,M3.5.0,M10.5.0/3" },
+    { label = "London",                     tz = "GMT0BST,M3.5.0/1,M10.5.0" },
+    { label = "Athens",                     tz = "EET-2EEST,M3.5.0/3,M10.5.0/4" },
     { label = "Moscow",           tz = "MSK-3" },
     { label = "New York",         tz = "EST5EDT,M3.2.0,M11.1.0" },
     { label = "Chicago",          tz = "CST6CDT,M3.2.0,M11.1.0" },

--- a/lua/util/timezones.lua
+++ b/lua/util/timezones.lua
@@ -1,0 +1,52 @@
+-- Shared timezone presets and lookup helpers.
+--
+-- The full POSIX-TZ table lives here so both the Time settings screen and
+-- the first-run onboarding wizard can offer the same picker without
+-- duplicating the table. Order is "what most users pick" rather than
+-- strictly alphabetical; DST rules are baked in so the displayed time
+-- flips automatically with the wall-clock change.
+
+local M = {}
+
+M.PREF_KEY = "tz_posix"
+
+M.CHOICES = {
+    { label = "UTC",              tz = "UTC0" },
+    { label = "Amsterdam / CET",  tz = "CET-1CEST,M3.5.0,M10.5.0/3" },
+    { label = "London",           tz = "GMT0BST,M3.5.0/1,M10.5.0" },
+    { label = "Paris / Berlin",   tz = "CET-1CEST,M3.5.0,M10.5.0/3" },
+    { label = "Athens",           tz = "EET-2EEST,M3.5.0/3,M10.5.0/4" },
+    { label = "Moscow",           tz = "MSK-3" },
+    { label = "New York",         tz = "EST5EDT,M3.2.0,M11.1.0" },
+    { label = "Chicago",          tz = "CST6CDT,M3.2.0,M11.1.0" },
+    { label = "Denver",           tz = "MST7MDT,M3.2.0,M11.1.0" },
+    { label = "Los Angeles",      tz = "PST8PDT,M3.2.0,M11.1.0" },
+    { label = "Tokyo",            tz = "JST-9" },
+    { label = "Sydney",           tz = "AEST-10AEDT,M10.1.0,M4.1.0/3" },
+}
+
+M.LABELS = {}
+for i, c in ipairs(M.CHOICES) do M.LABELS[i] = c.label end
+
+-- Returns the index in CHOICES that matches the saved tz_posix pref, or 1
+-- (UTC) if the saved value is missing or no longer matches a preset.
+function M.current_index()
+    local cur = ez.storage.get_pref(M.PREF_KEY, "UTC0")
+    for i, c in ipairs(M.CHOICES) do
+        if c.tz == cur then return i end
+    end
+    return 1
+end
+
+-- Persist the picked index and apply it to the system clock.
+function M.apply_index(idx)
+    local entry = M.CHOICES[idx]
+    if not entry then return false end
+    ez.storage.set_pref(M.PREF_KEY, entry.tz)
+    if ez.system.set_timezone then
+        ez.system.set_timezone(entry.tz)
+    end
+    return true
+end
+
+return M

--- a/tools/remote/tests/test_onboarding.py
+++ b/tools/remote/tests/test_onboarding.py
@@ -1,0 +1,57 @@
+"""
+Onboarding wizard smoke test.
+
+Acceptance criteria for issue #22 calls for "at least one test that
+pushes the onboarding root screen and asserts the title is right (the
+rest is interactive)". Stepping through the wizard exercises text-edit
+mode, dropdowns, and accent picking — all of which are awkward to drive
+end-to-end over the remote protocol — so that part is left to manual
+verification.
+"""
+
+from __future__ import annotations
+
+
+_PUSH_HELPER = """
+local s = require('ezui.screen')
+local def = require('{path}')
+def._onboarding = true
+local init = type(def.initial_state) == 'function' and def.initial_state() or {{}}
+s.push(s.create(def, init))
+"""
+
+
+def test_welcome_screen_has_expected_title(device):
+    device.lua_exec(_PUSH_HELPER.format(path="screens.onboarding.welcome"))
+    title = device.lua_exec(
+        "local s = require('ezui.screen'); local t = s.stack[#s.stack]; "
+        "return t and t.title or nil"
+    )
+    assert title == "Welcome", (
+        f"Pushed onboarding welcome, expected title 'Welcome', got {title!r}"
+    )
+
+
+def test_module_exposes_required_step_count(device):
+    """The progress label is computed against this list, so a regression
+    that drops a step would show up here before users notice it."""
+    count = device.lua_exec(
+        "local m = require('screens.onboarding'); return #m.REQUIRED"
+    )
+    assert count == 5, f"expected 5 required steps, got {count}"
+
+
+def test_is_onboarded_helper_handles_missing_pref(device):
+    """The boot-time gate relies on is_onboarded() returning false when
+    no pref has been written; nil/'' must not be treated as truthy.
+    Saves and restores the pref so the next reboot doesn't re-trigger
+    the wizard on a device that was previously onboarded."""
+    result = device.lua_exec(
+        "local m = require('screens.onboarding'); "
+        "local prev = ez.storage.get_pref('onboarded', nil); "
+        "ez.storage.remove_pref('onboarded'); "
+        "local got = m.is_onboarded(); "
+        "if prev ~= nil then ez.storage.set_pref('onboarded', prev) end; "
+        "return got"
+    )
+    assert result is False, f"expected false for missing pref, got {result!r}"


### PR DESCRIPTION
## Summary

- 5-step first-run wizard (welcome, node name, region, timezone, theme) plus 2 optional follow-ups (callsign, identity readout). Each step persists its pref on ENTER so a power loss mid-flow can't lose progress; the done step sets `onboarded = "1"` and pops back to the desktop.
- Boot gate in `lua/boot.lua` skips the wizard once `onboarded` is set, restores the saved theme name and LoRa frequency at startup (the latter previously had no boot-time replay), and provides a `Settings → System → Repeat onboarding` re-entry point.
- Drive-by docs fix in `CLAUDE.md`: the on-device-font ASCII rule now explicitly covers embedded markdown under `lua/docs/`, with em/en-dash, curly-quote, and arrow substitutes called out — the on-device renderer uses the same fonts as the rest of the UI, so non-ASCII source renders as `[]` boxes there too.

## Notable design choices

- **Frequency persists as a string** (`"869.525"`) rather than a Lua float. `ez.storage.set_pref(key, <float>)` routes through `putFloat → blob`, but the matching `get_pref` has no float decoder and reads back `""`. Source comments in `boot.lua` and `region.lua` capture the why.
- **Welcome screen suppresses BACKSPACE/ESCAPE** so the user can't escape to the desktop until the required steps are committed. All later steps allow back-nav freely.
- **Done screen writes `onboarded` in `on_enter`** (not on the dismissal keystroke) so a power loss between landing on Done and pressing ENTER still records the device as onboarded — pressing ENTER would just be re-litigation otherwise.
- **`util.timezones`** extracted from `time_settings.lua` so both the Time settings screen and the wizard's TZ step share one POSIX-TZ table.

## Out of scope (per the issue)

- QR rendering of the public key on the identity step — no QR encoder in the firmware yet, deferred.
- SD-based identity backup/restore — already a separate issue.
- Sample-contact import — already a separate issue.

## Test plan

- [x] `pio run` — clean build (50% flash, 38% RAM)
- [x] Manual end-to-end walkthrough on T-Deck via `tools/remote/ez_remote.py`: welcome → node name → region → timezone → theme → callsign (skipped) → identity → done → desktop. Each step's pref verified after commit. Screenshots captured at each step.
- [x] Reboot post-onboarding lands on Desktop (depth=1), no wizard.
- [x] `Settings → System → Repeat onboarding` re-pushes Welcome cleanly.
- [x] Welcome BACKSPACE swallowed (depth unchanged).
- [x] Region step's `radio_freq_mhz` round-trips as a parseable string after the float-storage fix.
- [x] `pytest tools/remote/tests/test_onboarding.py` — 3 tests pass (root-screen title, step count, missing-pref gate).
- [x] `pytest tools/remote/tests/test_screens.py` — existing screen tests still pass (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)