### PR TITLE
Claude review workflow: pass --comment so the review actually posts

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,10 +38,14 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # Allow the reviewer to read PR context and post both inline and
-          # top-level comments. Without these the plugin runs but the post
-          # step finds "No buffered inline comments" and emits nothing.
+          # The --comment flag is mandatory in CI — the plugin's spec
+          # treats its absence as "dry run, don't post". Without it the
+          # full multi-agent review runs (~18 turns, ~$5) and the output
+          # is dropped on the runner. See plugins/code-review/README.md
+          # in anthropics/claude-code: "As part of CI/CD: /code-review
+          # --comment".
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          # Allow the reviewer to post both inline and top-level comments.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary

- Append `--comment` to the `/code-review:code-review …` prompt so the plugin posts its findings instead of dropping them on the CI runner's terminal.

## Why

The default `/install-github-app` template that landed in [`e867996`](https://github.com/ezmesh/ezos/commit/e867996) invokes the plugin without `--comment`. Per the plugin's own command spec (`plugins/code-review/commands/code-review.md` in [anthropics/claude-code](https://github.com/anthropics/claude-code), step 7):

> If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.

And the plugin README explicitly tells you to pass it in CI:

> **As part of CI/CD:**
> `/code-review --comment   # Use --comment flag to post review comments`

So the install template is a one-flag-short of working. Two recent runs on PR #28 confirm: 18 turns / 11 then 13 permission denials / ~\$5 of compute / zero output on the PR.

## Test plan

- [ ] Merge.
- [ ] Push a no-op commit on PR #28 (or open a fresh PR) and confirm the next workflow run posts at least a top-level summary comment, or filed inline comments where applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)