### PR TITLE
ci(branch-protection): migrate to rulesets requiring PRs

### DIFF
--- a/.github/workflows/main-artifacts.yml
+++ b/.github/workflows/main-artifacts.yml
@@ -23,8 +23,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Use the deploy key for the checkout so that `git push` later in
+      # the changelog step also goes over SSH using the same key. Branch
+      # rulesets exempt deploy-key pushes, which is the only way the
+      # auto-release commit can land on a protected branch on a free
+      # org plan (no GitHub App / bypass actor available in the picker).
+      - name: Set up deploy key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.RELEASE_PUSH_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.RELEASE_PUSH_KEY }}
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -23,8 +23,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Use the deploy key for the checkout so that `git push` later in
+      # the changelog step also goes over SSH using the same key. Branch
+      # rulesets exempt deploy-key pushes, which is the only way the
+      # auto-release commit can land on a protected branch on a free
+      # org plan (no GitHub App / bypass actor available in the picker).
+      - name: Set up deploy key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.RELEASE_PUSH_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.RELEASE_PUSH_KEY }}
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,30 @@ Key rotation is "burn a new firmware containing the new pubkey, then
 rotate the secret". Don't lose the private key — there's no recovery
 path other than reflashing every device manually.
 
+**Branch ruleset setup** (also once per project): the auto-release
+workflow's `xtr-changelog --push` step pushes the `[skip ci]` release
+commit + tag straight back to `main` / `test`. Both branches are
+protected by repo rulesets (see `scripts/branch-protection.sh`), and
+the rulesets' `pull_request` rule blocks direct pushes from any actor
+not on the bypass list — including the workflow's `GITHUB_TOKEN`,
+regardless of `permissions:` scope. Without a bypass entry the push
+fails with GH006 ("changes must be made through a pull request") and
+the workflow stops publishing OTA releases.
+
+The GitHub Actions runner identity isn't a queryable Integration on
+the repo, so it can't be added via the rulesets API. After running
+`scripts/branch-protection.sh`, manually add `github-actions` as a
+bypass actor in the GitHub UI for both rulesets:
+
+  Settings → Rules → `ezos-branch-main` → Bypass list → Add bypass
+  → "GitHub Actions"
+
+Repeat for `ezos-branch-test`. Symptom of forgetting this step: the
+release workflow's "Generate changelog, sync version, and push back"
+step fails with GH006, the rolling-main / rolling-test releases stop
+updating, and devices on those channels report "no newer version
+available" indefinitely.
+
 ## Project Structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,29 +171,32 @@ Key rotation is "burn a new firmware containing the new pubkey, then
 rotate the secret". Don't lose the private key — there's no recovery
 path other than reflashing every device manually.
 
-**Branch ruleset setup** (also once per project): the auto-release
-workflow's `xtr-changelog --push` step pushes the `[skip ci]` release
-commit + tag straight back to `main` / `test`. Both branches are
-protected by repo rulesets (see `scripts/branch-protection.sh`), and
-the rulesets' `pull_request` rule blocks direct pushes from any actor
-not on the bypass list — including the workflow's `GITHUB_TOKEN`,
-regardless of `permissions:` scope. Without a bypass entry the push
-fails with GH006 ("changes must be made through a pull request") and
-the workflow stops publishing OTA releases.
+**Branch ruleset push gate** (already wired, documented for context):
+the auto-release workflow's `xtr-changelog --push` step pushes the
+`[skip ci]` release commit + tag straight back to `main` / `test`.
+Both branches are protected by repo rulesets (see
+`scripts/branch-protection.sh`), and the rulesets' `pull_request`
+rule blocks direct pushes from any actor not on the bypass list --
+including the workflow's `GITHUB_TOKEN`, regardless of `permissions:`
+scope. The "GitHub Actions" identity does not appear in the bypass
+picker on the free org plan, so we can't put it on the bypass list.
 
-The GitHub Actions runner identity isn't a queryable Integration on
-the repo, so it can't be added via the rulesets API. After running
-`scripts/branch-protection.sh`, manually add `github-actions` as a
-bypass actor in the GitHub UI for both rulesets:
+Workaround in use: a write-enabled **deploy key** (`auto-release-push`,
+private half stored in repo secret `RELEASE_PUSH_KEY`). Deploy-key
+pushes bypass branch rulesets by design. Both `*-artifacts.yml`
+workflows load the key into ssh-agent via `webfactory/ssh-agent`
+and check the repo out over SSH so the subsequent `git push` from
+xtr-changelog flows through the same key.
 
