### PR TITLE
Keep last 3 firmware artefact builds of main

### DIFF
--- a/.github/workflows/main-artifacts.yml
+++ b/.github/workflows/main-artifacts.yml
@@ -45,6 +45,21 @@ jobs:
           python -m pip install --upgrade pip
           pip install platformio
 
+      - name: Fetch PlatformIO dependencies
+        run: pio pkg install -e ${{ matrix.env }}
+
+      - name: Build 32-bit luac for bytecode embedding
+        run: |
+          mkdir -p tools/bin
+          LUA_SRC=".pio/libdeps/${{ matrix.env }}/Esp32Lua/src/lua"
+          if [ ! -d "$LUA_SRC" ]; then
+            echo "Lua source not found at $LUA_SRC" >&2
+            ls .pio/libdeps/${{ matrix.env }} || true
+            exit 1
+          fi
+          (cd "$LUA_SRC" && cc -O2 -DLUA_32BITS=1 -o "$GITHUB_WORKSPACE/tools/bin/luac32" luac.c l*.c -lm)
+          tools/bin/luac32 -v
+
       - name: Build firmware (${{ matrix.name }})
         run: pio run -e ${{ matrix.env }}
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/main-artifacts.yml`: builds embedded and sdcard firmware on every push to `main`, uploads each as `firmware-<variant>-<sha>`, then prunes older artefacts so only the 3 most recent of each variant are kept (via the GitHub API in a follow-up `prune` job).
- Build a 32-bit `luac` (`LUA_32BITS=1`) from the `Esp32Lua` source in CI so the Lua embedder produces bytecode instead of stripped source. Without it, the embedded scripts overflow the 1024KB hard limit and the build fails.

## Test plan
- [ ] Merge and confirm the workflow runs on the resulting push to `main`.
- [ ] Verify both `firmware-embedded-<sha>` and `firmware-sdcard-<sha>` artefacts appear on the run.
- [ ] After 4+ runs, confirm only the 3 most recent of each variant remain in the repo's Artefacts list.
- [ ] Confirm the build log shows `Bytecode compiler: .../tools/bin/luac32` and an embedded size below 1024KB.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HkAMXcCmbz8oSLLNCenka)_