### PR TITLE
Multi-voice software synth (ez.synth) + chiptune SFX bank

### DIFF
--- a/lua/engine/synth.lua
+++ b/lua/engine/synth.lua
@@ -1,0 +1,325 @@
+-- engine.synth — multi-voice chiptune SFX bank.
+--
+-- Wraps ez.synth with a data-driven sound bank. Each entry in M.sfx is
+-- a list of "layer" tables; play_sfx(name) iterates the list and fires
+-- ez.synth.note_on(...) for each layer at roughly the same instant.
+-- Each layer may target a different voice — that's the whole reason
+-- the C++ engine has 4 of them, so a single SFX can stack a noise
+-- crackle, a sub-bass thump, and a pitched ringing into one event.
+--
+-- Voice layout (from synth.h):
+--   1 = pulse A   (variable duty)
+--   2 = pulse B   (variable duty)
+--   3 = triangle  (smooth body / sub)
+--   4 = noise     (LFSR — period set by hz)
+--
+-- Layer fields (passed through to ez.synth.note_on):
+--   voice         1..4
+--   hz            base pitch / noise tap rate
+--   vol           0..255
+--   duty          (pulse only) 0.05..0.95
+--   attack_ms / decay_ms / sustain / release_ms   ADSR (sustain 0..255)
+--   sweep_hz, sweep_ms                           linear pitch sweep
+--   vib_depth_hz, vib_rate_hz                    sinusoidal pitch wobble
+--
+-- For a one-shot percussion-like effect, set sustain=0 and skip the
+-- release. The voice retires the moment decay completes, freeing it
+-- for the next trigger.
+
+local M = {}
+
+-- Friendly voice constants — for callers that prefer names.
+M.PULSE_A  = 1
+M.PULSE_B  = 2
+M.TRIANGLE = 3
+M.NOISE    = 4
+
+-- Master volume sugar. Persisted under "audio_volume" so the
+-- existing Settings -> Sound slider continues to do something useful
+-- even when games drive the synth instead of the legacy beeper.
+local PREF_VOLUME = "audio_volume"
+
+function M.set_master_pct(pct)
+    pct = tonumber(pct) or 0
+    if pct < 0 then pct = 0 elseif pct > 100 then pct = 100 end
+    if ez.synth and ez.synth.set_master then
+        -- Map 0..100 -> 0..255. Quadratic so a slider tweak in the
+        -- low half feels meaningful (linear amplitude is perceived
+        -- non-linearly in loudness).
+        local v = math.floor((pct / 100) ^ 1.6 * 255)
+        ez.synth.set_master(v)
+    end
+    ez.storage.set_pref(PREF_VOLUME, pct)
+end
+
+function M.get_master_pct()
+    local v = tonumber(ez.storage.get_pref(PREF_VOLUME, 80))
+    if v == nil then return 80 end
+    if v < 0 then v = 0 elseif v > 100 then v = 100 end
+    return v
+end
+
+-- Apply the saved volume to the engine. Called once on first require()
+-- and again on demand from settings screens. Safe to call when the
+-- synth bindings aren't present (graceful degradation).
+function M.apply_saved_volume()
+    M.set_master_pct(M.get_master_pct())
+end
+
+-- ---------------------------------------------------------------------------
+-- SFX bank.
+-- ---------------------------------------------------------------------------
+
+M.sfx = {
+    -- Blaster: pulse zap with fast pitch sweep down. Reads as a tight
+    -- "pew" without the smooth-sweep siren feel of the old beeper.
+    blaster = {
+        { voice = 1, hz = 1400, vol = 200, duty = 0.25,
+          attack_ms = 0, decay_ms = 90, sustain = 0,
+          sweep_hz = 350, sweep_ms = 90 },
+    },
+
+    -- Rapid: short tick at ~2.6 kHz with 12.5% duty for a thinner
+    -- timbre vs the blaster.
+    rapid = {
+        { voice = 1, hz = 2600, vol = 170, duty = 0.125,
+          attack_ms = 0, decay_ms = 40, sustain = 0,
+          sweep_hz = 1400, sweep_ms = 40 },
+    },
+
+    -- Spread: two pulses an interval apart so the shotgun-y feel
+    -- comes from real polyphony, not arpeggio fakery.
+    spread = {
+        { voice = 1, hz = 1100, vol = 160, duty = 0.5,
+          attack_ms = 0, decay_ms = 70, sustain = 0,
+          sweep_hz = 500, sweep_ms = 70 },
+        { voice = 2, hz =  733, vol = 140, duty = 0.5,
+          attack_ms = 0, decay_ms = 70, sustain = 0,
+          sweep_hz = 333, sweep_ms = 70 },
+    },
+
+    -- Missile: low triangle rumble + pulse ring.
+    missile = {
+        { voice = 3, hz = 110, vol = 220,
+          attack_ms = 30, decay_ms = 220, sustain = 0,
+          sweep_hz = 60, sweep_ms = 220 },
+        { voice = 1, hz = 880, vol = 90, duty = 0.125,
+          attack_ms = 5, decay_ms = 180, sustain = 0,
+          vib_depth_hz = 18, vib_rate_hz = 9 },
+    },
+
+    -- Enemy hit: tight noise burst, fast decay.
+    enemy_hit = {
+        { voice = 4, hz = 5500, vol = 200,
+          attack_ms = 0, decay_ms = 70, sustain = 0,
+          sweep_hz = 1500, sweep_ms = 70 },
+    },
+
+    -- Enemy destroyed: noise crunch + descending pulse for the "pop".
+    enemy_pop = {
+        { voice = 4, hz = 4000, vol = 220,
+          attack_ms = 0, decay_ms = 220, sustain = 0,
+          sweep_hz = 800, sweep_ms = 220 },
+        { voice = 1, hz = 660, vol = 120, duty = 0.5,
+          attack_ms = 0, decay_ms = 120, sustain = 0,
+          sweep_hz = 220, sweep_ms = 120 },
+    },
+
+    -- Heavy explosion: textbook three-layer chiptune boom.
+    --   Noise layer  — bright crackle sweeping down to rumble. Long
+    --                  decay carries the tail.
+    --   Triangle sub — 65 Hz dropping to 30 Hz over 80 ms; the body
+    --                  thump you feel before the crackle.
+    --   Pulse ring   — short 1.2 kHz squeak with quick down-sweep so
+    --                  there's a glassy "shrapnel" overtone on the
+    --                  attack. Lower volume so it doesn't dominate.
+    -- Tunable: shrink decay/sweep_ms to half for a "small_explosion"
+    -- patch, double them for a "boss_explosion".
+    explosion = {
+        { voice = 4, hz = 7500, vol = 230,
+          attack_ms = 0, decay_ms = 450, sustain = 0,
+          sweep_hz = 600, sweep_ms = 400 },
+        { voice = 3, hz = 65,   vol = 250,
+          attack_ms = 0, decay_ms = 130, sustain = 0,
+          sweep_hz = 30, sweep_ms = 80 },
+        { voice = 1, hz = 1200, vol = 100, duty = 0.125,
+          attack_ms = 0, decay_ms = 50,  sustain = 0,
+          sweep_hz = 200, sweep_ms = 40 },
+    },
+
+    -- Smaller "puff" explosion for cheap enemies. Same shape as
+    -- explosion, scaled down so the big ones still feel big.
+    small_explosion = {
+        { voice = 4, hz = 5000, vol = 200,
+          attack_ms = 0, decay_ms = 180, sustain = 0,
+          sweep_hz = 700, sweep_ms = 160 },
+        { voice = 3, hz = 90,   vol = 220,
+          attack_ms = 0, decay_ms = 70, sustain = 0,
+          sweep_hz = 45, sweep_ms = 60 },
+    },
+
+    -- Boss explosion: huge tail, layered sub + crackle + ring.
+    boss_explosion = {
+        { voice = 4, hz = 9000, vol = 240,
+          attack_ms = 0, decay_ms = 900, sustain = 0,
+          sweep_hz = 400, sweep_ms = 800 },
+        { voice = 3, hz = 50,   vol = 255,
+          attack_ms = 0, decay_ms = 260, sustain = 0,
+          sweep_hz = 22, sweep_ms = 200 },
+        { voice = 1, hz = 1500, vol = 130, duty = 0.125,
+          attack_ms = 0, decay_ms = 200, sustain = 0,
+          sweep_hz = 250, sweep_ms = 200 },
+        { voice = 2, hz = 600,  vol = 110, duty = 0.5,
+          attack_ms = 0, decay_ms = 320, sustain = 0,
+          sweep_hz = 120, sweep_ms = 320,
+          vib_depth_hz = 12, vib_rate_hz = 7 },
+    },
+
+    -- Player hurt: dissonant pulse stab + low triangle thud.
+    hurt = {
+        { voice = 1, hz = 520, vol = 200, duty = 0.5,
+          attack_ms = 0, decay_ms = 160, sustain = 0,
+          sweep_hz = 260, sweep_ms = 160 },
+        { voice = 3, hz = 90, vol = 180,
+          attack_ms = 0, decay_ms = 90, sustain = 0,
+          sweep_hz = 50, sweep_ms = 90 },
+    },
+
+    -- Pickup: classic perfect-fifth ding (C6 -> G6).
+    pickup = {
+        { voice = 1, hz = 1046, vol = 180, duty = 0.25,
+          attack_ms = 0, decay_ms = 60, sustain = 0 },
+        { voice = 2, hz = 1568, vol = 180, duty = 0.25,
+          attack_ms = 60, decay_ms = 110, sustain = 0 },
+    },
+
+    -- Power-up fanfare: ascending major triad arpeggio across both
+    -- pulse voices, triangle reinforces the root.
+    powerup = {
+        { voice = 1, hz = 523, vol = 170, duty = 0.5,
+          attack_ms = 0, decay_ms = 50, sustain = 0 },
+        { voice = 2, hz = 659, vol = 170, duty = 0.5,
+          attack_ms = 50, decay_ms = 50, sustain = 0 },
+        { voice = 1, hz = 784, vol = 180, duty = 0.5,
+          attack_ms = 100, decay_ms = 60, sustain = 0 },
+        { voice = 2, hz = 1046, vol = 200, duty = 0.5,
+          attack_ms = 160, decay_ms = 200, sustain = 0,
+          vib_depth_hz = 6, vib_rate_hz = 8 },
+        { voice = 3, hz = 261, vol = 160,
+          attack_ms = 0, decay_ms = 360, sustain = 0 },
+    },
+
+    -- Gun cycle: short two-note pulse bounce.
+    gun_up = {
+        { voice = 1, hz = 880, vol = 170, duty = 0.25,
+          attack_ms = 0, decay_ms = 35, sustain = 0 },
+        { voice = 1, hz = 1320, vol = 200, duty = 0.25,
+          attack_ms = 35, decay_ms = 90, sustain = 0 },
+    },
+
+    -- Game over: descending minor motif on triangle + decaying pulse.
+    game_over = {
+        { voice = 3, hz = 261, vol = 220,
+          attack_ms = 0, decay_ms = 250, sustain = 0 },
+        { voice = 3, hz = 220, vol = 220,
+          attack_ms = 250, decay_ms = 250, sustain = 0 },
+        { voice = 3, hz = 196, vol = 220,
+          attack_ms = 500, decay_ms = 350, sustain = 0,
+          vib_depth_hz = 6, vib_rate_hz = 5 },
+        { voice = 1, hz = 261, vol = 120, duty = 0.125,
+          attack_ms = 0, decay_ms = 850, sustain = 0,
+          sweep_hz = 130, sweep_ms = 800 },
+    },
+
+    -- Wave up: bright C-major fanfare, three ascending notes plus a
+    -- sustained pulse on top so the level-clear feels like a flourish
+    -- rather than a status beep.
+    wave_up = {
+        { voice = 1, hz = 784, vol = 180, duty = 0.5,
+          attack_ms = 0, decay_ms = 60, sustain = 0 },
+        { voice = 1, hz = 1046, vol = 190, duty = 0.5,
+          attack_ms = 60, decay_ms = 60, sustain = 0 },
+        { voice = 2, hz = 1318, vol = 200, duty = 0.5,
+          attack_ms = 120, decay_ms = 200, sustain = 0,
+          vib_depth_hz = 4, vib_rate_hz = 6 },
+        { voice = 3, hz = 392, vol = 160,
+          attack_ms = 0, decay_ms = 320, sustain = 0 },
+    },
+
+    -- UI tick — quiet single pulse for menu navigation. Keeps it out
+    -- of the way of bigger SFX.
+    ui_tick = {
+        { voice = 1, hz = 1500, vol = 90, duty = 0.5,
+          attack_ms = 0, decay_ms = 25, sustain = 0 },
+    },
+
+    -- UI confirm — slightly bigger ding for "selected".
+    ui_confirm = {
+        { voice = 1, hz = 1320, vol = 150, duty = 0.5,
+          attack_ms = 0, decay_ms = 30, sustain = 0 },
+        { voice = 1, hz = 1976, vol = 180, duty = 0.5,
+          attack_ms = 30, decay_ms = 70, sustain = 0 },
+    },
+}
+
+-- ---------------------------------------------------------------------------
+-- Public play() API. Schedules layered triggers so each layer fires
+-- with its own attack offset relative to the call instant. Layers
+-- whose attack_ms > 0 are scheduled via ez.system.set_timer; layers
+-- with attack_ms == 0 fire immediately.
+--
+-- Implementation detail: we re-use attack_ms in note_on() as the
+-- envelope attack, so a layer with attack_ms = 60 fades in after
+-- triggering. To get a hard re-trigger 60 ms later (the chiptune
+-- "second note in an arpeggio" pattern), we want a fresh note_on at
+-- t+60 ms with attack_ms=0. play_sfx() distinguishes the two: if the
+-- layer table has `_delay_ms` we schedule it; otherwise the layer
+-- fires now and the engine handles the in-segment attack.
+-- ---------------------------------------------------------------------------
+
+local function fire_layer(layer)
+    if not (ez.synth and ez.synth.note_on) then return end
+    local opts = {
+        duty = layer.duty,
+        attack_ms = 0,
+        decay_ms = layer.decay_ms,
+        sustain = layer.sustain or 0,
+        release_ms = layer.release_ms,
+        sweep_hz = layer.sweep_hz,
+        sweep_ms = layer.sweep_ms,
+        vib_depth_hz = layer.vib_depth_hz,
+        vib_rate_hz = layer.vib_rate_hz,
+    }
+    ez.synth.note_on(layer.voice, layer.hz, layer.vol, opts)
+end
+
+-- Treat `attack_ms` on a layer as a delay-from-trigger: layers with
+-- attack_ms > 0 are scheduled via set_timer so a multi-layer SFX can
+-- fire its second/third/fourth notes as discrete attacks rather than
+-- slurred fade-ins. The synth engine's own attack semantics still
+-- apply within each layer (we just zero them at the per-layer call).
+function M.play(name)
+    local sfx = M.sfx[name]
+    if not sfx then return end
+    for _, layer in ipairs(sfx) do
+        local delay = layer.attack_ms or 0
+        if delay <= 0 then
+            fire_layer(layer)
+        else
+            local cap = layer
+            ez.system.set_timer(delay, function() fire_layer(cap) end)
+        end
+    end
+end
+
+function M.silence()
+    if ez.synth and ez.synth.silence then ez.synth.silence() end
+end
+
+-- Apply saved volume on first import so the engine starts at the
+-- user's preferred level — matches the expectation that the volume
+-- slider in Settings → Sound is the source of truth for both the
+-- legacy beeper and the new synth.
+M.apply_saved_volume()
+
+return M

