### PR TITLE
Claude review workflow: allow comment-posting tools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -39,6 +39,11 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # Allow the reviewer to read PR context and post both inline and
+          # top-level comments. Without these the plugin runs but the post
+          # step finds "No buffered inline comments" and emits nothing.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

- Bumps `pull-requests: read` → `write` and adds an `--allowedTools` allowlist so the reviewer can actually post the comments it generates.

## Why

The default install of `claude-code-review.yml` runs the plugin but gives it `pull-requests: read` and no `--allowedTools`, so even when the reviewer finds things to flag the post step logs `No buffered inline comments` and emits nothing. The most recent run on PR #28 finished at 18 turns / 11 permission denials / $4.70 with zero output — strong signal that work was happening but couldn't surface.

The allowlist is lifted from the upstream [`pr-review-comprehensive.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) example.

## Test plan

- [ ] Merge, then push a no-op commit on an existing feature PR (or open a fresh one) and confirm the next workflow run posts at least a top-level summary comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)