### PR TITLE
chore(deps): bump @xtr-dev/changelog to ^0.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "ezos",
-  "version": "1.0.0",
+  "version": "0.0.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ezos",
-      "version": "1.0.0",
+      "version": "0.0.70",
       "license": "ISC",
       "devDependencies": {
-        "@xtr-dev/changelog": "^0.0.4"
+        "@xtr-dev/changelog": "^0.0.5"
       }
     },
     "node_modules/@xtr-dev/changelog": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@xtr-dev/changelog/-/changelog-0.0.4.tgz",
-      "integrity": "sha512-VEFTK+4lgYt1Qn/tOFbmcqLkTKv/5mtqqaGRnrpNykUSg8GDroJDOt0vNfivUq58PQ+jLgrLWdH2VIxJL7unxg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@xtr-dev/changelog/-/changelog-0.0.5.tgz",
+      "integrity": "sha512-FN7EjufjWWFiI2+9enZHZ5LYP6H6xdl41wSMJzFQ2l62bIuj0hmNv5xq+azGYkJbQ/YhboVTQoCnR2vZYd/Iug==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/ezmesh/ezos#readme",
   "devDependencies": {
-    "@xtr-dev/changelog": "^0.0.4"
+    "@xtr-dev/changelog": "^0.0.5"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `@xtr-dev/changelog` devDependency from `^0.0.4` to `^0.0.5`.

## Test plan
- [ ] CI passes
- [ ] Release workflow still runs `xtr-changelog release` cleanly on next push to `test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)