--- a/lua/screens/games/shooter.lua
+++ b/lua/screens/games/shooter.lua
@@ -18,7 +18,19 @@ local theme      = require("ezui.theme")
 local screen_mod = require("ezui.screen")
 local audio      = require("engine.audio_engine")
 local sfx        = audio.sounds
+local synth      = require("engine.synth")
 local highscores = require("engine.highscores")
+
+-- Route an effect through the multi-voice synth when available, else
+-- fall back to the legacy single-voice beeper. Centralised here so a
+-- future synth-only build just deletes the fallback branch.
+local function play_sfx(name, fallback_table, fallback_vol)
+    if ez.synth and synth and synth.sfx[name] then
+        synth.play(name)
+    elseif fallback_table then
+        audio.play(fallback_table, fallback_vol or 80)
+    end
+end
 
 local HS_KEY = "starshot"
 
@@ -245,7 +257,7 @@ local function update_spawner()
     if frame_no % (15 * 30) == 0 and frame_no > 0 then
         wave = wave + 1
         status_text = "Wave " .. wave
-        audio.play(sfx.wave_up, 75)
+        play_sfx("wave_up", sfx.wave_up, 75)
     end
 end
 
@@ -383,16 +395,16 @@ local function apply_item(p, kind)
     -- without looking at the HUD.
     if kind == I_HEAL then
         p.hp = math.min(5, p.hp + 2)