-  Settings → Rules → `ezos-branch-main` → Bypass list → Add bypass
-  → "GitHub Actions"
-
-Repeat for `ezos-branch-test`. Symptom of forgetting this step: the
-release workflow's "Generate changelog, sync version, and push back"
-step fails with GH006, the rolling-main / rolling-test releases stop
-updating, and devices on those channels report "no newer version
-available" indefinitely.
+If OTA releases ever stop publishing, check the failing workflow
+run's "Generate changelog, sync version, and push back" step. A
+GH013 / "Changes must be made through a pull request" error means
+the SSH push fell back to HTTPS+GITHUB_TOKEN -- usually because the
+checkout step's `ssh-key` input was lost or the secret was rotated
+without updating the deploy key. Regenerate the keypair with
+`ssh-keygen -t ed25519`, register the public half via
+`POST /repos/ezmesh/ezos/keys` with `read_only: false`, and re-upload
+the private half to the `RELEASE_PUSH_KEY` secret.
 
 ## Project Structure
 

--- a/scripts/branch-protection.sh
+++ b/scripts/branch-protection.sh
@@ -11,26 +11,29 @@
 #   - Linear history (no merge commits land on the branch).
 #   - No force-push, no deletion.
 #
-# Bypass:
-#   The GitHub Actions runner identity isn't a queryable Integration
-#   on the repo, so we can't add it via the rulesets API. After this
-#   script runs, manually add "github-actions" as a bypass actor in
-#   the GitHub UI for both rulesets (Settings -> Rules -> ezos-branch-
-#   <branch> -> Bypass list -> Add bypass -> "GitHub Actions"). Without
-#   it, the auto-release workflow's xtr-changelog --push will fail
-#   with GH006.
+# Bypass for the auto-release workflow:
+#   The "GitHub Actions" identity does not appear in the bypass-actor
+#   picker on the free org plan, so the runner can't be added to the
+#   rulesets' bypass list. The auto-release workflow instead pushes
+#   over SSH using a write-enabled deploy key (repo secret
+#   RELEASE_PUSH_KEY, public half registered as deploy key
+#   "auto-release-push"). Deploy-key pushes bypass branch rulesets by
+#   design, so `bypass_actors` here stays empty -- there is no actor
+#   to preserve across re-runs. See CLAUDE.md "Rolling OTA updates"
+#   for the wiring.
 #
 # Why rulesets, not classic branch protection:
 #   Classic protection's "required_status_checks" applies to *every*
-#   push, and GITHUB_TOKEN can't bypass it -- so the auto-release
-#   workflow gets rejected (GH006) when the gate is on. Rulesets
-#   support per-actor bypass, which is exactly what we want.
+#   push and GITHUB_TOKEN can't bypass it. Rulesets support per-actor
+#   bypass (and deploy-key exemption), which is what we want.
 #
 #   Classic protection on these branches is removed in the same step
 #   to avoid two competing layers of policy.
 #
-# Run once. Re-running replaces the existing rulesets idempotently
-# (delete-then-create per branch).
+# Run once. Re-running is idempotent: it snapshots existing
+# ezos-branch-* rulesets, creates fresh ones, drops classic
+# protection, then prunes the snapshotted IDs (create-then-delete,
+# so a creation failure leaves the existing protection intact).
 #
 # Requires: gh auth login (admin on the repo).
 

--- a/scripts/branch-protection.sh
+++ b/scripts/branch-protection.sh
@@ -47,17 +47,23 @@ remove_classic_protection() {
     fi
 }
 
