### PR TITLE
Simplify CI to single firmware build, expose OTA bin

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,15 +15,8 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - env: t-deck-plus
-            name: embedded
-          - env: t-deck-plus-sdcard
-            name: sdcard
 
     steps:
       - name: Checkout repository
@@ -44,50 +37,29 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pio-
 
-      - name: Install PlatformIO
+      - name: Install PlatformIO and esptool
         run: |
           python -m pip install --upgrade pip
-          pip install platformio
+          pip install platformio esptool
 
-      - name: Build firmware (${{ matrix.name }})
-        run: pio run -e ${{ matrix.env }}
+      - name: Fetch PlatformIO dependencies
+        run: pio pkg install -e t-deck-plus
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: firmware-${{ matrix.name }}
-          path: |
-            .pio/build/${{ matrix.env }}/firmware.bin
-            .pio/build/${{ matrix.env }}/bootloader.bin
-            .pio/build/${{ matrix.env }}/partitions.bin
+      - name: Build 32-bit luac for bytecode embedding
+        run: |
+          mkdir -p tools/bin
+          LUA_SRC=".pio/libdeps/t-deck-plus/Esp32Lua/src/lua"
+          if [ ! -d "$LUA_SRC" ]; then
+            echo "Lua source not found at $LUA_SRC" >&2
+            ls .pio/libdeps/t-deck-plus || true
+            exit 1
+          fi
+          (cd "$LUA_SRC" && cc -O2 -DLUA_32BITS=1 -o "$GITHUB_WORKSPACE/tools/bin/luac32" \
+              luac.c $(ls l*.c | grep -vE '^(lua|luac)\.c$') -lm)
+          tools/bin/luac32 -v
 
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install esptool
-        run: pip install esptool
-
-      - name: Download embedded firmware
-        uses: actions/download-artifact@v4
-        with:
-          name: firmware-embedded
-          path: build/embedded
-
-      - name: Download sdcard firmware
-        uses: actions/download-artifact@v4
-        with:
-          name: firmware-sdcard
-          path: build/sdcard
+      - name: Build firmware
+        run: pio run -e t-deck-plus
 
       - name: Get version
         id: version
@@ -102,44 +74,25 @@ jobs:
         run: |
           mkdir -p release
           VERSION="${{ steps.version.outputs.version }}"
+          BUILD_DIR=".pio/build/t-deck-plus"
 
-          # Main firmware (with embedded scripts)
-          cp build/embedded/firmware.bin release/ezos-${VERSION}.bin
-          cp build/embedded/bootloader.bin release/ezos-${VERSION}-bootloader.bin
-          cp build/embedded/partitions.bin release/ezos-${VERSION}-partitions.bin
+          cp "$BUILD_DIR/firmware.bin"    "release/ezos-${VERSION}.bin"
+          cp "$BUILD_DIR/bootloader.bin"  "release/ezos-${VERSION}-bootloader.bin"
+          cp "$BUILD_DIR/partitions.bin"  "release/ezos-${VERSION}-partitions.bin"
 
-          # Create combined binary for web flasher
           esptool.py --chip esp32s3 merge_bin \
-            -o release/ezos-${VERSION}-full.bin \
+            -o "release/ezos-${VERSION}-full.bin" \
             --flash_mode dio \
             --flash_freq 80m \
             --flash_size 16MB \
-            0x0000 build/embedded/bootloader.bin \
-            0x8000 build/embedded/partitions.bin \
-            0x10000 build/embedded/firmware.bin
-
-          # SD card firmware (without embedded scripts)
-          cp build/sdcard/firmware.bin release/ezos-${VERSION}-sdcard.bin
-
-          # Create combined binary for SD card variant
-          esptool.py --chip esp32s3 merge_bin \
-            -o release/ezos-${VERSION}-sdcard-full.bin \
-            --flash_mode dio \
-            --flash_freq 80m \
-            --flash_size 16MB \
-            0x0000 build/sdcard/bootloader.bin \
-            0x8000 build/sdcard/partitions.bin \
-            0x10000 build/sdcard/firmware.bin
-
-          # Package Lua scripts for SD card
-          cd data
-          zip -r ../release/ezos-${VERSION}-scripts.zip scripts/
-          cd ..
+            0x0000  "$BUILD_DIR/bootloader.bin" \
+            0x8000  "$BUILD_DIR/partitions.bin" \
+            0x10000 "$BUILD_DIR/firmware.bin"
 
       - name: Generate checksums
         run: |
           cd release
