### PR TITLE
ci(release): push changelog release commit back to branch

### DIFF
--- a/.github/workflows/main-artifacts.yml
+++ b/.github/workflows/main-artifacts.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - main
+    # Don't retrigger on our own release commits (which only touch the
+    # generated changelog / version-stamp files). [skip ci] in the
+    # commit message is the belt; this is the suspenders.
+    paths-ignore:
+      - 'changelog/versions.json'
+      - 'changelog/archive.json'
+      - 'lua/docs/changelog.json'
+      - 'CHANGELOG.md'
+      - 'platformio.ini'
   workflow_dispatch:
 
 permissions:
@@ -45,15 +54,43 @@ jobs:
       - name: Fetch PlatformIO dependencies
         run: pio pkg install -e t-deck-plus
 
-      - name: Generate changelog and sync version
+      - name: Configure git for release commit
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate changelog, sync version, and push back
         id: changelog
         run: |
           npm ci
-          npx xtr-changelog release --execute --commit --tag
+          # --push pushes the release commit + tag back to main so
+          # versions.json[0].commit advances each run. Without this,
+          # subsequent runs all compute "next version" against a frozen
+          # anchor and the published version label drifts non-
+          # monotonically; the version-bump-required PR gate also has
+          # nothing real to anchor against.
+          #
+          # [skip ci] in the message keeps the resulting push from
+          # re-triggering this workflow (paths-ignore above is the
+          # primary loop-break; this is defense in depth).
+          if ! npx xtr-changelog release \
+                --execute --commit --tag --push \
+                --message '[skip ci] chore(release): {version}'; then
+            echo "Initial release push failed; rebasing on origin/$GITHUB_REF_NAME and retrying..."
+            git fetch origin "$GITHUB_REF_NAME"
+            git rebase "origin/$GITHUB_REF_NAME"
+            git push origin "HEAD:$GITHUB_REF_NAME"
+            git push origin --tags
+          fi
+
           cp changelog/versions.json lua/docs/changelog.json
-          # Extract the version the changelog tool just wrote and stamp
-          # it into platformio.ini so the firmware binary reports the
-          # same version string.
+          # Stamp the just-released version into platformio.ini so the
+          # built binary reports the same version string. Note: this
+          # edit is local to the runner -- it is not committed back to
+          # the branch (nor needs to be: the version is derivable from
+          # versions.json[0]). If you want platformio.ini's checked-in
+          # version to track too, amend the release commit before
+          # --push above. Today it lags by exactly one release.
           VERSION=$(node -e "const v=require('./changelog/versions.json'); console.log(v.versions[0].version)")
           sed -i "s/^custom_version *= *.*/custom_version = ${VERSION}/" platformio.ini
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - test
+    # Don't retrigger when our own release commit pushes generated
+    # changelog/version-stamp files back to the branch. Belt + suspenders
+    # with [skip ci] in the release commit message.
+    paths-ignore:
+      - 'changelog/versions.json'
+      - 'changelog/archive.json'
+      - 'lua/docs/changelog.json'
+      - 'CHANGELOG.md'
+      - 'platformio.ini'
   workflow_dispatch:
 
 permissions:
@@ -45,11 +54,41 @@ jobs:
       - name: Fetch PlatformIO dependencies
         run: pio pkg install -e t-deck-plus
 
-      - name: Generate changelog and sync version
+      - name: Configure git for release commit
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate changelog, sync version, and push back
         id: changelog
         run: |
           npm ci
-          npx xtr-changelog release --execute
+          # Push the release commit + tag back to the branch so
+          # versions.json[0].commit advances and the next run computes
+          # the next version against the freshly-released anchor (not
+          # against the original f2370c9 hand-edit). Without this the
+          # version label drifts non-monotonically and the
+          # version-bump-required PR gate has no real anchor.
+          #
+          # [skip ci] in the commit message keeps the resulting push
+          # from re-triggering this workflow on top of the paths-ignore
+          # filter above (defense in depth).
+          #
+          # Run release on the SHA we were triggered for. If origin
+          # advanced under us between commit and push, rebase the
+          # release commit onto the new tip and push again -- preserves
+          # the relationship between this build's artifacts and the
+          # release commit. One retry is plenty for this repo's traffic.
+          if ! npx xtr-changelog release \
+                --execute --commit --tag --push \
+                --message '[skip ci] chore(release): {version}'; then
+            echo "Initial release push failed; rebasing on origin/$GITHUB_REF_NAME and retrying..."
+            git fetch origin "$GITHUB_REF_NAME"
+            git rebase "origin/$GITHUB_REF_NAME"
+            git push origin "HEAD:$GITHUB_REF_NAME"
+            git push origin --tags
+          fi
+
           cp changelog/versions.json lua/docs/changelog.json
           VERSION=$(node -e "const v=require('./changelog/versions.json'); console.log(v.versions[0].version)")
           sed -i "s/^custom_version *= *.*/custom_version = ${VERSION}/" platformio.ini


### PR DESCRIPTION
## Summary

- Add `--push` to both rolling-release workflows so `versions.json[0].commit` advances each run.
- `paths-ignore` + `[skip ci]` prevent the resulting push from retriggering the workflow.
- Configures the github-actions[bot] author + retry-on-rebase recovery.

## Why

`xtr-changelog release --execute [--commit --tag]` was creating release commits but never pushing them — so every run computed "next version" against the frozen `f2370c9` anchor and the published version label drifted non-monotonically (7a6b2b9 published 0.0.71 the day after b3ca474 published 0.0.78). The version-bump-required PR gate from #46 (the prior commit) also had no real anchor.

After this lands, version labels are monotonic per release, and the gate compares against the actual last-released SHA.

## Test plan
- [ ] PR-checks workflow runs on this PR and passes (CC title + version-bump check)
- [ ] After squash-merge to test, Test Branch Artifacts runs once, pushes a `[skip ci] chore(release): vX.Y.Z` commit + tag back, does NOT retrigger itself
- [ ] `versions.json[0].commit` on test now points at the commit just merged
- [ ] Open a follow-up tiny PR; the version-bump check now anchors against the just-released SHA
- [ ] Then mirror to main (or this PR already does — check diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)