-remove_existing_rulesets() {
-    # List existing repo rulesets and delete any that target this script's
-    # naming convention. Without this, re-running this script accumulates
-    # stale ruleset entries.
-    gh api "repos/${REPO}/rulesets" --jq '.[] | select(.name | startswith("ezos-branch-")) | .id' \
-        | while read -r id; do
-            if [ -n "$id" ]; then
-                gh api -X DELETE "repos/${REPO}/rulesets/$id" >/dev/null
-                echo "  deleted existing ruleset $id"
-            fi
-        done
+list_stale_ruleset_ids() {
+    # Print IDs of any existing ezos-branch-* rulesets, one per line.
+    # Captured BEFORE creating the new ones so that a later cleanup pass
+    # only removes the pre-existing entries, not the ones we just made.
+    gh api "repos/${REPO}/rulesets" \
+        --jq '.[] | select(.name | startswith("ezos-branch-")) | .id'
+}
+
+delete_ruleset_ids() {
+    # Delete each ruleset ID passed on stdin. Safe to call with an empty
+    # list; just logs nothing.
+    while read -r id; do
+        if [ -n "$id" ]; then
+            gh api -X DELETE "repos/${REPO}/rulesets/$id" >/dev/null
+            echo "  deleted stale ruleset $id"
+        fi
+    done
 }
 
 create_ruleset() {
@@ -106,15 +112,30 @@ EOF
     echo "  ${branch}: ruleset $(echo "$resp" | jq -r .id) created"
 }
 
-echo "Removing classic branch protection..."
-remove_classic_protection main
-remove_classic_protection test
-
-echo "Removing any existing ezos-branch-* rulesets..."
-remove_existing_rulesets
+# Order matters: snapshot any pre-existing rulesets, then CREATE the
+# new ones, then remove the old protection layers. With `set -euo
+# pipefail`, a delete-then-create order would leave both branches
+# fully unprotected (direct pushes, force-pushes, deletions all
+# allowed) if create_ruleset failed mid-run. Create-then-delete keeps
+# the existing protection in place if creation hits a transient API
+# error, rate limit, or 422.
+echo "Snapshotting any existing ezos-branch-* rulesets..."
+STALE_IDS=$(list_stale_ruleset_ids || true)
+if [ -n "$STALE_IDS" ]; then
+    echo "  found $(echo "$STALE_IDS" | wc -l) stale ruleset(s) to remove after new ones are in place"
+fi
 
 echo "Creating new rulesets..."
 create_ruleset main
 create_ruleset test
+
+echo "Removing classic branch protection..."
+remove_classic_protection main
+remove_classic_protection test
+
+if [ -n "$STALE_IDS" ]; then
+    echo "Removing snapshotted stale rulesets..."
+    printf '%s\n' "$STALE_IDS" | delete_ruleset_ids
+fi
 
 echo "Done. Verify in https://github.com/${REPO}/settings/rules"

--- a/scripts/branch-protection.sh
+++ b/scripts/branch-protection.sh
@@ -123,7 +123,7 @@ EOF
 # the existing protection in place if creation hits a transient API
 # error, rate limit, or 422.
 echo "Snapshotting any existing ezos-branch-* rulesets..."
-STALE_IDS=$(list_stale_ruleset_ids || true)
+STALE_IDS=$(list_stale_ruleset_ids)
 if [ -n "$STALE_IDS" ]; then
     echo "  found $(echo "$STALE_IDS" | wc -l) stale ruleset(s) to remove after new ones are in place"
 fi

--- a/scripts/branch-protection.sh
+++ b/scripts/branch-protection.sh
@@ -1,22 +1,36 @@
 #!/usr/bin/env bash
 #
-# Apply branch protection to main and test on github.com/ezmesh/ezos.
+# Apply branch protection (rulesets) to main and test on
+# github.com/ezmesh/ezos.
 #
-# Linear history: blocks merge commits, so the squash-merge commit subject
-# (which we validate via PR Checks) is what actually lands on the branch.
+# What this enforces:
+#   - All updates must come through a pull request (no direct pushes
+#     from human accounts). PRs need 0 reviewers, so you can self-merge
+#     -- the gate is just "go through a PR" -- but the merge button
+#     still surfaces failed status checks for read-and-decide.
+#   - Linear history (no merge commits land on the branch).
+#   - No force-push, no deletion.
 #
-# We deliberately do NOT enforce required_status_checks here. The classic
-# branch-protection endpoint applies status-check requirements to ALL
-# pushes (including the GITHUB_TOKEN-authenticated push from the auto-
-# release workflow), and the GITHUB_TOKEN can't bypass them. The cleaner
-# fix would be migrating to branch rulesets with a bypass actor, or
-# provisioning a PAT secret with admin rights. For now we leave the gate
-# advisory: the PR Checks workflow still runs on every PR and renders
-# pass/fail on the PR page, but doesn't block the merge button via
-# branch protection. Functionally, "read the status, then click merge"
-# is the gate, which is acceptable for the current solo workflow.
+# Bypass:
+#   The GitHub Actions runner identity isn't a queryable Integration
+#   on the repo, so we can't add it via the rulesets API. After this
+#   script runs, manually add "github-actions" as a bypass actor in
+#   the GitHub UI for both rulesets (Settings -> Rules -> ezos-branch-
+#   <branch> -> Bypass list -> Add bypass -> "GitHub Actions"). Without
+#   it, the auto-release workflow's xtr-changelog --push will fail
+#   with GH006.
 #
-# Run once. Re-running is idempotent.
+# Why rulesets, not classic branch protection:
+#   Classic protection's "required_status_checks" applies to *every*
+#   push, and GITHUB_TOKEN can't bypass it -- so the auto-release
+#   workflow gets rejected (GH006) when the gate is on. Rulesets
+#   support per-actor bypass, which is exactly what we want.
+#
+#   Classic protection on these branches is removed in the same step
+#   to avoid two competing layers of policy.
+#
+# Run once. Re-running replaces the existing rulesets idempotently
+# (delete-then-create per branch).
 #
 # Requires: gh auth login (admin on the repo).
 
@@ -24,38 +38,83 @@ set -euo pipefail
 
 REPO=ezmesh/ezos
 
-# JSON body for the protection PUT call. Notes on each field:
-# - required_status_checks=null: don't enforce checks at the protection
-#   layer (would block the auto-release workflow's git push). Checks
-#   still run on PRs and surface in the UI.
-# - required_pull_request_reviews=null: don't require reviewers (solo dev)
-# - required_linear_history=true: rejects merge commits, forces squash/rebase
-# - allow_force_pushes=false / allow_deletions=false: standard
-# - enforce_admins=false: lets you override in emergencies
-PAYLOAD='{
-  "required_status_checks": null,
-  "enforce_admins": false,
-  "required_pull_request_reviews": null,
-  "restrictions": null,
-  "required_linear_history": true,
-  "allow_force_pushes": false,
-  "allow_deletions": false,
-  "required_conversation_resolution": false,
-  "lock_branch": false,
-  "allow_fork_syncing": false
-}'
-
-apply() {
+remove_classic_protection() {
     local branch=$1
-    echo "Applying protection to ${branch}..."
-    printf '%s\n' "$PAYLOAD" | gh api \
-        --method PUT \
-        -H "Accept: application/vnd.github+json" \
-        "repos/${REPO}/branches/${branch}/protection" \
-        --input -
-    echo "  ${branch}: protected."
+    if gh api -X DELETE "repos/${REPO}/branches/${branch}/protection" 2>/dev/null; then
+        echo "  ${branch}: classic branch protection removed"
+    else
+        echo "  ${branch}: no classic branch protection (skipping)"
+    fi
 }
 
-apply main
-apply test
-echo "Done. Verify in https://github.com/${REPO}/settings/branches"
+remove_existing_rulesets() {
+    # List existing repo rulesets and delete any that target this script's
+    # naming convention. Without this, re-running this script accumulates
+    # stale ruleset entries.
+    gh api "repos/${REPO}/rulesets" --jq '.[] | select(.name | startswith("ezos-branch-")) | .id' \
+        | while read -r id; do
+            if [ -n "$id" ]; then
+                gh api -X DELETE "repos/${REPO}/rulesets/$id" >/dev/null
+                echo "  deleted existing ruleset $id"
+            fi
+        done
+}
+
+create_ruleset() {
+    local branch=$1
+    local payload
+    payload=$(cat <<EOF
+{
+  "name": "ezos-branch-${branch}",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/${branch}"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash", "rebase"]
+      }
+    }
+  ]
+}
+EOF
+)
+    echo "Creating ruleset for ${branch}..."
+    local resp
+    resp=$(printf '%s\n' "$payload" \
+        | gh api --method POST -H "Accept: application/vnd.github+json" \
+            "repos/${REPO}/rulesets" --input - 2>&1) || {
+        echo "  ${branch}: failed"
+        echo "$resp" | head -3
+        return 1
+    }
+    echo "  ${branch}: ruleset $(echo "$resp" | jq -r .id) created"
+}
+
+echo "Removing classic branch protection..."
+remove_classic_protection main
+remove_classic_protection test
+
+echo "Removing any existing ezos-branch-* rulesets..."
+remove_existing_rulesets
+
+echo "Creating new rulesets..."
+create_ruleset main
+create_ruleset test
+
+echo "Done. Verify in https://github.com/${REPO}/settings/rules"


### PR DESCRIPTION
## Summary

- Replace classic branch protection with the newer rulesets API on `main` and `test`.
- New policy: PR-only updates (no human direct pushes), linear history, no force-push/deletion.
- 0 reviewers required so self-merge still works; PR Checks workflow remains advisory (not gated).

## Why

The user asked: "restrict pushes to main and test only from PRs." Classic branch protection couldn't do this without setting `required_pull_request_reviews`, which would also gate the auto-release workflow's `git push` and (transitively) any later attempt to add a CI bypass — classic protection has no per-actor bypass list.

Rulesets do support per-actor bypass. Already applied via API; this PR commits the script that codifies them.

## Manual follow-up after merge

The auto-release workflow's `xtr-changelog --push` will be rejected with `GH013` once this lands until you go to **Settings → Rules → ezos-branch-{main,test} → Bypass list → Add bypass → "GitHub Actions"**. The runner identity isn't a queryable Integration on the repo, so we can't add it via the API.

## Test plan
- [x] Direct push to `test` rejected with `GH013: Changes must be made through a pull request` (verified live)
- [ ] After merge: add GitHub Actions to bypass list on both rulesets
- [ ] Trigger main-/test-artifacts and verify `--push` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)