-          sha256sum *.bin *.zip > checksums.txt
+          sha256sum *.bin > checksums.txt
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
@@ -154,43 +107,29 @@ jobs:
             release/ezos-${{ steps.version.outputs.version }}.bin
             release/ezos-${{ steps.version.outputs.version }}-bootloader.bin
             release/ezos-${{ steps.version.outputs.version }}-partitions.bin
-            release/ezos-${{ steps.version.outputs.version }}-sdcard-full.bin
-            release/ezos-${{ steps.version.outputs.version }}-sdcard.bin
-            release/ezos-${{ steps.version.outputs.version }}-scripts.zip
             release/checksums.txt
           body: |
             ## Downloads
 
-            ### Standard Firmware (recommended)
-            Scripts are embedded in the firmware - just flash and go.
-
             | File | Description |
             |------|-------------|
-            | `ezos-${{ steps.version.outputs.version }}-full.bin` | Complete firmware for web flasher |
-            | `ezos-${{ steps.version.outputs.version }}.bin` | Application firmware only |
-
-            ### SD Card Firmware
-            Scripts loaded from SD card - allows customizing Lua without reflashing.
-
-            | File | Description |
-            |------|-------------|
-            | `ezos-${{ steps.version.outputs.version }}-sdcard-full.bin` | Firmware for web flasher (no scripts) |
-            | `ezos-${{ steps.version.outputs.version }}-scripts.zip` | Lua scripts - extract to SD card root |
+            | `ezos-${{ steps.version.outputs.version }}-full.bin` | Complete firmware image (bootloader + partitions + app) for fresh flashing |
+            | `ezos-${{ steps.version.outputs.version }}.bin` | Application firmware only -- use this for OTA updates |
+            | `ezos-${{ steps.version.outputs.version }}-bootloader.bin` | Bootloader image |
+            | `ezos-${{ steps.version.outputs.version }}-partitions.bin` | Partition table |
 
             ## Flashing
 
             **Web Flasher (easiest):**
