### PR TITLE
Rolling-main OTA: signed-manifest releases + firmware update screen

### DIFF
--- a/.github/workflows/main-artifacts.yml
+++ b/.github/workflows/main-artifacts.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   actions: write
 
 jobs:
@@ -32,10 +32,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pio-
 
-      - name: Install PlatformIO and esptool
+      - name: Install PlatformIO, esptool, and PyNaCl
         run: |
           python -m pip install --upgrade pip
-          pip install platformio esptool
+          pip install platformio esptool pynacl
 
       - name: Fetch PlatformIO dependencies
         run: pio pkg install -e t-deck-plus
@@ -54,9 +54,11 @@ jobs:
           tools/bin/luac32 -v
 
       - name: Build firmware
+        env:
+          EZOS_BUILD_SHA: ${{ github.sha }}
         run: pio run -e t-deck-plus
 
-      - name: Create merged full image for fresh flashing
+      - name: Stage release artifacts
         run: |
           mkdir -p artifacts
           cp .pio/build/t-deck-plus/firmware.bin    artifacts/firmware.bin
@@ -71,12 +73,86 @@ jobs:
             0x8000  artifacts/partitions.bin \
             0x10000 artifacts/firmware.bin
 
+      - name: Build signed manifest
+        env:
+          OTA_SIGNING_PRIVKEY: ${{ secrets.OTA_SIGNING_PRIVKEY }}
+        run: |
+          set -euo pipefail
+          FIRMWARE_BIN=artifacts/firmware.bin
+          SIZE=$(stat -c%s "$FIRMWARE_BIN")
+          SHA256=$(sha256sum "$FIRMWARE_BIN" | awk '{print $1}')
+          VERSION=$(awk -F= '/^custom_version[[:space:]]*=/{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}' platformio.ini)
+          BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          BIN_URL="https://github.com/${{ github.repository }}/releases/download/rolling-main/firmware.bin"
+
+          python -c "
+          import json
+          m = {
+              'tag': 'rolling-main',
+              'sha': '${{ github.sha }}',
+              'short_sha': '${{ github.sha }}'[:7],
+              'version': '$VERSION',
+              'built_at': '$BUILT_AT',
+              'size': $SIZE,
+              'sha256': '$SHA256',
+              'bin_url': '$BIN_URL',
+          }
+          with open('artifacts/manifest.json', 'w') as f:
+              json.dump(m, f, sort_keys=True, separators=(',', ':'))
+          "
+
+          if [ -n "${OTA_SIGNING_PRIVKEY:-}" ]; then
+            python tools/ota/sign_manifest.py artifacts/manifest.json
+          else
+            echo "::warning::OTA_SIGNING_PRIVKEY secret not set; skipping signature. Devices will refuse this manifest."
+          fi
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: firmware-${{ github.sha }}
           path: artifacts/*
           retention-days: 90
+
+      - name: Publish rolling-main release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          TAG=rolling-main
+          NOTES_FILE=$(mktemp)
+          SHORT_SHA="${GITHUB_SHA::7}"
+          cat >"$NOTES_FILE" <<EOF
+          Auto-built from main on $(date -u +%Y-%m-%dT%H:%M:%SZ).
+
+          Commit: ${GITHUB_SHA}
+          Short SHA: ${SHORT_SHA}
+
+          - firmware.bin -- application image (use this for OTA)
+          - firmware-full.bin -- bootloader + partitions + app for fresh flashing
+          - manifest.json + manifest.sig -- consumed by the on-device firmware-update screen
+          EOF
+
+          # Move the tag to the current commit (force-update both ref + tag).
+          git tag -f "$TAG" "$GITHUB_SHA"
+          git push -f origin "refs/tags/${TAG}"
+
+          # Wipe any existing release at this tag, then recreate it with
+          # the freshly built assets. Easier than diffing assets.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release delete "$TAG" --yes --cleanup-tag=false
+          fi
+
+          ASSETS=(artifacts/firmware.bin artifacts/firmware-full.bin artifacts/manifest.json)
+          if [ -f artifacts/manifest.json.sig ]; then
+            ASSETS+=(artifacts/manifest.json.sig)
+          fi
+
+          gh release create "$TAG" "${ASSETS[@]}" \
+            --title "Rolling main (${SHORT_SHA})" \
+            --notes-file "$NOTES_FILE" \
+            --prerelease
 
   prune:
     needs: build

--- a/.github/workflows/main-artifacts.yml
+++ b/.github/workflows/main-artifacts.yml
@@ -53,9 +53,20 @@ jobs:
               luac.c $(ls l*.c | grep -vE '^(lua|luac)\.c$') -lm)
           tools/bin/luac32 -v
 
+      - name: Stamp build timestamp
+        id: build_stamp
+        # Captured here (not inside the build step) so the manifest
+        # builder below can reference the exact same value -- the
+        # firmware-update screen compares manifest.built_at against
+        # the running firmware's build_at to spot downgrades, and a
+        # 1-second skew from re-invoking `date` would have produced
+        # spurious warnings on freshly-pushed builds.
+        run: echo "built_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Build firmware
         env:
           EZOS_BUILD_SHA: ${{ github.sha }}
+          EZOS_BUILD_AT:  ${{ steps.build_stamp.outputs.built_at }}
         run: pio run -e t-deck-plus
 
       - name: Stage release artifacts
@@ -82,7 +93,7 @@ jobs:
           SIZE=$(stat -c%s "$FIRMWARE_BIN")
           SHA256=$(sha256sum "$FIRMWARE_BIN" | awk '{print $1}')
           VERSION=$(awk -F= '/^custom_version[[:space:]]*=/{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}' platformio.ini)
-          BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          BUILT_AT='${{ steps.build_stamp.outputs.built_at }}'
           BIN_URL="https://github.com/${{ github.repository }}/releases/download/rolling-main/firmware.bin"
 
           python -c "

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,41 @@ pio run
 pio run -t upload
 ```
 
+## Rolling-main OTA updates
+
+Every push to `main` triggers `.github/workflows/main-artifacts.yml`,
+which builds the firmware, generates a `manifest.json` describing the
+build (SHA, version, sha256, size, asset URL), signs it with an
+Ed25519 key from the `OTA_SIGNING_PRIVKEY` GitHub Actions secret, and
+republishes the `rolling-main` GitHub Release with the binaries +
+manifest + detached signature. Older builds are kept as run artefacts
+(prune step caps at 3) for short-term debugging.
+
+The on-device update screen (`lua/screens/settings/firmware_update.lua`)
+fetches `manifest.json` and `manifest.json.sig` from the rolling-main
+release, calls `ez.crypto.ed25519_verify` against the embedded
+`kOtaSigningPubkey` (`src/ota_pubkey.cpp`), and only on a valid
+signature passes the asset URL + sha256 into `ez.ota.apply_url`, which
+streams the firmware straight into the inactive OTA partition. Trust
+flows from the signature, not from TLS — the streamer uses
+`setInsecure()` and re-checks SHA-256 against the manifest while
+writing.
+
+**Setup ceremony** (do this once per project, not per release):
+
+1. `pip install pynacl && python tools/ota/gen_signing_key.py`
+2. Paste the printed private key into the GitHub repo secret
+   `OTA_SIGNING_PRIVKEY` (Settings → Secrets and variables → Actions).
+3. Paste the printed C-array form into `src/ota_pubkey.cpp`'s
+   `kOtaSigningPubkey` (replacing the all-zero placeholder).
+4. Build + flash. Devices flashed *before* this step won't accept
+   rolling-main updates — `ez.ota.signing_pubkey()` returns nil and
+   the screen shows "OTA signing not configured on this device".
+
+Key rotation is "burn a new firmware containing the new pubkey, then
+rotate the secret". Don't lose the private key — there's no recovery
+path other than reflashing every device manually.
+
 ## Project Structure
 
 ```

--- a/lua/docs/manual/settings.md
+++ b/lua/docs/manual/settings.md
@@ -46,3 +46,32 @@ Device-level operations.
 - Repeat onboarding: re-runs the first-run wizard from the welcome
   screen. The flow over-writes prefs idempotently, so it's safe to
   rerun on an already-onboarded device.
+
+## Firmware
+
+Pull the latest rolling-main build from GitHub and install it over
+the air.
+
+The screen shows the SHA of the running build and the SHA of the
+build currently published as the rolling-main release. WiFi must
+be connected; the device fetches a small manifest plus its
+detached Ed25519 signature, verifies the signature against a
+public key baked into the firmware, then -- and only then -- uses
+the URL and SHA-256 from the manifest to install.
+
+Trust is rooted in the signature, not in TLS. A swapped or
+corrupted asset is rejected on two grounds: the manifest signature
+fails, or the SHA-256 computed while writing the firmware does
+not match the manifest's claim.
+
+- "Install update" downloads the firmware straight into the
+  inactive OTA partition and stages it. Progress shows the bytes
+  written so far.
+- "Reboot now" appears once the install finishes (or if a previous
+  install is already staged). The device boots into the new image
+  and confirms it's healthy after the UI comes up.
+
+Devices flashed before the project's signing key was configured
+display "OTA signing not configured on this device" and refuse to
+install. The fix is to flash a firmware whose embedded public key
+matches the one CI signs releases with.

--- a/lua/docs/manual/settings.md
+++ b/lua/docs/manual/settings.md
@@ -71,6 +71,16 @@ not match the manifest's claim.
   install is already staged). The device boots into the new image
   and confirms it's healthy after the UI comes up.
 
+If the manifest's build timestamp is older than the running
+firmware's, the screen shows a yellow downgrade warning and the
+button changes to "Install (downgrade)". Tapping it pops a
+confirmation dialog before the install actually starts. This is
+the rollback-attack guard: a signature-only trust model is
+otherwise vulnerable to an attacker replaying any older,
+legitimately-signed manifest. Downgrades are still allowed --
+useful when a freshly-rolled main breaks something -- but only
+through the explicit two-step gate.
+
 Devices flashed before the project's signing key was configured
 display "OTA signing not configured on this device" and refuse to
 install. The fix is to flash a firmware whose embedded public key

--- a/lua/screens/settings/firmware_update.lua
+++ b/lua/screens/settings/firmware_update.lua
@@ -63,14 +63,25 @@ function FirmwareUpdate.initial_state()
 end
 
 function FirmwareUpdate:on_enter()
-    self._sub = ez.bus.subscribe("ota/progress", function(_topic, data)
-        if type(data) ~= "table" then return end
-        self:set_state({
-            progress_phase = data.phase,
-            progress_bytes = data.bytes or 0,
-            progress_error = data.error,
-        })
-    end)
+    -- on_enter fires every time the screen resurfaces -- including
+    -- when a screen pushed on top is popped. Guard the subscription
+    -- and the manifest fetch so we don't leak handles or restart an
+    -- in-flight or completed check on every resume.
+    if not self._sub then
+        self._sub = ez.bus.subscribe("ota/progress", function(_topic, data)
+            if type(data) ~= "table" then return end
+            self:set_state({
+                progress_phase = data.phase,
+                progress_bytes = data.bytes or 0,
+                progress_error = data.error,
+            })
+        end)
+    end
+
+    -- Already finished checking (manifest in hand or terminal error)
+    -- or a download is in flight -- nothing to do on resume.
+    local s = self:get_state()
+    if s.manifest or s.error or s.installing then return end
 
     if not (ez.wifi.is_connected and ez.wifi.is_connected()) then
         self:set_state({ loading = false, error = "WiFi not connected." })

--- a/lua/screens/settings/firmware_update.lua
+++ b/lua/screens/settings/firmware_update.lua
@@ -1,0 +1,280 @@
+-- Firmware update: pull the rolling-main manifest from GitHub
+-- Releases, verify its Ed25519 signature against the embedded
+-- ez.ota.signing_pubkey(), and stream the firmware.bin straight into
+-- the inactive OTA partition via ez.ota.apply_url. Authenticity comes
+-- entirely from the signature -- TLS is opportunistic (setInsecure).
+--
+-- Flow:
+--   on_enter: fetch manifest.json + manifest.json.sig, verify, compare
+--             current build_sha against manifest.sha. Show whether
+--             we're up to date.
+--   Install:  call ez.ota.apply_url(bin_url, manifest.sha256). Stream
+--             progress via the existing "ota/progress" bus topic.
+--   On end:   surface a "Reboot to apply" button.
+
+local ui     = require("ezui")
+local dialog = require("ezui.dialog")
+
+local FirmwareUpdate = { title = "Firmware Update" }
+
+local OWNER         = "ezmesh"
+local REPO          = "ezos"
+local TAG           = "rolling-main"
+local MANIFEST_URL  = "https://github.com/" .. OWNER .. "/" .. REPO ..
+                     "/releases/download/" .. TAG .. "/manifest.json"
+local SIGNATURE_URL = MANIFEST_URL .. ".sig"
+
+local function format_bytes(n)
+    n = n or 0
+    if n < 1024 then return tostring(n) .. " B" end
+    if n < 1024 * 1024 then return string.format("%.1f KB", n / 1024) end
+    return string.format("%.2f MB", n / (1024 * 1024))
+end
+
+local function parse_json(text)
+    local ok, data = pcall(ez.storage.json_decode, text)
+    if ok and type(data) == "table" then return data end
+    return nil
+end
+
+local function current_sha()
+    local info = ez.system.get_firmware_info() or {}
+    return info.build_sha
+end
+
+local function short(s, n)
+    n = n or 7
+    if not s or s == "" then return "?" end
+    return s:sub(1, n)
+end
+
+function FirmwareUpdate.initial_state()
+    return {
+        loading       = true,
+        error         = nil,
+        manifest      = nil,        -- decoded manifest table
+        verified      = false,      -- signature ok against embedded pubkey
+        installing    = false,
+        progress_bytes = 0,
+        progress_phase = nil,       -- "start" | "write" | "end" | "error"
+        progress_error = nil,
+        wifi_connected = ez.wifi.is_connected and ez.wifi.is_connected() or false,
+    }
+end
+
+function FirmwareUpdate:on_enter()
+    self._sub = ez.bus.subscribe("ota/progress", function(_topic, data)
+        if type(data) ~= "table" then return end
+        self:set_state({
+            progress_phase = data.phase,
+            progress_bytes = data.bytes or 0,
+            progress_error = data.error,
+        })
+    end)
+
+    if not (ez.wifi.is_connected and ez.wifi.is_connected()) then
+        self:set_state({ loading = false, error = "WiFi not connected." })
+        return
+    end
+
+    local pub = ez.ota.signing_pubkey()
+    if not pub then
+        self:set_state({
+            loading = false,
+            error   = "OTA signing not configured on this device.\n" ..
+                      "Burn a firmware whose kOtaSigningPubkey matches the CI signing key.",
+        })
+        return
+    end
+
+    local this = self
+    spawn(function()
+        local mres = ez.http.fetch(MANIFEST_URL, { timeout = 15000 })
+        if not mres.ok or mres.status ~= 200 or not mres.body then
+            this:set_state({
+                loading = false,
+                error   = "Manifest fetch failed (" ..
+                          (mres.error or ("HTTP " .. tostring(mres.status))) ..
+                          ")",
+            })
+            return
+        end
+
+        local sres = ez.http.fetch(SIGNATURE_URL, { timeout = 15000 })
+        if not sres.ok or sres.status ~= 200 or not sres.body
+           or #sres.body ~= 64 then
+            this:set_state({
+                loading = false,
+                error   = "Signature fetch failed -- update refused.",
+            })
+            return
+        end
+
+        if not ez.crypto.ed25519_verify(pub, mres.body, sres.body) then
+            this:set_state({
+                loading = false,
+                error   = "Signature mismatch -- update refused.",
+            })
+            return
+        end
+
+        local manifest = parse_json(mres.body)
+        if not manifest or type(manifest.sha) ~= "string"
+           or type(manifest.bin_url) ~= "string"
+           or type(manifest.sha256) ~= "string" then
+            this:set_state({
+                loading = false,
+                error   = "Manifest malformed.",
+            })
+            return
+        end
+
+        this:set_state({
+            loading  = false,
+            verified = true,
+            manifest = manifest,
+        })
+    end)
+end
+
+function FirmwareUpdate:on_exit()
+    if self._sub then
+        ez.bus.unsubscribe(self._sub)
+        self._sub = nil
+    end
+end
+
+local function install(self)
+    local m = self._state.manifest
+    if not m then return end
+    self:set_state({
+        installing     = true,
+        progress_phase = "start",
+        progress_bytes = 0,
+        progress_error = nil,
+    })
+    local res = ez.ota.apply_url(m.bin_url, m.sha256)
+    if not res.ok then
+        self:set_state({
+            installing     = false,
+            progress_phase = "error",
+            progress_error = res.error or "failed to start",
+        })
+    end
+end
+
+local function status_section(state)
+    local nodes = {}
+    nodes[#nodes + 1] = ui.padding({ 8, 8, 4, 8 },
+        ui.text_widget("Current build", { color = "ACCENT", font = "small_aa" }))
+
+    local cur = current_sha() or "(no SHA embedded)"
+    nodes[#nodes + 1] = ui.padding({ 0, 8, 6, 8 },
+        ui.text_widget(cur, { font = "default" }))
+
+    if state.manifest then
+        nodes[#nodes + 1] = ui.padding({ 4, 8, 4, 8 },
+            ui.text_widget("Latest on rolling-main",
+                { color = "ACCENT", font = "small_aa" }))
+
+        local latest = state.manifest.short_sha or short(state.manifest.sha)
+        local size_str = format_bytes(state.manifest.size or 0)
+        local built = state.manifest.built_at or ""
+        nodes[#nodes + 1] = ui.padding({ 0, 8, 2, 8 },
+            ui.text_widget(latest .. "  -  " .. size_str,
+                { font = "default" }))
+        if built ~= "" then
+            nodes[#nodes + 1] = ui.padding({ 0, 8, 6, 8 },
+                ui.text_widget("built " .. built,
+                    { color = "TEXT_MUTED", font = "small_aa" }))
+        end
+
+        local up_to_date = (cur ~= "(no SHA embedded)") and
+                           (cur:sub(1, 7) == latest:sub(1, 7))
+        if up_to_date then
+            nodes[#nodes + 1] = ui.padding({ 4, 8, 4, 8 },
+                ui.text_widget("Up to date.",
+                    { color = "TEXT_MUTED", font = "small_aa" }))
+        end
+    end
+
+    return nodes
+end
+
+local function progress_section(state)
+    if not state.installing and not state.progress_phase then return {} end
+
+    local phase = state.progress_phase or ""
+    local nodes = {}
+
+    if phase == "error" then
+        nodes[#nodes + 1] = ui.padding({ 8, 8, 4, 8 },
+            ui.text_widget("Update failed: " .. (state.progress_error or "?"),
+                { wrap = true, color = "ACCENT", font = "small_aa" }))
+    elseif phase == "end" then
+        nodes[#nodes + 1] = ui.padding({ 8, 8, 4, 8 },
+            ui.text_widget("Download complete -- " ..
+                format_bytes(state.progress_bytes) ..
+                ". Reboot to apply.",
+                { wrap = true, color = "ACCENT", font = "small_aa" }))
+    else
+        nodes[#nodes + 1] = ui.padding({ 8, 8, 4, 8 },
+            ui.text_widget("Downloading: " ..
+                format_bytes(state.progress_bytes),
+                { color = "ACCENT", font = "small_aa" }))
+    end
+
+    return nodes
+end
+
+function FirmwareUpdate:build(state)
+    local content = {}
+
+    if state.loading then
+        content[#content + 1] = ui.padding({ 12, 12, 12, 12 },
+            ui.text_widget("Checking rolling-main...",
+                { color = "TEXT_MUTED", font = "small_aa" }))
+    elseif state.error then
+        content[#content + 1] = ui.padding({ 12, 12, 12, 12 },
+            ui.text_widget(state.error,
+                { wrap = true, color = "ACCENT", font = "small_aa" }))
+    else
+        for _, n in ipairs(status_section(state)) do
+            content[#content + 1] = n
+        end
+        for _, n in ipairs(progress_section(state)) do
+            content[#content + 1] = n
+        end
+
+        local pending = ez.ota.pending_partition()
+        local can_install = state.manifest and not state.installing
+                            and state.progress_phase ~= "end"
+                            and not pending
+
+        if can_install then
+            content[#content + 1] = ui.padding({ 8, 8, 4, 8 },
+                ui.button("Install update", {
+                    on_press = function() install(self) end,
+                }))
+        end
+
+        if pending or state.progress_phase == "end" then
+            content[#content + 1] = ui.padding({ 4, 8, 8, 8 },
+                ui.button("Reboot now", {
+                    on_press = function() ez.system.restart() end,
+                }))
+        end
+    end
+
+    return ui.vbox({ gap = 0, bg = "BG" }, {
+        ui.title_bar("Firmware Update", { back = true }),
+        ui.scroll({ grow = 1 }, ui.vbox({ gap = 0 }, content)),
+    })
+end
+
+function FirmwareUpdate:handle_key(key)
+    if key.special == "BACKSPACE" or key.special == "ESCAPE" then return "pop" end
+    return nil
+end
+
+return FirmwareUpdate

--- a/lua/screens/settings/firmware_update.lua
+++ b/lua/screens/settings/firmware_update.lua
@@ -42,6 +42,36 @@ local function current_sha()
     return info.build_sha
 end
 
+local function current_build_at()
+    local info = ez.system.get_firmware_info() or {}
+    return info.build_at
+end
+
+-- Detect a manifest that's older than the running firmware. Without
+-- this check a MITM on the (intentionally setInsecure()) HTTPS
+-- connection to GitHub could serve any previously-published,
+-- legitimately-signed manifest -- the standard rollback attack
+-- against a signature-only trust model.
+--
+-- We don't refuse downgrades outright -- they're a useful tool when
+-- a freshly-rolled main breaks something the user depends on -- but
+-- we surface a clear warning and require a separate confirmation
+-- before the install runs, so an unattended click can't quietly
+-- regress the firmware.
+--
+-- ISO 8601 timestamps in the form `YYYY-MM-DDTHH:MM:SSZ` sort
+-- correctly under Lua's lexicographic string compare, so a string
+-- compare here is intentional -- no date parsing required.
+local function is_downgrade(state)
+    if not state.manifest then return false end
+    local cur_at = current_build_at()
+    local m_at   = state.manifest.built_at
+    if not cur_at or cur_at == "" or not m_at or m_at == "" then
+        return false  -- can't tell; don't false-positive
+    end
+    return m_at < cur_at
+end
+
 local function short(s, n)
     n = n or 7
     if not s or s == "" then return "?" end
@@ -206,6 +236,19 @@ local function status_section(state)
             nodes[#nodes + 1] = ui.padding({ 4, 8, 4, 8 },
                 ui.text_widget("Up to date.",
                     { color = "TEXT_MUTED", font = "small_aa" }))
+        elseif is_downgrade(state) then
+            -- Warning, not block. ACCENT colour is already used for
+            -- error text on this screen so it carries the right
+            -- visual weight. The wording calls out the rollback-
+            -- replay risk explicitly so a user who triggered the
+            -- check themselves (and just wants to roll back a bad
+            -- main) can confirm with informed consent.
+            nodes[#nodes + 1] = ui.padding({ 4, 8, 4, 8 },
+                ui.text_widget(
+                    "! Older build than running firmware.\n" ..
+                    "Installing will downgrade. Could also be a " ..
+                    "MITM serving an old signed manifest.",
+                    { wrap = true, color = "ACCENT", font = "small_aa" }))
         end
     end
 
@@ -263,9 +306,31 @@ function FirmwareUpdate:build(state)
                             and not pending
 
         if can_install then
+            local downgrade  = is_downgrade(state)
+            local btn_label  = downgrade and "Install (downgrade)"
+                                          or "Install update"
+            local me = self
             content[#content + 1] = ui.padding({ 8, 8, 4, 8 },
-                ui.button("Install update", {
-                    on_press = function() install(self) end,
+                ui.button(btn_label, {
+                    on_press = function()
+                        if downgrade then
+                            -- Two-step gate: warning banner + confirm
+                            -- dialog. A misclicked Install is the only
+                            -- way an attacker's MITM-served old
+                            -- manifest could land on a device, so make
+                            -- sure the user has to actively agree.
+                            dialog.confirm({
+                                title    = "Downgrade firmware?",
+                                message  = "This manifest is older " ..
+                                    "than the running build. Install " ..
+                                    "anyway?",
+                                ok_label     = "Downgrade",
+                                cancel_label = "Cancel",
+                            }, function() install(me) end)
+                        else
+                            install(me)
+                        end
+                    end,
                 }))
         end
 

--- a/lua/screens/settings/settings.lua
+++ b/lua/screens/settings/settings.lua
@@ -26,6 +26,7 @@ local CATEGORIES = {
     { title = "Radio",     subtitle = "Mesh advert, announce cadence",icon = icons.radio_tower,   mod = "screens.settings.radio_settings" },
     { title = "Sound",     subtitle = "UI feedback, volume",          icon = icons.radio_tower,   mod = "screens.settings.sound_settings" },
     { title = "System",    subtitle = "Repeat onboarding",            icon = icons.settings,      mod = "screens.settings.system_settings" },
+    { title = "Firmware",  subtitle = "Check rolling-main update",    icon = icons.cloud_upload,  mod = "screens.settings.firmware_update" },
     { title = "About",     subtitle = "Version, credits",             icon = icons.info,          mod = "screens.about" },
 }
 

--- a/scripts/embed_lua_scripts.py
+++ b/scripts/embed_lua_scripts.py
@@ -619,6 +619,13 @@ try:
     version = env.GetProjectOption("custom_version") or "0.0.0"
     env.Append(CPPDEFINES=[("EZOS_VERSION", env.StringifyMacro(version))])
 
+    # Optional: short build identifier (e.g. git SHA) supplied by CI via
+    # the EZOS_BUILD_SHA env var. Used by the firmware-update screen to
+    # tell the running build apart from the latest rolling-main release.
+    build_sha = os.environ.get("EZOS_BUILD_SHA", "").strip()
+    if build_sha:
+        env.Append(CPPDEFINES=[("EZOS_BUILD_SHA", env.StringifyMacro(build_sha))])
+
     skip_embedding = False
     for d in cpp_defines:
         if isinstance(d, tuple):

--- a/scripts/embed_lua_scripts.py
+++ b/scripts/embed_lua_scripts.py
@@ -626,6 +626,15 @@ try:
     if build_sha:
         env.Append(CPPDEFINES=[("EZOS_BUILD_SHA", env.StringifyMacro(build_sha))])
 
+    # Optional: ISO 8601 build timestamp. Same value the CI release
+    # workflow embeds in manifest.json, so the firmware-update screen
+    # can spot a manifest that's older than the running firmware
+    # (signature-only trust models are vulnerable to downgrade replay
+    # by a MITM serving an older but legitimately-signed manifest).
+    build_at = os.environ.get("EZOS_BUILD_AT", "").strip()
+    if build_at:
+        env.Append(CPPDEFINES=[("EZOS_BUILD_AT", env.StringifyMacro(build_at))])
+
     skip_embedding = False
     for d in cpp_defines:
         if isinstance(d, tuple):

--- a/src/lua/bindings/crypto_bindings.cpp
+++ b/src/lua/bindings/crypto_bindings.cpp
@@ -21,6 +21,9 @@
 #include "mbedtls/sha512.h"
 #include "mbedtls/base64.h"
 
+// Ed25519 from rweather/Crypto -- already linked for MeshCore identity.
+#include <Ed25519.h>
+
 // AES block size
 constexpr size_t AES_BLOCK_SIZE = 16;
 
@@ -573,6 +576,35 @@ LUA_FUNCTION(l_crypto_base64_decode) {
     return 1;
 }
 
+// @lua ez.crypto.ed25519_verify(pubkey, message, signature) -> boolean
+// @brief Verify an Ed25519 signature
+// @description Returns true when `signature` (64 bytes) is a valid
+// Ed25519 signature of `message` under the given 32-byte public key.
+// All inputs are raw binary strings -- pass `hex_to_bytes` output if
+// you have hex.
+// @param pubkey  32-byte Ed25519 public key
+// @param message  Arbitrary message bytes
+// @param signature  64-byte Ed25519 signature
+// @return true when the signature is valid, false otherwise
+// @example
+// local ok = ez.crypto.ed25519_verify(pub, manifest_text, sig)
+// @end
+static int l_crypto_ed25519_verify(lua_State* L) {
+    size_t pubLen = 0, msgLen = 0, sigLen = 0;
+    const uint8_t* pub = (const uint8_t*)luaL_checklstring(L, 1, &pubLen);
+    const uint8_t* msg = (const uint8_t*)luaL_checklstring(L, 2, &msgLen);
+    const uint8_t* sig = (const uint8_t*)luaL_checklstring(L, 3, &sigLen);
+
+    if (pubLen != 32 || sigLen != 64) {
+        lua_pushboolean(L, 0);
+        return 1;
+    }
+
+    bool ok = Ed25519::verify(sig, pub, msg, msgLen);
+    lua_pushboolean(L, ok ? 1 : 0);
+    return 1;
+}
+
 // Function table for ez.crypto
 static const luaL_Reg crypto_funcs[] = {
     {"sha256",              l_crypto_sha256},
@@ -588,6 +620,7 @@ static const luaL_Reg crypto_funcs[] = {
     {"hex_to_bytes",        l_crypto_hex_to_bytes},
     {"base64_encode",       l_crypto_base64_encode},
     {"base64_decode",       l_crypto_base64_decode},
+    {"ed25519_verify",      l_crypto_ed25519_verify},
     {nullptr, nullptr}
 };
 

--- a/src/lua/bindings/ota_bindings.cpp
+++ b/src/lua/bindings/ota_bindings.cpp
@@ -47,11 +47,17 @@
 #include <Preferences.h>
 #include <Update.h>
 #include <WiFi.h>
+#include <WiFiClientSecure.h>
+#include <HTTPClient.h>
+#include <mbedtls/sha256.h>
 #include <esp_ota_ops.h>
 #include <ESPAsyncWebServer.h>
 #include <AsyncTCP.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
+#include <freertos/task.h>
+
+#include "../../ota_pubkey.h"
 
 extern "C" {
 #include <lua.h>
@@ -912,6 +918,287 @@ LUA_FUNCTION(l_ota_rollback_and_reboot) {
 }
 
 // ---------------------------------------------------------------------------
+// Pull-mode OTA: download a firmware image over HTTPS, verify its hash
+// against an expected SHA-256, stream it into Update.write, and stage
+// it for the next reboot.
+//
+// Authenticity is enforced by the *caller*: the firmware-update screen
+// fetches a small manifest.json + manifest.sig from the rolling-main
+// release, verifies the Ed25519 signature against the embedded
+// kOtaSigningPubkey via ez.crypto.ed25519_verify, and only then passes
+// the manifest's URL + sha256 down here. We re-check the hash while
+// streaming so a swapped-out asset still gets rejected even though we
+// drop full TLS cert validation (setInsecure -- cert pinning would
+// double the flash budget for no extra security on top of the
+// signature).
+//
+// Runs the actual download on a one-shot FreeRTOS task pinned to the
+// AsyncIO core so the UI loop stays responsive. Progress is reported
+// through the existing ota/progress bus topic; a final phase of
+// "end" or "error" closes the run. Refuses to start a second download
+// while one is in flight.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct PullParams {
+    String url;
+    uint8_t expectedSha[32];
+    bool hasExpectedSha = false;
+};
+
+volatile bool g_pullRunning = false;
+
+bool parseHexSha(const char* hex, size_t len, uint8_t out[32]) {
+    if (len != 64) return false;
+    for (size_t i = 0; i < 32; ++i) {
+        char c1 = hex[i * 2];
+        char c2 = hex[i * 2 + 1];
+        auto nibble = [](char c, uint8_t& v) {
+            if (c >= '0' && c <= '9') { v = c - '0'; return true; }
+            if (c >= 'a' && c <= 'f') { v = 10 + c - 'a'; return true; }
+            if (c >= 'A' && c <= 'F') { v = 10 + c - 'A'; return true; }
+            return false;
+        };
+        uint8_t hi = 0, lo = 0;
+        if (!nibble(c1, hi) || !nibble(c2, lo)) return false;
+        out[i] = (hi << 4) | lo;
+    }
+    return true;
+}
+
+void pullTask(void* arg) {
+    PullParams* p = (PullParams*)arg;
+
+    auto fail = [&](const char* msg) {
+        LOG("OTA", "pull failed: %s", msg);
+        Update.abort();
+        g_lastResult = -1;
+        strncpy(g_lastError, msg, MAX_ERROR_LEN - 1);
+        g_lastError[MAX_ERROR_LEN - 1] = '\0';
+        postProgress("error", 0, msg);
+        g_pullRunning = false;
+        delete p;
+        vTaskDelete(nullptr);
+    };
+
+    if (!WiFi.isConnected()) { fail("WiFi not connected"); return; }
+
+    WiFiClientSecure client;
+    client.setInsecure();  // signature on manifest is the trust boundary
+    client.setTimeout(15);
+
+    HTTPClient http;
+    http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+    http.setReuse(false);
+    http.setConnectTimeout(15000);
+    http.setTimeout(20000);
+    http.setUserAgent("ezos-ota");
+
+    if (!http.begin(client, p->url)) { fail("http.begin failed"); return; }
+    int code = http.GET();
+    if (code != HTTP_CODE_OK) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "HTTP %d", code);
+        http.end();
+        fail(msg);
+        return;
+    }
+
+    int total = http.getSize();
+    if (total <= 0) { http.end(); fail("missing Content-Length"); return; }
+
+    if (!Update.begin((size_t)total, U_FLASH)) {
+        char msg[80];
+        snprintf(msg, sizeof(msg), "Update.begin: %s", Update.errorString());
+        http.end();
+        fail(msg);
+        return;
+    }
+
+    postProgress("start", 0, nullptr);
+
+    mbedtls_sha256_context sha;
+    mbedtls_sha256_init(&sha);
+    mbedtls_sha256_starts(&sha, 0);
+
+    WiFiClient* stream = http.getStreamPtr();
+    uint8_t buf[2048];
+    size_t got = 0;
+    size_t lastReport = 0;
+
+    while (got < (size_t)total && http.connected()) {
+        size_t avail = stream->available();
+        if (avail == 0) {
+            vTaskDelay(pdMS_TO_TICKS(2));
+            continue;
+        }
+        size_t n = avail < sizeof(buf) ? avail : sizeof(buf);
+        if (got + n > (size_t)total) n = (size_t)total - got;
+        int rd = stream->readBytes(buf, n);
+        if (rd <= 0) {
+            vTaskDelay(pdMS_TO_TICKS(2));
+            continue;
+        }
+        if (Update.write(buf, rd) != (size_t)rd) {
+            char msg[80];
+            snprintf(msg, sizeof(msg), "Update.write: %s", Update.errorString());
+            http.end();
+            mbedtls_sha256_free(&sha);
+            fail(msg);
+            return;
+        }
+        mbedtls_sha256_update(&sha, buf, rd);
+        got += rd;
+        if (got - lastReport >= PROGRESS_INTERVAL) {
+            postProgress("write", got, nullptr);
+            lastReport = got;
+        }
+    }
+    http.end();
+
+    if (got != (size_t)total) {
+        mbedtls_sha256_free(&sha);
+        fail("short read");
+        return;
+    }
+
+    uint8_t digest[32];
+    mbedtls_sha256_finish(&sha, digest);
+    mbedtls_sha256_free(&sha);
+
+    if (p->hasExpectedSha) {
+        if (memcmp(digest, p->expectedSha, 32) != 0) {
+            fail("sha256 mismatch");
+            return;
+        }
+    }
+
+    if (!Update.end(true)) {
+        char msg[80];
+        snprintf(msg, sizeof(msg), "Update.end: %s", Update.errorString());
+        fail(msg);
+        return;
+    }
+
+    LOG("OTA", "pull complete (%u bytes)", (unsigned)got);
+    g_lastResult = 1;
+    snprintf(g_lastError, MAX_ERROR_LEN, "%u bytes downloaded", (unsigned)got);
+    postProgress("end", got, nullptr);
+    g_pullRunning = false;
+    delete p;
+    vTaskDelete(nullptr);
+}
+
+}  // anonymous
+
+// @lua ez.ota.apply_url(url, expected_sha256_hex?) -> table
+// @brief Download a firmware image and stage it for the next reboot
+// @description
+// Streams `url` straight into the OTA partition without buffering the
+// whole image in RAM. When `expected_sha256_hex` is supplied (64 hex
+// chars), the running SHA-256 over the downloaded bytes is compared
+// against it before the new image is committed; a mismatch aborts
+// the update. The caller is responsible for verifying the URL and
+// hash came from a trusted source -- typically by checking an
+// Ed25519 signature on a manifest with `ez.crypto.ed25519_verify`
+// against `ez.ota.signing_pubkey()`.
+//
+// Returns immediately after spawning the download task. Subscribe to
+// the `ota/progress` bus topic for progress and completion events.
+// Refuses with `{ok=false, error="busy"}` when another download is
+// already in flight, and with `{ok=false, error="signing not
+// configured"}` when the embedded signing pubkey is still all zeros.
+// @param url  HTTPS URL to fetch (redirects are followed)
+// @param expected_sha256_hex  Optional 64-char hex SHA-256 the download must match
+// @return Table { ok = boolean, error?: string } describing whether
+//         the task was started successfully.
+// @example
+// local res = ez.ota.apply_url(url, manifest.sha256)
+// if not res.ok then ui.toast("OTA: " .. res.error) end
+// @end
+LUA_FUNCTION(l_ota_apply_url) {
+    if (!ota_signing_configured()) {
+        lua_newtable(L);
+        lua_pushboolean(L, false); lua_setfield(L, -2, "ok");
+        lua_pushstring(L, "signing not configured");
+        lua_setfield(L, -2, "error");
+        return 1;
+    }
+    if (g_pullRunning || g_updateRunning) {
+        lua_newtable(L);
+        lua_pushboolean(L, false); lua_setfield(L, -2, "ok");
+        lua_pushstring(L, "busy"); lua_setfield(L, -2, "error");
+        return 1;
+    }
+    if (!WiFi.isConnected()) {
+        lua_newtable(L);
+        lua_pushboolean(L, false); lua_setfield(L, -2, "ok");
+        lua_pushstring(L, "WiFi not connected"); lua_setfield(L, -2, "error");
+        return 1;
+    }
+
+    const char* url = luaL_checkstring(L, 1);
+
+    PullParams* p = new PullParams();
+    p->url = url;
+
+    if (lua_gettop(L) >= 2 && !lua_isnil(L, 2)) {
+        size_t hexLen = 0;
+        const char* hex = luaL_checklstring(L, 2, &hexLen);
+        if (!parseHexSha(hex, hexLen, p->expectedSha)) {
+            delete p;
+            lua_newtable(L);
+            lua_pushboolean(L, false); lua_setfield(L, -2, "ok");
+            lua_pushstring(L, "bad expected_sha256_hex");
+            lua_setfield(L, -2, "error");
+            return 1;
+        }
+        p->hasExpectedSha = true;
+    }
+
+    g_pullRunning = true;
+    BaseType_t ok = xTaskCreatePinnedToCore(
+        pullTask, "ota_pull", 8192, p, 5, nullptr, 0);
+    if (ok != pdPASS) {
+        g_pullRunning = false;
+        delete p;
+        lua_newtable(L);
+        lua_pushboolean(L, false); lua_setfield(L, -2, "ok");
+        lua_pushstring(L, "task spawn failed");
+        lua_setfield(L, -2, "error");
+        return 1;
+    }
+
+    lua_newtable(L);
+    lua_pushboolean(L, true); lua_setfield(L, -2, "ok");
+    return 1;
+}
+
+// @lua ez.ota.signing_pubkey() -> string|nil
+// @brief Return the embedded Ed25519 OTA signing pubkey
+// @description
+// Returns the 32-byte Ed25519 public key the firmware was built to
+// trust for OTA manifest signatures. Returns nil when the build was
+// flashed without a configured key (kOtaSigningPubkey still all
+// zeros) -- in that case `apply_url` will refuse to start.
+// Use with `ez.crypto.ed25519_verify` to check a manifest signature
+// before passing its URL into `apply_url`.
+// @return 32-byte raw pubkey string, or nil when not configured
+// @example
+// local pub = ez.ota.signing_pubkey()
+// if pub and ez.crypto.ed25519_verify(pub, manifest_text, sig) then ... end
+// @end
+LUA_FUNCTION(l_ota_signing_pubkey) {
+    if (!ota_signing_configured()) {
+        lua_pushnil(L);
+        return 1;
+    }
+    lua_pushlstring(L, (const char*)kOtaSigningPubkey, OTA_SIGNING_PUBKEY_SIZE);
+    return 1;
+}
+
+// ---------------------------------------------------------------------------
 
 void registerBindings(lua_State* L) {
     static const luaL_Reg funcs[] = {
@@ -924,6 +1211,8 @@ void registerBindings(lua_State* L) {
         {"pending_partition",  l_ota_pending_partition},
         {"mark_valid",         l_ota_mark_valid},
         {"rollback_and_reboot", l_ota_rollback_and_reboot},
+        {"apply_url",          l_ota_apply_url},
+        {"signing_pubkey",     l_ota_signing_pubkey},
         {nullptr, nullptr}
     };
     lua_register_module(L, "ota", funcs);

--- a/src/lua/bindings/system_bindings.cpp
+++ b/src/lua/bindings/system_bindings.cpp
@@ -956,11 +956,16 @@ LUA_FUNCTION(l_system_is_sd_available) {
 // @brief Get firmware partition info
 // @description Returns information about the running firmware partition including
 // size, app binary size, and available space for OTA updates.
-// @return Table with partition_size, app_size, free_bytes, partition_label, flash_chip_size
+// @return Table with partition_size, app_size, free_bytes, partition_label,
+// flash_chip_size; plus version (when EZOS_VERSION is defined) and
+// build_sha (when EZOS_BUILD_SHA is defined, e.g. CI builds). The two
+// optional fields identify the running build for the firmware-update
+// screen.
 // @example
 // local info = ez.system.get_firmware_info()
 // print("Partition:", info.partition_label)
 // print("App size:", info.app_size / 1024, "KB")
+// print("Build:", info.version, info.build_sha)
 // @end
 LUA_FUNCTION(l_system_get_firmware_info) {
     lua_newtable(L);

--- a/src/lua/bindings/system_bindings.cpp
+++ b/src/lua/bindings/system_bindings.cpp
@@ -957,10 +957,12 @@ LUA_FUNCTION(l_system_is_sd_available) {
 // @description Returns information about the running firmware partition including
 // size, app binary size, and available space for OTA updates.
 // @return Table with partition_size, app_size, free_bytes, partition_label,
-// flash_chip_size; plus version (when EZOS_VERSION is defined) and
-// build_sha (when EZOS_BUILD_SHA is defined, e.g. CI builds). The two
+// flash_chip_size; plus version (when EZOS_VERSION is defined),
+// build_sha (when EZOS_BUILD_SHA is defined, e.g. CI builds), and
+// build_at (when EZOS_BUILD_AT is defined; ISO 8601 timestamp). The
 // optional fields identify the running build for the firmware-update
-// screen.
+// screen and let it detect downgrade attempts (manifest.built_at <
+// build_at).
 // @example
 // local info = ez.system.get_firmware_info()
 // print("Partition:", info.partition_label)
@@ -1009,6 +1011,11 @@ LUA_FUNCTION(l_system_get_firmware_info) {
 #ifdef EZOS_BUILD_SHA
     lua_pushstring(L, EZOS_BUILD_SHA);
     lua_setfield(L, -2, "build_sha");
+#endif
+
+#ifdef EZOS_BUILD_AT
+    lua_pushstring(L, EZOS_BUILD_AT);
+    lua_setfield(L, -2, "build_at");
 #endif
 
     return 1;

--- a/src/lua/bindings/system_bindings.cpp
+++ b/src/lua/bindings/system_bindings.cpp
@@ -996,6 +996,16 @@ LUA_FUNCTION(l_system_get_firmware_info) {
     lua_pushinteger(L, ESP.getFlashChipSize());
     lua_setfield(L, -2, "flash_chip_size");
 
+#ifdef EZOS_VERSION
+    lua_pushstring(L, EZOS_VERSION);
+    lua_setfield(L, -2, "version");
+#endif
+
+#ifdef EZOS_BUILD_SHA
+    lua_pushstring(L, EZOS_BUILD_SHA);
+    lua_setfield(L, -2, "build_sha");
+#endif
+
     return 1;
 }
 

--- a/src/ota_pubkey.cpp
+++ b/src/ota_pubkey.cpp
@@ -1,0 +1,19 @@
+#include "ota_pubkey.h"
+
+// Default: 32 zero bytes. Treated by the runtime as "signing not
+// configured". Replace with the real Ed25519 public key minted by
+// tools/ota/gen_signing_key.py before deploying signed-update
+// firmware to the field. See ota_pubkey.h for the full ceremony.
+const uint8_t kOtaSigningPubkey[OTA_SIGNING_PUBKEY_SIZE] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+bool ota_signing_configured() {
+    for (size_t i = 0; i < OTA_SIGNING_PUBKEY_SIZE; ++i) {
+        if (kOtaSigningPubkey[i] != 0) return true;
+    }
+    return false;
+}

--- a/src/ota_pubkey.h
+++ b/src/ota_pubkey.h
@@ -1,0 +1,36 @@
+// OTA firmware-update signing public key.
+//
+// The on-device firmware-update flow downloads a manifest.json describing
+// the latest rolling-main release alongside an Ed25519 signature in
+// manifest.sig. The signature is verified against the 32-byte public key
+// declared here before the device commits to any URL/hash from that
+// manifest.
+//
+// Default value is all zeros, which the runtime treats as "OTA signing
+// not configured on this device" and refuses to install. To enable
+// signed updates:
+//
+//   1. Run `python tools/ota/gen_signing_key.py` once. It prints both
+//      a private key (base64; goes into the GitHub Actions secret
+//      OTA_SIGNING_PRIVKEY) and a public key (32 bytes hex).
+//   2. Paste the public key bytes into kOtaSigningPubkey below, then
+//      flash the new firmware to every device that should accept
+//      rolling-main updates.
+//
+// Treat the private key like any other release signing key: store it
+// only in GitHub secrets, rotate by burning a new firmware containing
+// the new pubkey to all devices in the field.
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+constexpr size_t OTA_SIGNING_PUBKEY_SIZE = 32;
+
+extern const uint8_t kOtaSigningPubkey[OTA_SIGNING_PUBKEY_SIZE];
+
+// Returns true once kOtaSigningPubkey has been populated with a real
+// key (i.e. is not all zero). Both the apply_url binding and the
+// firmware-update screen short-circuit when this is false.
+bool ota_signing_configured();

--- a/tools/ota/gen_signing_key.py
+++ b/tools/ota/gen_signing_key.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Generate an Ed25519 keypair for signing rolling-main OTA manifests.
+
+Run once during the OTA setup ceremony:
+
+  $ pip install pynacl
+  $ python tools/ota/gen_signing_key.py
+
+The script prints:
+  - PRIVATE KEY (base64): paste into the GitHub Actions secret
+                          OTA_SIGNING_PRIVKEY
+  - PUBLIC KEY  (hex):    paste into src/ota_pubkey.cpp's
+                          kOtaSigningPubkey array, then rebuild +
+                          flash every device that should accept
+                          rolling-main updates.
+
+The private key never needs to live anywhere else. Treat it like any
+other release-signing key.
+"""
+
+import base64
+import sys
+
+try:
+    from nacl.signing import SigningKey
+except ImportError:
+    sys.stderr.write("This script needs PyNaCl. Install it with:\n  pip install pynacl\n")
+    sys.exit(1)
+
+
+def main():
+    sk = SigningKey.generate()
+    privkey_b64 = base64.b64encode(bytes(sk)).decode()
+    pubkey = bytes(sk.verify_key)
+
+    print("=== ezOS OTA signing keypair ===")
+    print()
+    print("PRIVATE KEY (base64) -- paste into GitHub Actions secret OTA_SIGNING_PRIVKEY:")
+    print(privkey_b64)
+    print()
+    print("PUBLIC KEY (hex) -- 32 bytes for src/ota_pubkey.cpp:")
+    print("".join(f"{b:02x}" for b in pubkey))
+    print()
+    print("PUBLIC KEY (C array form) -- copy/paste into kOtaSigningPubkey:")
+    rows = []
+    for i in range(0, 32, 8):
+        row = ", ".join(f"0x{b:02x}" for b in pubkey[i:i + 8])
+        rows.append("    " + row + ",")
+    print("\n".join(rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ota/sign_manifest.py
+++ b/tools/ota/sign_manifest.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Sign a rolling-main OTA manifest with the Ed25519 release key.
+
+Reads the manifest path as the first argument, signs its raw bytes,
+and writes the 64-byte detached signature next to it as
+`<manifest>.sig`. The private key is read from the
+OTA_SIGNING_PRIVKEY environment variable as base64-encoded 32-byte
+seed material (the format printed by gen_signing_key.py).
+
+Used by `.github/workflows/main-artifacts.yml` after the firmware
+build, before publishing the rolling-main release.
+"""
+
+import base64
+import os
+import sys
+
+try:
+    from nacl.signing import SigningKey
+except ImportError:
+    sys.stderr.write("This script needs PyNaCl. Install it with:\n  pip install pynacl\n")
+    sys.exit(1)
+
+
+def main(argv):
+    if len(argv) != 2:
+        sys.stderr.write("usage: sign_manifest.py <path-to-manifest.json>\n")
+        sys.exit(2)
+
+    manifest_path = argv[1]
+    sig_path = manifest_path + ".sig"
+
+    privkey_b64 = os.environ.get("OTA_SIGNING_PRIVKEY")
+    if not privkey_b64:
+        sys.stderr.write("OTA_SIGNING_PRIVKEY env var not set\n")
+        sys.exit(3)
+
+    seed = base64.b64decode(privkey_b64)
+    if len(seed) != 32:
+        sys.stderr.write(f"OTA_SIGNING_PRIVKEY must decode to 32 bytes, got {len(seed)}\n")
+        sys.exit(4)
+
+    sk = SigningKey(seed)
+    with open(manifest_path, "rb") as f:
+        manifest_bytes = f.read()
+
+    signed = sk.sign(manifest_bytes)
+    signature = signed.signature  # 64 bytes, detached
+    if len(signature) != 64:
+        sys.stderr.write(f"unexpected signature length {len(signature)}\n")
+        sys.exit(5)
+
+    with open(sig_path, "wb") as f:
+        f.write(signature)
+
+    print(f"signed: {manifest_path} -> {sig_path} ({len(manifest_bytes)} bytes)")
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
## Summary

Wires up automatic rolling-main releases plus a Firmware Update screen on the device that consumes them, with Ed25519-signed manifests as the trust boundary (no TLS pinning needed).

### CI changes (`.github/workflows/main-artifacts.yml`)
- Every push to `main` rebuilds and republishes the `rolling-main` GitHub Release with `firmware.bin`, `firmware-full.bin`, `manifest.json`, and `manifest.json.sig`.
- Manifest carries `{tag, sha, short_sha, version, built_at, size, sha256, bin_url}`. Signed with the `OTA_SIGNING_PRIVKEY` Actions secret (Ed25519, 32-byte seed, base64).
- Forwards `EZOS_BUILD_SHA=$GITHUB_SHA` into the build so the running firmware can identify itself against future manifests.

### Device side
- New `lua/screens/settings/firmware_update.lua`: fetches manifest + sig, verifies signature against the embedded pubkey, shows current vs latest SHA, "Install update" → reboot prompt.
- New C++ bindings in this PR:
  - `ez.crypto.ed25519_verify(pubkey, message, signature) -> bool`
  - `ez.ota.apply_url(url, sha256_hex?) -> {ok, error?}` — streaming HTTPS download straight into `Update.write` on a FreeRTOS task; `setInsecure()` (signature is the trust boundary), SHA-256 re-checked while writing, refuses if the embedded pubkey is all-zero.
  - `ez.ota.signing_pubkey() -> string|nil`
- `ez.system.get_firmware_info()` now also returns `version` and `build_sha`.

### Tooling
- `tools/ota/gen_signing_key.py` — mints the keypair (one-off ceremony).
- `tools/ota/sign_manifest.py` — used by CI to sign each manifest.

### Setup ceremony (one-time, see CLAUDE.md)
1. `pip install pynacl && python tools/ota/gen_signing_key.py`
2. Paste the printed private key into `OTA_SIGNING_PRIVKEY` Actions secret.
3. Paste the printed C-array into `src/ota_pubkey.cpp`'s `kOtaSigningPubkey` (replacing the all-zero placeholder).
4. Build + flash. Until the key is configured, devices show "OTA signing not configured" and `apply_url` refuses to start — feature is safely inert.

## Test plan
- [ ] Run the key-gen ceremony, set the Actions secret + pubkey, and merge.
- [ ] Push to main and confirm the workflow publishes/updates the `rolling-main` release with all four assets.
- [ ] Flash a device with the configured pubkey; open Settings → Firmware; confirm signature verifies and current/latest SHAs show.
- [ ] Tap Install update; observe `ota/progress` events from "start" → "write" → "end"; reboot; confirm new SHA in About.
- [ ] Flip a byte of the manifest on disk locally and re-sign with a different key; confirm the device shows "Signature mismatch -- update refused".
- [ ] On a device with the all-zero placeholder pubkey, confirm `apply_url` returns `{ok=false, error="signing not configured"}` and the screen says so.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HkAMXcCmbz8oSLLNCenka)_