-        if p.id == 1 then audio.play(sfx.pickup, 80) end
+        if p.id == 1 then play_sfx("pickup", sfx.pickup, 80) end
     elseif kind == I_SHIELD then
         p.shield_end_ms = now + 8000
-        if p.id == 1 then audio.play(sfx.powerup, 80) end
+        if p.id == 1 then play_sfx("powerup", sfx.powerup, 80) end
     elseif kind == I_GUN then
         p.gun = (p.gun % #GUNS) + 1
-        if p.id == 1 then audio.play(sfx.gun_up, 80) end
+        if p.id == 1 then play_sfx("gun_up", sfx.gun_up, 80) end
     elseif kind == I_MULTI then
         p.multi_end_ms = now + 10000
-        if p.id == 1 then audio.play(sfx.powerup, 80) end
+        if p.id == 1 then play_sfx("powerup", sfx.powerup, 80) end
     end
 end
 
@@ -400,7 +412,7 @@ local function damage_player(p, dmg)
     local now = ez.system.millis()
     if p.shield_end_ms > now then return end
     p.hp = p.hp - dmg
-    if p.id == 1 then audio.play(sfx.hurt, 85) end
+    if p.id == 1 then play_sfx("hurt", sfx.hurt, 85) end
     if p.hp <= 0 then
         p.lives = p.lives - 1
         if p.lives <= 0 then
@@ -438,7 +450,19 @@ local function apply_input(p, in_left, in_right, in_up, in_down, in_fire)
             -- is always "us" both on host and join because the join
             -- side renders from a remote snapshot, not from local
             -- players state.
-            if p.id == 1 and g.sound then audio.play(g.sound, 70) end
+            -- Map gun number to a synth-bank name; falls back to the
+            -- legacy beeper sound table when the synth bindings are
+            -- absent. Keeping this lookup local so g.sound stays the
+            -- single source of truth for the legacy path.
+            if p.id == 1 then
+                local gun_names = {
+                    [GUN_BLASTER] = "blaster",
+                    [GUN_SPREAD]  = "spread",
+                    [GUN_RAPID]   = "rapid",
+                    [GUN_MISSILE] = "missile",
+                }
+                play_sfx(gun_names[p.gun] or "blaster", g.sound, 70)
+            end
         end
     end
 end
@@ -515,16 +539,21 @@ local function step_authoritative()
                             and 2 or 1
                         p.score = p.score + def.points * mult
                         drop_item(e.x, e.y, e.kind)
-                        -- Big enemies earn the longer "explosion"
-                        -- cue, small fry get the quicker pop.
-                        local snd = (e.kind == E_HEAVY
+                        -- Big enemies (heavy boss, bomber) earn the
+                        -- full layered explosion patch (noise crackle
+                        -- + sub-bass thump + ringing pulse). Smaller
+                        -- enemies get the shorter "pop" patch.
+                        local big = (e.kind == E_HEAVY
                                   or e.kind == E_BOMBER)
-                                    and sfx.explosion or sfx.enemy_pop
-                        audio.play(snd, 85)
+                        if big then
+                            play_sfx("explosion", sfx.explosion, 85)
+                        else
+                            play_sfx("enemy_pop", sfx.enemy_pop, 85)
+                        end
                         table.remove(enemies, ei)
                     else
                         -- Non-lethal hit: short crunch for feedback.
-                        audio.play(sfx.enemy_hit, 60)
+                        play_sfx("enemy_hit", sfx.enemy_hit, 60)
                     end
                     goto next_bullet
                 end
@@ -565,7 +594,7 @@ local function step_authoritative()
     for _, p in ipairs(players) do if p.alive then any_alive = true; break end end
     if not any_alive then
         if game_state ~= "over" then
-            audio.play(sfx.game_over, 90)
+            play_sfx("game_over", sfx.game_over, 90)
             -- Record high score once on transition. Solo runs get
             -- credited their own score; in MP the host records its
             -- own (player 1) score since there's no shared ranking.
@@ -841,6 +870,7 @@ local function tear_down(self)
     if mode == "host" then ez.wifi.stop_ap()
     elseif mode == "join" then ez.wifi.disconnect() end
     audio.stop()
+    if synth and synth.silence then synth.silence() end
     mode = "menu"; game_state = "menu"
     net_peer_ip, net_peer_port = nil, nil
     remote_snapshot = nil

--- a/src/audio/synth.cpp
+++ b/src/audio/synth.cpp
@@ -1,0 +1,358 @@
+// Multi-voice software synth implementation. See synth.h for the
+// design overview.
+
+#include "synth.h"
+
+#include <math.h>
+#include <algorithm>
+
+namespace synth {
+
+Engine g;
+
+// Must match the I2S sample rate configured in audio_bindings.cpp. If
+// that ever changes we'll need to bump this in lockstep — there's no
+// compile-time link between the two right now because the audio task
+// owns the I2S setup and the synth just gets handed a buffer.
+static constexpr float SAMPLE_RATE = 44100.0f;
+static constexpr float DT_MS = 1000.0f / SAMPLE_RATE;
+static constexpr float TWO_PI = 6.28318530717958647692f;
+
+// Output amplitude for a fully-modulated single voice. With 4 voices
+// at full volume the headroom is `4 * VOICE_AMP`, which is set so the
+// mix maxes out around 75% of int16 to leave a little space for the
+// inevitable peak excursions when noise + pulses align.
+static constexpr float VOICE_AMP = 6500.0f;
+
+// -----------------------------------------------------------------------------
+// Public setters. All sanity-clamp their inputs and bail out cleanly
+// on bogus voice indices so a Lua-side typo can't crash the audio task.
+// -----------------------------------------------------------------------------
+
+void Engine::note_on(int idx, float hz, uint8_t vol) {
+    if (idx < 0 || idx >= N_VOICES) return;
+    Voice& v = voices_[idx];
+    v.freq_hz = hz;
+    v.volume = vol;
+    v.env_phase = EnvPhase::Attack;
+    v.env_pos_ms = 0;
+    v.env_value = 0;
+    v.sweeping = false;
+    v.sweep_pos_ms = 0;
+    v.sweep_start_hz = hz;
+    v.vib_phase = 0;
+    v.phase = 0;
+    if (idx == VOICE_NOISE) {
+        v.noise_counter = 0;
+        // Period in samples derived from the requested hz. This is a
+        // rough approximation — real NES noise tables are not linear
+        // in frequency — but it gives the player a continuous knob
+        // from "rumble" (low hz) to "hiss" (high hz).
+        float clamped = hz < 30.0f ? 30.0f : hz;
+        v.noise_period_samples = (int)(SAMPLE_RATE / clamped);
+        if (v.noise_period_samples < 1) v.noise_period_samples = 1;
+        v.lfsr = 0x4000;
+        v.noise_sample = 0;
+    }
+    v.active = true;
+}
+
+void Engine::note_off(int idx) {
+    if (idx < 0 || idx >= N_VOICES) return;
+    Voice& v = voices_[idx];
+    if (v.env_phase == EnvPhase::Idle) return;
+    v.env_release_start = v.env_value;
+    v.env_phase = EnvPhase::Release;
+    v.env_pos_ms = 0;
+}
+
+void Engine::set_duty(int idx, float duty) {
+    if (idx < 0 || idx >= N_VOICES) return;
+    if (duty < 0.05f) duty = 0.05f;
+    if (duty > 0.95f) duty = 0.95f;
+    voices_[idx].duty = duty;
+}
+
+void Engine::set_envelope(int idx,
+                          uint16_t a, uint16_t d,
+                          uint8_t s, uint16_t r) {
+    if (idx < 0 || idx >= N_VOICES) return;
+    voices_[idx].attack_ms = a;
+    voices_[idx].decay_ms = d;
+    voices_[idx].sustain_lvl = s;
+    voices_[idx].release_ms = r;
+}
+
+void Engine::set_sweep(int idx, float target_hz, uint16_t ms) {
+    if (idx < 0 || idx >= N_VOICES) return;
+    Voice& v = voices_[idx];
+    v.sweep_target_hz = target_hz;
+    v.sweep_ms = ms;
+    v.sweep_pos_ms = 0;
+    v.sweep_start_hz = v.freq_hz;
+    v.sweeping = (ms > 0);
+}
+
+void Engine::set_vibrato(int idx, float depth_hz, float rate_hz) {
+    if (idx < 0 || idx >= N_VOICES) return;
+    voices_[idx].vib_depth_hz = depth_hz;
+    voices_[idx].vib_rate_hz = rate_hz;
+}
+
+void Engine::set_master(uint8_t m) {
+    master_ = m;
+}
+
+void Engine::silence_all() {
+    for (int i = 0; i < N_VOICES; i++) {
+        Voice& v = voices_[i];
+        v.active = false;
+        v.volume = 0;
+        v.env_phase = EnvPhase::Idle;
+        v.env_value = 0;
+        v.sweeping = false;
+    }
+}
+
+bool Engine::any_active() const {
+    for (int i = 0; i < N_VOICES; i++) {
+        if (voices_[i].active) return true;
+    }
+    return false;
+}
+
+// -----------------------------------------------------------------------------
+// Per-sample envelope step. Returns the current envelope output 0..1.
+// Updates v.env_phase and v.env_value as it advances. When the
+// envelope finishes (Release reaches t=1), we flip active=false so the
+// renderer can early-out on this voice next sample.
+// -----------------------------------------------------------------------------
+
+static inline float step_env(Voice& v) {
+    switch (v.env_phase) {
+    case EnvPhase::Attack: {
+        if (v.attack_ms == 0) {
+            v.env_value = 1.0f;
+            v.env_phase = EnvPhase::Decay;
+            v.env_pos_ms = 0;
+        } else {
+            v.env_pos_ms += DT_MS;
+            float t = v.env_pos_ms / v.attack_ms;
+            if (t >= 1.0f) {
+                v.env_value = 1.0f;
+                v.env_phase = EnvPhase::Decay;
+                v.env_pos_ms = 0;
+            } else {
+                v.env_value = t;
+            }
+        }
+        break;
+    }
+    case EnvPhase::Decay: {
+        float sustain01 = v.sustain_lvl / 255.0f;
+        if (v.decay_ms == 0) {
+            v.env_value = sustain01;
+            v.env_phase = EnvPhase::Sustain;
+        } else {
+            v.env_pos_ms += DT_MS;
+            float t = v.env_pos_ms / v.decay_ms;
+            if (t >= 1.0f) {
+                v.env_value = sustain01;
+                v.env_phase = EnvPhase::Sustain;
+            } else {
+                v.env_value = 1.0f - (1.0f - sustain01) * t;
+            }
+        }
+        break;
+    }
+    case EnvPhase::Sustain:
+        // Sustain at the configured level. If the user passed
+        // sustain=0 the envelope effectively becomes AD-only and the
+        // voice should now retire — that's the standard "one-shot"
+        // behaviour for percussion. Without this, voices with no
+        // release path would idle forever at silent volume.
+        if (v.sustain_lvl == 0) {
+            v.env_value = 0;
+            v.env_phase = EnvPhase::Idle;
+            v.active = false;
+        } else {
+            v.env_value = v.sustain_lvl / 255.0f;
+        }
+        break;
+    case EnvPhase::Release: {
+        if (v.release_ms == 0) {
+            v.env_value = 0;
+            v.env_phase = EnvPhase::Idle;
+            v.active = false;
+        } else {
+            v.env_pos_ms += DT_MS;
+            float t = v.env_pos_ms / v.release_ms;
+            if (t >= 1.0f) {
+                v.env_value = 0;
+                v.env_phase = EnvPhase::Idle;
+                v.active = false;
+            } else {
+                v.env_value = v.env_release_start * (1.0f - t);
+            }
+        }
+        break;
+    }
+    case EnvPhase::Idle:
+    default:
+        v.env_value = 0;
+        v.active = false;
+        break;
+    }
+    return v.env_value;
+}
+
+// -----------------------------------------------------------------------------
+// Sweep + vibrato modulators. Returns the effective frequency for this
+// sample — the sum of (linear-swept base) + (vibrato wobble). Vibrato
+// is added to the swept frequency rather than to the original so the
+// two effects compose without eating each other.
+// -----------------------------------------------------------------------------
+
+static inline float step_freq(Voice& v) {
+    float f = v.freq_hz;
+
+    if (v.sweeping && v.sweep_ms > 0) {
+        v.sweep_pos_ms += DT_MS;
+        float t = v.sweep_pos_ms / v.sweep_ms;
+        if (t >= 1.0f) {
+            f = v.sweep_target_hz;
+            v.freq_hz = f;
+            v.sweeping = false;
+        } else {
+            f = v.sweep_start_hz + (v.sweep_target_hz - v.sweep_start_hz) * t;
+            v.freq_hz = f;
+        }
+    }
+
+    if (v.vib_depth_hz > 0 && v.vib_rate_hz > 0) {
+        v.vib_phase += TWO_PI * v.vib_rate_hz / SAMPLE_RATE;
+        if (v.vib_phase >= TWO_PI) v.vib_phase -= TWO_PI;
+        f += v.vib_depth_hz * sinf(v.vib_phase);
+    }
+
+    if (f < 1.0f) f = 1.0f;
+    if (f > 18000.0f) f = 18000.0f;
+    return f;
+}
+
+// -----------------------------------------------------------------------------
+// Per-voice oscillator. Returns a sample in [-1, 1].
+// -----------------------------------------------------------------------------
+
+static inline float osc_pulse(Voice& v, float freq_hz) {
+    v.phase += freq_hz / SAMPLE_RATE;
+    if (v.phase >= 1.0f) v.phase -= 1.0f;
+    return (v.phase < v.duty) ? 1.0f : -1.0f;
+}
+
+static inline float osc_triangle(Voice& v, float freq_hz) {
+    v.phase += freq_hz / SAMPLE_RATE;
+    if (v.phase >= 1.0f) v.phase -= 1.0f;
+    // 0..0.5 ramps -1..+1; 0.5..1 ramps +1..-1. Standard symmetric
+    // triangle shape, no anti-aliasing — the chip aesthetic prefers
+    // the harshness.
+    if (v.phase < 0.5f) {
+        return -1.0f + 4.0f * v.phase;
+    } else {
+        return 3.0f - 4.0f * v.phase;
+    }
+}
+
+static inline float osc_noise(Voice& v) {
+    if (v.noise_counter <= 0) {
+        // Galois LFSR step. Tap selection (bit 0 ^ bit 1) gives the
+        // long noise pattern (~32k samples). Keeps the sound crunchy
+        // without obvious periodicity in normal SFX durations.
+        uint16_t bit = (v.lfsr ^ (v.lfsr >> 1)) & 1;
+        v.lfsr = (v.lfsr >> 1) | (bit << 14);
+        v.noise_sample = (v.lfsr & 1) ? 1 : -1;
+        v.noise_counter = v.noise_period_samples;
+    } else {
+        v.noise_counter--;
+    }
+    return (float)v.noise_sample;
+}
+
+// -----------------------------------------------------------------------------
+// Main render loop. Mix all active voices into `out`, sample by sample.
+// -----------------------------------------------------------------------------
+
+void Engine::render(int16_t* out, size_t n_samples) {
+    const float master01 = master_ / 255.0f;
+
+    for (size_t i = 0; i < n_samples; i++) {
+        float mix = 0.0f;
+
+        // Pulse A
+        {
+            Voice& v = voices_[VOICE_PULSE_A];
+            if (v.active) {
+                float env = step_env(v);
+                if (v.active) {  // step_env may have flipped to Idle
+                    float f = step_freq(v);
+                    float s = osc_pulse(v, f);
+                    mix += s * env * (v.volume / 255.0f);
+                }
+            }
+        }
+
+        // Pulse B
+        {
+            Voice& v = voices_[VOICE_PULSE_B];
+            if (v.active) {
+                float env = step_env(v);
+                if (v.active) {
+                    float f = step_freq(v);
+                    float s = osc_pulse(v, f);
+                    mix += s * env * (v.volume / 255.0f);
+                }
+            }
+        }
+
+        // Triangle
+        {
+            Voice& v = voices_[VOICE_TRIANGLE];
+            if (v.active) {
+                float env = step_env(v);
+                if (v.active) {
+                    float f = step_freq(v);
+                    float s = osc_triangle(v, f);
+                    mix += s * env * (v.volume / 255.0f);
+                }
+            }
+        }
+
+        // Noise. The noise voice's "frequency" controls its tap rate,
+        // not an audible pitch — we recompute period_samples whenever
+        // the live freq has drifted by more than a hair (sweep moves
+        // it). Cheap because we only do it when the voice is active.
+        {
+            Voice& v = voices_[VOICE_NOISE];
+            if (v.active) {
+                float env = step_env(v);
+                if (v.active) {
+                    float f = step_freq(v);
+                    int new_period = (int)(SAMPLE_RATE / (f < 30.0f ? 30.0f : f));
+                    if (new_period < 1) new_period = 1;
+                    v.noise_period_samples = new_period;
+                    float s = osc_noise(v);
+                    mix += s * env * (v.volume / 255.0f);
+                }
+            }
+        }
+
+        // Final mix scale + clamp to int16. master01 covers the user
+        // volume slider; VOICE_AMP is the per-voice peak headroom.
+        float sample = mix * VOICE_AMP * master01;
+        if (sample >  32767.0f) sample =  32767.0f;
+        if (sample < -32768.0f) sample = -32768.0f;
+        out[i] = (int16_t)sample;
+    }
+}
+
+} // namespace synth

--- a/src/audio/synth.h
+++ b/src/audio/synth.h
@@ -1,0 +1,144 @@
+// Multi-voice software synth for chip-tune sound effects + music.
+//
+// Mixes four fixed voices into a 16-bit mono buffer at the I2S sample
+// rate (currently 44.1 kHz, matched against the existing audio task in
+// src/lua/bindings/audio_bindings.cpp):
+//
+//   Voice 0 — pulse A   (variable duty 5..95%)
+//   Voice 1 — pulse B   (variable duty 5..95%)
+//   Voice 2 — triangle  (linear ramp; smooth, "bass body" timbre)
+//   Voice 3 — noise     (15-bit Galois LFSR; period set by freq_hz)
+//
+// Each voice has an ADSR envelope, an optional linear pitch sweep
+// (start_hz -> target_hz over sweep_ms), and an optional vibrato. All
+// are independent, so a layered SFX (e.g. an explosion) is just a few
+// note_on() calls in close succession from the Lua thread.
+//
+// Concurrency: parameters are written from the Lua thread (core 0) and
+// read from the audio task (core 1). All exposed setter fields are
+// volatile and 32-bit-aligned so reads see either the old or new value
+// — no torn updates that matter at sample resolution. Worst case the
+// audio task uses a stale parameter for one buffer (~5.8 ms at 256
+// samples / 44100 Hz), which is far below human perception.
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+namespace synth {
+
+constexpr int N_VOICES = 4;
+
+// Voice indices used by note_on() / note_off() / set_*. Lua side
+// binds to these via 1-based indexing so the public API matches the
+// rest of the firmware (Lua arrays are 1-indexed).
+constexpr int VOICE_PULSE_A  = 0;
+constexpr int VOICE_PULSE_B  = 1;
+constexpr int VOICE_TRIANGLE = 2;
+constexpr int VOICE_NOISE    = 3;
+
+enum class EnvPhase : uint8_t {
+    Idle = 0,
+    Attack,
+    Decay,
+    Sustain,
+    Release,
+};
+
+struct Voice {
+    // ----- Live parameters (set from Lua, read from audio task) -----
+    volatile bool active = false;
+    volatile float freq_hz = 440.0f;
+    volatile float duty = 0.5f;          // pulse only
+
+    // Velocity / volume (0..255). Multiplied with envelope value and
+    // master volume in the mixer.
+    volatile uint8_t volume = 0;
+
+    // ADSR (ms; sustain_lvl is 0..255 fraction of peak).
+    volatile uint16_t attack_ms = 0;
+    volatile uint16_t decay_ms = 0;
+    volatile uint8_t sustain_lvl = 255;
+    volatile uint16_t release_ms = 0;
+
+    // Linear pitch sweep. start_hz captured at note_on; target_hz +
+    // sweep_ms set by set_sweep(). When sweeping, freq_hz is the
+    // engine's interpolated value — Lua reads/writes are still legal
+    // but get overwritten on the next sample.
+    volatile float sweep_target_hz = 0;
+    volatile uint16_t sweep_ms = 0;
+
+    // Vibrato — sinusoidal pitch wiggle.
+    volatile float vib_depth_hz = 0;
+    volatile float vib_rate_hz = 0;
+
+    // ----- Audio-task-only state (not touched from Lua) -----
+    EnvPhase env_phase = EnvPhase::Idle;
+    float    env_pos_ms = 0;
+    float    env_value = 0;            // current envelope output 0..1
+    float    env_release_start = 0;    // env value at moment of note_off
+
+    float    sweep_pos_ms = 0;
+    float    sweep_start_hz = 440.0f;
+    bool     sweeping = false;
+
+    float    vib_phase = 0;            // radians
+
+    // Oscillator state.
+    float    phase = 0;                // 0..1 for pulse / triangle
+
+    // Noise state. The 15-bit Galois LFSR matches the NES' "long" mode
+    // (the "metallic" mode on real hardware uses a shorter feedback
+    // tap; we'll leave that for later if an SFX needs it).
+    uint16_t lfsr = 0x4000;            // any non-zero seed
+    int      noise_counter = 0;        // sample countdown to next tap
+    int      noise_period_samples = 8; // re-derived from freq_hz on note_on
+    int      noise_sample = 0;         // last LFSR-derived ±1 sample
+};
+
+// Singleton engine. Only one I2S output, so one engine instance is
+// enough. Audio task takes a const reference; Lua thread mutates
+// through the public methods.
+class Engine {
+public:
+    void note_on(int voice_idx, float hz, uint8_t vol);
+    void note_off(int voice_idx);
+
+    void set_duty(int voice_idx, float duty);
+    void set_envelope(int voice_idx,
+                      uint16_t attack_ms,
+                      uint16_t decay_ms,
+                      uint8_t  sustain_lvl,
+                      uint16_t release_ms);
+    void set_sweep(int voice_idx, float target_hz, uint16_t ms);
+    void set_vibrato(int voice_idx, float depth_hz, float rate_hz);
+
+    // Whole-engine controls.
+    void set_master(uint8_t m);
+    uint8_t master() const { return master_; }
+
+    // Force every voice into Idle and zero output. Used by the Lua
+    // shutdown path or panic-stop.
+    void silence_all();
+
+    // True if any voice is in a non-Idle envelope phase. Used by the
+    // audio task to know when to drop back to Off mode and stop
+    // burning I2S DMA frames on silence.
+    bool any_active() const;
+
+    // Render `n_samples` mono int16 samples into `out`. Called from
+    // the audio task with the I2S DMA chunk size (typically 256). The
+    // returned pointer is the same as `out`. Mixing is signed, clamped
+    // to int16 range. Per-sample work is small enough to fit ~6% of
+    // one core at 4 voices.
+    void render(int16_t* out, size_t n_samples);
+
+private:
+    Voice voices_[N_VOICES];
+    uint8_t master_ = 200;
+};
+
+extern Engine g;
+
+} // namespace synth

--- a/src/lua/bindings/audio_bindings.cpp
+++ b/src/lua/bindings/audio_bindings.cpp
@@ -3,6 +3,7 @@
 
 #include "../lua_bindings.h"
 #include "../../config.h"
+#include "../../audio/synth.h"
 #include <Arduino.h>
 #include <driver/i2s.h>
 #include <cmath>
@@ -40,8 +41,19 @@ static volatile uint8_t audioVolume = 100;  // 0-100 volume level
 // What the audio task should be doing each iteration.
 // `Off` parks the task; blocking play_wav/play_mp3/play_sample set this so
 // the task doesn't race the calling thread on the I2S bus.
-enum class AudioMode : uint8_t { Off = 0, Tone = 1, Sample = 2 };
+enum class AudioMode : uint8_t { Off = 0, Tone = 1, Sample = 2, Synth = 3 };
 static volatile AudioMode audioMode = AudioMode::Off;
+
+// `ensureAudioTask` exposed forward so synth bindings can hand off to
+// the same shared task without duplicating the I2S init dance.
+extern "C" void ezAudioEnsureTask();
+
+// Mode setters: keep `audioMode` file-static so other TUs can't poke
+// it directly, but expose narrow C-linkage shims so the synth bindings
+// (and any future audio source) can flip the active source without a
+// shared header.
+extern "C" void ezAudioSetSynthMode() { audioMode = AudioMode::Synth; }
+extern "C" void ezAudioSetOffMode()   { audioMode = AudioMode::Off;   }
 
 // Async sample playback state, populated by play_preloaded_async and drained
 // by audioTask.
@@ -157,11 +169,34 @@ static void audioTask(void* param) {
                 size_t written;
                 i2s_write(I2S_PORT, up, chunk * 4, &written, portMAX_DELAY);
             }
+        } else if (mode == AudioMode::Synth) {
+            // Render directly into the I2S DMA chunk and push it.
+            // synth::g manages voice state internally; this branch
+            // doesn't touch any audio_bindings state.
+            synth::g.render(samples, 256);
+            size_t written;
+            i2s_write(I2S_PORT, samples, sizeof(samples), &written, portMAX_DELAY);
+
+            // Auto-park: if every voice has gone Idle since the last
+            // buffer (e.g. a one-shot SFX finished its release), drop
+            // back to Off so the task isn't burning DMA frames on
+            // pure silence. A new ez.synth.note_on will flip mode
+            // back to Synth via the bindings.
+            if (!synth::g.any_active()) {
+                audioMode = AudioMode::Off;
+            }
         } else {
             vTaskDelay(10 / portTICK_PERIOD_MS);
         }
     }
 }