-            Use the [MeshCore Web Flasher](https://flasher.meshcore.co/) with the `-full.bin` file
+            Use the [MeshCore Web Flasher](https://flasher.meshcore.co/) with the `-full.bin` file.
 
             **esptool.py:**
             ```bash
             esptool.py --chip esp32s3 --port /dev/ttyACM0 write_flash 0x0 ezos-${{ steps.version.outputs.version }}-full.bin
             ```
 
-            ## SD Card Setup (for sdcard firmware)
-            1. Flash `ezos-${{ steps.version.outputs.version }}-sdcard-full.bin`
-            2. Extract `ezos-${{ steps.version.outputs.version }}-scripts.zip` to SD card root
-            3. SD card should have `/scripts/boot.lua` at the root
+            **OTA update:**
+            Push `ezos-${{ steps.version.outputs.version }}.bin` (the application-only image) through the on-device OTA flow.
 
             ## Requirements
 
@@ -199,6 +138,6 @@ jobs:
 
             ---
 
-            ⚠️ **Warning:** This is experimental software. Use at your own risk.
+            Warning: This is experimental software. Use at your own risk.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main-artifacts.yml
+++ b/.github/workflows/main-artifacts.yml
@@ -13,14 +13,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - env: t-deck-plus
-            name: embedded
-          - env: t-deck-plus-sdcard
-            name: sdcard
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,38 +32,50 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pio-
 
-      - name: Install PlatformIO
+      - name: Install PlatformIO and esptool
         run: |
           python -m pip install --upgrade pip
-          pip install platformio
+          pip install platformio esptool
 
       - name: Fetch PlatformIO dependencies
-        run: pio pkg install -e ${{ matrix.env }}
+        run: pio pkg install -e t-deck-plus
 
       - name: Build 32-bit luac for bytecode embedding
         run: |
           mkdir -p tools/bin
-          LUA_SRC=".pio/libdeps/${{ matrix.env }}/Esp32Lua/src/lua"
+          LUA_SRC=".pio/libdeps/t-deck-plus/Esp32Lua/src/lua"
           if [ ! -d "$LUA_SRC" ]; then
             echo "Lua source not found at $LUA_SRC" >&2
-            ls .pio/libdeps/${{ matrix.env }} || true
+            ls .pio/libdeps/t-deck-plus || true
             exit 1
           fi
           (cd "$LUA_SRC" && cc -O2 -DLUA_32BITS=1 -o "$GITHUB_WORKSPACE/tools/bin/luac32" \
               luac.c $(ls l*.c | grep -vE '^(lua|luac)\.c$') -lm)
           tools/bin/luac32 -v
 
-      - name: Build firmware (${{ matrix.name }})
-        run: pio run -e ${{ matrix.env }}
+      - name: Build firmware
+        run: pio run -e t-deck-plus
+
+      - name: Create merged full image for fresh flashing
+        run: |
+          mkdir -p artifacts
+          cp .pio/build/t-deck-plus/firmware.bin    artifacts/firmware.bin
+          cp .pio/build/t-deck-plus/bootloader.bin  artifacts/bootloader.bin
+          cp .pio/build/t-deck-plus/partitions.bin  artifacts/partitions.bin
+          esptool.py --chip esp32s3 merge_bin \
+            -o artifacts/firmware-full.bin \
+            --flash_mode dio \
+            --flash_freq 80m \
+            --flash_size 16MB \
+            0x0000  artifacts/bootloader.bin \
+            0x8000  artifacts/partitions.bin \
+            0x10000 artifacts/firmware.bin
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-${{ matrix.name }}-${{ github.sha }}
-          path: |
-            .pio/build/${{ matrix.env }}/firmware.bin
-            .pio/build/${{ matrix.env }}/bootloader.bin
-            .pio/build/${{ matrix.env }}/partitions.bin
+          name: firmware-${{ github.sha }}
+          path: artifacts/*
           retention-days: 90
 
   prune:
@@ -83,27 +87,25 @@ jobs:
         with:
           script: |
             const KEEP = 3;
-            const prefixes = ['firmware-embedded-', 'firmware-sdcard-'];
+            const PREFIX = 'firmware-';
 
             const artifacts = await github.paginate(
               github.rest.actions.listArtifactsForRepo,
               { owner: context.repo.owner, repo: context.repo.repo, per_page: 100 }
             );
 
-            for (const prefix of prefixes) {
-              const matching = artifacts
-                .filter(a => a.name.startsWith(prefix) && !a.expired)
-                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+            const matching = artifacts
+              .filter(a => a.name.startsWith(PREFIX) && !a.expired)
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
-              const toDelete = matching.slice(KEEP);
-              core.info(`${prefix}: ${matching.length} artifacts, deleting ${toDelete.length}`);
+            const toDelete = matching.slice(KEEP);
+            core.info(`${matching.length} artifacts, deleting ${toDelete.length}`);
 
-              for (const artifact of toDelete) {
-                core.info(`Deleting ${artifact.name} (id=${artifact.id}, created=${artifact.created_at})`);
-                await github.rest.actions.deleteArtifact({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  artifact_id: artifact.id,
-                });
-              }
+            for (const artifact of toDelete) {
+              core.info(`Deleting ${artifact.name} (id=${artifact.id}, created=${artifact.created_at})`);
+              await github.rest.actions.deleteArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+              });
             }


### PR DESCRIPTION
## Summary
- Drop the `embedded` / `sdcard` matrix from both `main-artifacts.yml` and `build-release.yml`. CI now does one build using the `t-deck-plus` env.
- Each workflow uploads `firmware.bin` (application image, OTA-flashable), `bootloader.bin`, `partitions.bin`, and a merged `firmware-full.bin` for fresh flashing via the web flasher.
- `main-artifacts.yml` still keeps only the 3 most recent main-branch builds via the GitHub API prune step.
- Both workflows build a 32-bit `luac` (`LUA_32BITS=1`) before `pio run` so the embedder produces bytecode and stays under the 1024KB embedded-script limit.

## Test plan
- [ ] Push to `main` triggers `main-artifacts.yml`; artefact contains `firmware.bin`, `bootloader.bin`, `partitions.bin`, `firmware-full.bin`.
- [ ] After 4+ runs, only the 3 most recent artefacts remain.
- [ ] Tagging `v*` triggers `build-release.yml` and produces a release with the same four bins plus checksums.
- [ ] OTA flash on-device using the application `firmware.bin` from a release succeeds.
- [ ] Build log shows `Bytecode compiler: .../tools/bin/luac32` and embedded size below 1024KB.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HkAMXcCmbz8oSLLNCenka)_