### PR TITLE
ui: tighten status bar and lead-in above first chat bubble

### DIFF
--- a/lua/ezui/theme.lua
+++ b/lua/ezui/theme.lua
@@ -68,7 +68,7 @@ theme.SPACING = {
 -- Screen geometry
 theme.SCREEN_W = 320
 theme.SCREEN_H = 240
-theme.STATUS_H = 20    -- Global status bar height (always rendered at top)
+theme.STATUS_H = 18    -- Global status bar height (always rendered at top)
 theme.TITLE_H  = 14    -- In-screen sub-bar height (back hint / right action)
 
 -- Map tile palettes. Tiles store 3-bit semantic indices (0..7 = Land, Water,

--- a/lua/screens/chat/channel_chat.lua
+++ b/lua/screens/chat/channel_chat.lua
@@ -55,6 +55,7 @@ function ChannelChat:build(state)
             })
         )
     else
+        content_items[#content_items + 1] = { type = "spacer", h = 2, grow = 0 }
         for _, msg in ipairs(msgs) do
             content_items[#content_items + 1] = {
                 type = "chat_bubble",

--- a/lua/screens/chat/dm_conversation.lua
+++ b/lua/screens/chat/dm_conversation.lua
@@ -324,6 +324,7 @@ function DMConversation:build(state)
         -- the chat partner's for inbound. (build_share_actions in the
         -- context menu uses the same dispatch.)
         local self_pub = ez.mesh.get_public_key_hex()
+        content_items[#content_items + 1] = { type = "spacer", h = 2, grow = 0 }
         for i, msg in ipairs(msgs) do
             local share_sender = msg.is_self and self_pub or key
             content_items[#content_items + 1] = {


### PR DESCRIPTION
## Summary
- Reduce global status bar height from 20px to 18px (`theme.STATUS_H`).
- Insert a 2px spacer above the first chat bubble in DM and channel chat screens so bubbles don't butt up against the title bar.

## Test plan
- [ ] `pio run -t upload` builds and flashes.
- [ ] Status bar renders 2px shorter; clock/battery/icons still legible.
- [ ] DM conversation: 2px gap above the topmost bubble, no extra gap on empty state.
- [ ] Channel chat: 2px gap above the topmost bubble, no extra gap on empty state.
- [ ] Scroll-to-bottom behaviour unchanged after sending a message.

https://claude.ai/code/session_016fmmkDh2cofDm8KtqtRX68

---
_Generated by [Claude Code](https://claude.ai/code/session_016fmmkDh2cofDm8KtqtRX68)_