### PR TITLE
Keep last 3 firmware artefact builds of main

### DIFF
--- a/.github/workflows/main-artifacts.yml
+++ b/.github/workflows/main-artifacts.yml
@@ -57,7 +57,8 @@ jobs:
             ls .pio/libdeps/${{ matrix.env }} || true
             exit 1
           fi
-          (cd "$LUA_SRC" && cc -O2 -DLUA_32BITS=1 -o "$GITHUB_WORKSPACE/tools/bin/luac32" luac.c l*.c -lm)
+          (cd "$LUA_SRC" && cc -O2 -DLUA_32BITS=1 -o "$GITHUB_WORKSPACE/tools/bin/luac32" \
+              luac.c $(ls l*.c | grep -vE '^(lua|luac)\.c$') -lm)
           tools/bin/luac32 -v
 
       - name: Build firmware (${{ matrix.name }})


### PR DESCRIPTION
## Summary
- Add `.github/workflows/main-artifacts.yml`: builds embedded and sdcard firmware on every push to `main`, uploads each as `firmware-<variant>-<sha>`, then a `prune` job deletes older artefacts so only the 3 most recent of each variant are kept.
- Build a 32-bit `luac` (`LUA_32BITS=1`) from the `Esp32Lua` source in CI so the embedder produces bytecode and stays under the 1024KB embedded-script limit.
- Filter `lua.c`/`luac.c` out of the library glob when linking `luac32` so only one `main` is provided.

## Test plan
- [ ] Workflow runs on push to `main`.
- [ ] `firmware-embedded-<sha>` and `firmware-sdcard-<sha>` artefacts are uploaded.
- [ ] After 4+ runs, only the 3 most recent of each variant remain.
- [ ] Build log shows `Bytecode compiler: .../tools/bin/luac32` and embedded size below 1024KB.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HkAMXcCmbz8oSLLNCenka)_