+
+// C-linkage shim used by ez.synth bindings to share the audio task.
+// Just forwards to the static helper below; we keep the static one
+// because it's how the rest of this file already calls into it.
+extern "C" void ezAudioEnsureTask();
+static void ensureAudioTask();
+extern "C" void ezAudioEnsureTask() { ensureAudioTask(); }
 
 static void ensureAudioTask() {
     if (!initI2S()) return;

--- a/src/lua/bindings/synth_bindings.cpp
+++ b/src/lua/bindings/synth_bindings.cpp
@@ -1,0 +1,250 @@
+// ez.synth — multi-voice software synth bindings.
+//
+// Thin wrappers around src/audio/synth.h. Voice indices arrive 1-based
+// from Lua and convert to 0-based on the way in. Argument errors raise
+// Lua errors so a typo at a callsite is loud, not silent.
+
+#include "../lua_bindings.h"
+#include "../../audio/synth.h"
+
+// Cross-file handoff into audio_bindings.cpp. Both setters are
+// no-arg C-linkage shims: ezAudioEnsureTask boots the audio task and
+// I2S driver if not already up, ezAudioSetSynthMode/OffMode flip the
+// task's `audioMode` without exposing the file-static variable.
+extern "C" void ezAudioEnsureTask();
+extern "C" void ezAudioSetSynthMode();
+extern "C" void ezAudioSetOffMode();
+
+// @module ez.synth
+// @brief Multi-voice software synth (chip-tune SFX + simple music).
+// @description
+// Drives a 4-voice synthesiser at 44.1 kHz mono into the same I2S
+// audio output the rest of ez.audio uses. The shape is NES-derived:
+// two pulse voices (variable duty), one triangle voice for sub-bass
+// bodies, and one noise voice for percussion / explosions. Each voice
+// has independent ADSR, an optional linear pitch sweep, and an
+// optional vibrato.
+// Voice indices (1-based from Lua):
+//   1 = pulse A
+//   2 = pulse B
+//   3 = triangle
+//   4 = noise
+// @end
+
+static int lua_voice_idx(lua_State* L, int arg) {
+    int idx = (int)luaL_checkinteger(L, arg);
+    if (idx < 1 || idx > synth::N_VOICES) {
+        return luaL_error(L,
+            "ez.synth: voice must be 1..%d, got %d",
+            synth::N_VOICES, idx);
+    }
+    return idx - 1;
+}
+
+// Activate the audio task into Synth mode if a voice was just
+// triggered. The synth's auto-park (in audio_bindings.cpp) drops the
+// mode back to Off when every voice goes Idle, so this is the only
+// place that needs to bring the task back up.
+static void activate_synth_mode() {
+    ezAudioEnsureTask();
+    ezAudioSetSynthMode();
+}
+
+// @lua ez.synth.note_on(voice, hz, vol [, opts]) -> nil
+// @brief Trigger a voice with a fresh envelope.
+// @description Starts (or retriggers) the given voice. Resets the
+// envelope to Attack, the oscillator phase to zero, and clears any
+// pending sweep. `opts` is an optional table of per-trigger overrides:
+//   { duty = 0.25,                  // pulse only, 0.05..0.95
+//     attack_ms = 0, decay_ms = 80,
+//     sustain = 0,                  // 0..255
+//     release_ms = 0,
+//     sweep_hz = 200, sweep_ms = 80,
+//     vib_depth_hz = 8, vib_rate_hz = 5 }
+// Anything missing keeps its previous setting; this matches the
+// expectation that game patches set most params once via set_envelope
+// etc. and just retrigger pitch+volume each shot.
+// @param voice integer 1..4
+// @param hz number frequency in Hz (or LFSR tap rate for the noise voice)
+// @param vol integer 0..255
+// @param opts table (optional) — see description
+// @example
+// ez.synth.note_on(1, 880, 200, { duty = 0.25, attack_ms = 0,
+//                                  decay_ms = 80, sustain = 0 })
+// @end
+LUA_FUNCTION(l_synth_note_on) {
+    int idx = lua_voice_idx(L, 1);
+    float hz = (float)luaL_checknumber(L, 2);
+    int vol = (int)luaL_checkinteger(L, 3);
+    if (vol < 0) vol = 0;
+    if (vol > 255) vol = 255;
+
+    // Per-trigger overrides via opts table. Read each field if
+    // present; missing fields leave the existing voice config alone.
+    if (lua_istable(L, 4)) {
+        lua_getfield(L, 4, "duty");
+        if (lua_isnumber(L, -1)) {
+            synth::g.set_duty(idx, (float)lua_tonumber(L, -1));
+        }
+        lua_pop(L, 1);
+
+        lua_getfield(L, 4, "attack_ms");
+        bool has_attack = lua_isnumber(L, -1);
+        int attack = has_attack ? (int)lua_tointeger(L, -1) : 0;
+        lua_pop(L, 1);
+        lua_getfield(L, 4, "decay_ms");
+        bool has_decay = lua_isnumber(L, -1);
+        int decay = has_decay ? (int)lua_tointeger(L, -1) : 0;
+        lua_pop(L, 1);
+        lua_getfield(L, 4, "sustain");
+        bool has_sustain = lua_isnumber(L, -1);
+        int sustain = has_sustain ? (int)lua_tointeger(L, -1) : 255;
+        lua_pop(L, 1);
+        lua_getfield(L, 4, "release_ms");
+        bool has_release = lua_isnumber(L, -1);
+        int release = has_release ? (int)lua_tointeger(L, -1) : 0;
+        lua_pop(L, 1);
+        if (has_attack || has_decay || has_sustain || has_release) {
+            synth::g.set_envelope(idx,
+                (uint16_t)(attack < 0 ? 0 : attack),
+                (uint16_t)(decay < 0 ? 0 : decay),
+                (uint8_t)(sustain < 0 ? 0 : (sustain > 255 ? 255 : sustain)),
+                (uint16_t)(release < 0 ? 0 : release));
+        }
+
+        lua_getfield(L, 4, "sweep_hz");
+        bool has_sweep_hz = lua_isnumber(L, -1);
+        float sweep_hz = has_sweep_hz ? (float)lua_tonumber(L, -1) : 0;
+        lua_pop(L, 1);
+        lua_getfield(L, 4, "sweep_ms");
+        bool has_sweep_ms = lua_isnumber(L, -1);
+        int sweep_ms = has_sweep_ms ? (int)lua_tointeger(L, -1) : 0;
+        lua_pop(L, 1);
+        if (has_sweep_hz || has_sweep_ms) {
+            synth::g.set_sweep(idx, sweep_hz,
+                (uint16_t)(sweep_ms < 0 ? 0 : sweep_ms));
+        }
+
+        lua_getfield(L, 4, "vib_depth_hz");
+        bool has_vd = lua_isnumber(L, -1);
+        float vd = has_vd ? (float)lua_tonumber(L, -1) : 0;
+        lua_pop(L, 1);
+        lua_getfield(L, 4, "vib_rate_hz");
+        bool has_vr = lua_isnumber(L, -1);
+        float vr = has_vr ? (float)lua_tonumber(L, -1) : 0;
+        lua_pop(L, 1);
+        if (has_vd || has_vr) {
+            synth::g.set_vibrato(idx, vd, vr);
+        }
+    }
+
+    synth::g.note_on(idx, hz, (uint8_t)vol);
+
+    // The note_on call is what kicks the audio task into Synth mode
+    // — opts processing happens first so set_sweep's sweep_start_hz
+    // capture in note_on() sees the *new* freq.
+    activate_synth_mode();
+    return 0;
+}
+
+// @lua ez.synth.note_off(voice) -> nil
+// @brief Enter the release phase of the voice's envelope.
+// @example ez.synth.note_off(2)
+// @end
+LUA_FUNCTION(l_synth_note_off) {
+    int idx = lua_voice_idx(L, 1);
+    synth::g.note_off(idx);
+    return 0;
+}
+
+// @lua ez.synth.set_envelope(voice, attack_ms, decay_ms, sustain, release_ms)
+// @brief Set the ADSR envelope shape for a voice.
+// @param sustain 0..255 — fraction of peak; 0 = AD-only one-shot
+// @end
+LUA_FUNCTION(l_synth_set_envelope) {
+    int idx = lua_voice_idx(L, 1);
+    int a = (int)luaL_checkinteger(L, 2);
+    int d = (int)luaL_checkinteger(L, 3);
+    int s = (int)luaL_checkinteger(L, 4);
+    int r = (int)luaL_checkinteger(L, 5);
+    if (a < 0) a = 0; if (d < 0) d = 0; if (r < 0) r = 0;
+    if (s < 0) s = 0; if (s > 255) s = 255;
+    synth::g.set_envelope(idx, (uint16_t)a, (uint16_t)d, (uint8_t)s, (uint16_t)r);
+    return 0;
+}
+
+// @lua ez.synth.set_sweep(voice, target_hz, ms) -> nil
+// @brief Linear pitch sweep from current freq to `target_hz` over `ms`.
+// @end
+LUA_FUNCTION(l_synth_set_sweep) {
+    int idx = lua_voice_idx(L, 1);
+    float target = (float)luaL_checknumber(L, 2);
+    int ms = (int)luaL_checkinteger(L, 3);
+    synth::g.set_sweep(idx, target, (uint16_t)(ms < 0 ? 0 : ms));
+    return 0;
+}
+
+// @lua ez.synth.set_vibrato(voice, depth_hz, rate_hz) -> nil
+// @brief Sinusoidal pitch wobble around the current freq.
+// @end
+LUA_FUNCTION(l_synth_set_vibrato) {
+    int idx = lua_voice_idx(L, 1);
+    float depth = (float)luaL_checknumber(L, 2);
+    float rate = (float)luaL_checknumber(L, 3);
+    synth::g.set_vibrato(idx, depth, rate);
+    return 0;
+}
+
+// @lua ez.synth.set_duty(voice, duty) -> nil
+// @brief Set pulse duty (0.05..0.95). Ignored for non-pulse voices.
+// @end
+LUA_FUNCTION(l_synth_set_duty) {
+    int idx = lua_voice_idx(L, 1);
+    float duty = (float)luaL_checknumber(L, 2);
+    synth::g.set_duty(idx, duty);
+    return 0;
+}
+
+// @lua ez.synth.set_master(v) -> nil
+// @brief Set engine master volume 0..255. Independent of ez.audio's volume.
+// @end
+LUA_FUNCTION(l_synth_set_master) {
+    int v = (int)luaL_checkinteger(L, 1);
+    if (v < 0) v = 0; if (v > 255) v = 255;
+    synth::g.set_master((uint8_t)v);
+    return 0;
+}
+
+// @lua ez.synth.silence() -> nil
+// @brief Stop every voice immediately. Drops audio mode back to Off.
+// @end
+LUA_FUNCTION(l_synth_silence) {
+    synth::g.silence_all();
+    ezAudioSetOffMode();
+    return 0;
+}
+
+// @lua ez.synth.is_active() -> boolean
+// @brief True if at least one voice is currently producing sound.
+// @end
+LUA_FUNCTION(l_synth_is_active) {
+    lua_pushboolean(L, synth::g.any_active() ? 1 : 0);
+    return 1;
+}
+
+static const luaL_Reg synth_funcs[] = {
+    {"note_on",      l_synth_note_on},
+    {"note_off",     l_synth_note_off},
+    {"set_envelope", l_synth_set_envelope},
+    {"set_sweep",    l_synth_set_sweep},
+    {"set_vibrato",  l_synth_set_vibrato},
+    {"set_duty",     l_synth_set_duty},
+    {"set_master",   l_synth_set_master},
+    {"silence",      l_synth_silence},
+    {"is_active",    l_synth_is_active},
+    {nullptr, nullptr}
+};
+
+void registerSynthModule(lua_State* L) {
+    lua_register_module(L, "synth", synth_funcs);
+}

--- a/src/lua/bindings/synth_bindings.cpp
+++ b/src/lua/bindings/synth_bindings.cpp
@@ -79,6 +79,16 @@ LUA_FUNCTION(l_synth_note_on) {
     if (vol < 0) vol = 0;
     if (vol > 255) vol = 255;
 
+    // Trigger the voice first, then apply opts. Order matters because
+    // synth::Engine::note_on() resets `sweeping = false` and rewinds
+    // the envelope to Attack — anything we wrote into the voice
+    // before that call would be wiped. Doing note_on first means
+    // set_sweep's `sweep_start_hz = v.freq_hz` capture sees the new
+    // freq we just stored, and the `sweeping = true` flag survives
+    // through render() so SFX patches with sweep_hz/sweep_ms actually
+    // sweep instead of playing flat.
+    synth::g.note_on(idx, hz, (uint8_t)vol);
+
     // Per-trigger overrides via opts table. Read each field if
     // present; missing fields leave the existing voice config alone.
     if (lua_istable(L, 4)) {
@@ -138,11 +148,6 @@ LUA_FUNCTION(l_synth_note_on) {
         }
     }
 
-    synth::g.note_on(idx, hz, (uint8_t)vol);
-
-    // The note_on call is what kicks the audio task into Synth mode
-    // — opts processing happens first so set_sweep's sweep_start_hz
-    // capture in note_on() sees the *new* freq.
     activate_synth_mode();
     return 0;
 }

--- a/src/lua/lua_runtime.cpp
+++ b/src/lua/lua_runtime.cpp
@@ -23,6 +23,7 @@ void registerKeyboardModule(lua_State* L);
 void registerRadioModule(lua_State* L);
 void registerMeshModule(lua_State* L);
 void registerAudioModule(lua_State* L);
+void registerSynthModule(lua_State* L);
 // Phase 4 modules
 void registerStorageModule(lua_State* L);
 void registerCryptoModule(lua_State* L);
@@ -175,6 +176,7 @@ void LuaRuntime::registerAllModules() {
     registerRadioModule(_state);
     registerMeshModule(_state);
     registerAudioModule(_state);
+    registerSynthModule(_state);
 
     // Phase 4 modules
     registerStorageModule(_state);


### PR DESCRIPTION
## Summary

- New C++ multi-voice software synth at `src/audio/synth.{h,cpp}` mixing four voices into the existing I2S TX path at 44.1 kHz mono.
- Lua bindings as `ez.synth.*` (note_on / note_off / set_envelope / set_sweep / set_vibrato / set_duty / set_master / silence / is_active).
- Lua-side data-driven SFX bank at `lua/engine/synth.lua` with three explosion patches (small / standard / boss) plus the full arcade event set.
- Shooter rewired to route SFX through the synth, with a `play_sfx()` fallback to the legacy beeper engine when bindings are absent.

## Voice layout

Fixed-shape, NES-derived:

| # | Voice | Use |
|---|-------|-----|
| 1 | Pulse A | Lead pews / arcade SFX, configurable duty 5..95% |
| 2 | Pulse B | Second polyphonic line — chords with voice 1 |
| 3 | Triangle | Sub-bass body — explosions thump, basslines |
| 4 | Noise (15-bit LFSR) | Crackle / hi-hat / explosion shrapnel |

Each voice has independent ADSR, optional linear pitch sweep, and optional vibrato. All exposed setters are `volatile` and 32-bit-aligned so the audio task on core 1 sees torn-but-coherent reads — worst case one buffer (~5.8 ms) of stale params, well below human perception.

## Why explosions get noticeably better

The previous beeper engine was monophonic — it had to choose between sub thump *or* noise crackle *or* pulse ring. With four voices a single trigger can fire all three at once:

```
explosion = {
    -- noise: bright crackle sweeping down to rumble
    { voice = 4, hz = 7500, vol = 230,
      attack_ms = 0, decay_ms = 450, sustain = 0,
      sweep_hz = 600, sweep_ms = 400 },
    -- triangle: sub-bass thump (65 Hz -> 30 Hz over 80 ms)
    { voice = 3, hz = 65, vol = 250,
      attack_ms = 0, decay_ms = 130, sustain = 0,
      sweep_hz = 30, sweep_ms = 80 },
    -- pulse ring: high-freq squeak for shrapnel overtone
    { voice = 1, hz = 1200, vol = 100, duty = 0.125,
      attack_ms = 0, decay_ms = 50, sustain = 0,
      sweep_hz = 200, sweep_ms = 40 },
}
```

That's the chip-era explosion idiom (Mega Man / Contra) doable in real time on the device.

## CPU + memory budget

- Mixer: ~6% of one core at 4 voices (per-sample envelope step + osc + vibrato + sweep, ~80 ops/sample/voice × 4 voices × 44.1 kHz = ~14 MHz of float work; FPU on the S3 absorbs it).
- Memory: voice state is ~120 bytes per voice + a 256-sample render buffer; total well under 1 KB.
- I2S DMA already configured by `audio_bindings.cpp` — synth shares the existing audio task and writes directly into its 256-sample buffer.

## Test plan

- [x] `pio run` clean build, links cleanly.
- [x] Flash + on-device: `ez.synth.note_on(1, 880, 220, {duty=0.25, decay_ms=200, sustain=0, sweep_hz=220, sweep_ms=200})` triggers and `is_active` returns true.
- [x] `engine.synth.play("explosion")` runs without errors.
- [x] `engine.synth.play("boss_explosion")` runs without errors.
- [ ] **Manual:** sit through a Starshot session and confirm the explosions, blaster, hurt, pickup, etc. all sound chip-tune-y rather than sirens (no automation possible — it's audio, has to be heard).
- [ ] **Manual:** verify Settings -> Sound volume slider scales the synth output via the existing `audio_volume` pref.

## Out of scope

- Sample / DPCM voice (the planned 5th voice for baked PCM kicks). Skipped because we don't ship sample assets yet; can be added incrementally without breaking this API.
- A music tracker layer (`synth.play_song(pattern)`). Possible follow-up — the engine and bindings already support per-tick `note_on/note_off` patterns.
- Per-voice filters / bitcrushers. Probably overkill for the chip aesthetic; revisit if we want richer textures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)