### PR TITLE
feat(chat): show repeat count + RSSI/hops/SNR ranges in bubble menu

### DIFF
--- a/lua/screens/chat/channel_chat.lua
+++ b/lua/screens/chat/channel_chat.lua
@@ -53,12 +53,51 @@ local function show_context_menu(self, channel, msg)
 
         if not msg.is_self then
             local sender_name = msg.sender_name or "?"
-            local rssi_str = msg.rssi and string.format("%d dBm", math.floor(msg.rssi)) or "unknown"
-            actions[#actions + 1] = ui.list_item({
-                title = "From: " .. sender_name,
-                subtitle = "Signal: " .. rssi_str,
-                disabled = true,
-            })
+            local count = msg.count or 1
+            -- Header row. Annotate the sender label with the repeat
+            -- count when the bubble is the rolled-up view of multiple
+            -- receptions of the same text. Single-receipt messages
+            -- collapse to a one-line "Signal: -94 dBm" subtitle, which
+            -- is what existing users expect.
+            if count > 1 then
+                actions[#actions + 1] = ui.list_item({
+                    title = "From: " .. sender_name
+                        .. " (" .. count .. " repeats)",
+                    disabled = true,
+                })
+                -- Range rows (only added if we actually saw the value).
+                if msg.rssi_min and msg.rssi_max then
+                    actions[#actions + 1] = ui.list_item({
+                        title = string.format("RSSI: %d..%d dBm",
+                            math.floor(msg.rssi_min),
+                            math.floor(msg.rssi_max)),
+                        disabled = true,
+                    })
+                end
+                if msg.hops_min and msg.hops_max then
+                    actions[#actions + 1] = ui.list_item({
+                        title = string.format("Hops: %d..%d",
+                            msg.hops_min, msg.hops_max),
+                        disabled = true,
+                    })
+                end
+                if msg.snr_min and msg.snr_max then
+                    actions[#actions + 1] = ui.list_item({
+                        title = string.format("SNR:  %.1f..%.1f dB",
+                            msg.snr_min, msg.snr_max),
+                        disabled = true,
+                    })
+                end
+            else
+                local rssi_str = msg.rssi and
+                    string.format("%d dBm", math.floor(msg.rssi))
+                    or "unknown"
+                actions[#actions + 1] = ui.list_item({
+                    title = "From: " .. sender_name,
+                    subtitle = "Signal: " .. rssi_str,
+                    disabled = true,
+                })
+            end
         end
 
         if msg.is_self then

--- a/lua/screens/chat/dm_conversation.lua
+++ b/lua/screens/chat/dm_conversation.lua
@@ -165,12 +165,49 @@ local function show_context_menu(self, key, msg, msg_index)
 
         if not msg.is_self then
             local sender_name = msg.sender_name or "?"
-            local rssi_str = msg.rssi and string.format("%d dBm", math.floor(msg.rssi)) or "unknown"
-            actions[#actions + 1] = ui.list_item({
-                title = "From: " .. sender_name,
-                subtitle = "Signal: " .. rssi_str,
-                disabled = true,
-            })
+            local count = msg.count or 1
+            -- See channel_chat.lua for the rationale on the count > 1
+            -- branch -- mirrored here so DM bubbles get the same
+            -- repeat-count + RSSI/hops/SNR ranges when the same DM was
+            -- relayed by multiple repeaters.
+            if count > 1 then
+                actions[#actions + 1] = ui.list_item({
+                    title = "From: " .. sender_name
+                        .. " (" .. count .. " repeats)",
+                    disabled = true,
+                })
+                if msg.rssi_min and msg.rssi_max then
+                    actions[#actions + 1] = ui.list_item({
+                        title = string.format("RSSI: %d..%d dBm",
+                            math.floor(msg.rssi_min),
+                            math.floor(msg.rssi_max)),
+                        disabled = true,
+                    })
+                end
+                if msg.hops_min and msg.hops_max then
+                    actions[#actions + 1] = ui.list_item({
+                        title = string.format("Hops: %d..%d",
+                            msg.hops_min, msg.hops_max),
+                        disabled = true,
+                    })
+                end
+                if msg.snr_min and msg.snr_max then
+                    actions[#actions + 1] = ui.list_item({
+                        title = string.format("SNR:  %.1f..%.1f dB",
+                            msg.snr_min, msg.snr_max),
+                        disabled = true,
+                    })
+                end
+            else
+                local rssi_str = msg.rssi and
+                    string.format("%d dBm", math.floor(msg.rssi))
+                    or "unknown"
+                actions[#actions + 1] = ui.list_item({
+                    title = "From: " .. sender_name,
+                    subtitle = "Signal: " .. rssi_str,
+                    disabled = true,
+                })
+            end
         end
 
         if msg.is_self then

--- a/lua/services/channels.lua
+++ b/lua/services/channels.lua
@@ -51,6 +51,26 @@ local function resolve_sender(sender_hash)
     return nil
 end
 
+-- Track running signal-quality ranges across collapsed duplicates so
+-- the bubble's context menu can show e.g. "RSSI: -110..-90 dBm" instead
+-- of just the most recent value. Called both when a fresh msg first
+-- lands (seed from its own values) and when a duplicate is folded in
+-- (extend the range).
+local function fold_signal(target, src)
+    if src.rssi then
+        target.rssi_min = math.min(target.rssi_min or src.rssi, src.rssi)
+        target.rssi_max = math.max(target.rssi_max or src.rssi, src.rssi)
+    end
+    if src.snr then
+        target.snr_min = math.min(target.snr_min or src.snr, src.snr)
+        target.snr_max = math.max(target.snr_max or src.snr, src.snr)
+    end
+    if src.hop_count then
+        target.hops_min = math.min(target.hops_min or src.hop_count, src.hop_count)
+        target.hops_max = math.max(target.hops_max or src.hop_count, src.hop_count)
+    end
+end
+
 -- Store a decoded message into history, grouping consecutive duplicates
 local function store_message(channel_name, msg)
     if not history[channel_name] then
@@ -64,10 +84,12 @@ local function store_message(channel_name, msg)
         last.count = (last.count or 1) + 1
         last.rssi = msg.rssi
         last.timestamp = msg.timestamp
+        fold_signal(last, msg)
         return
     end
 
     msg.count = 1
+    fold_signal(msg, msg)
     h[#h + 1] = msg
     while #h > MAX_HISTORY do
         table.remove(h, 1)
@@ -420,6 +442,10 @@ function channels.init()
             timestamp = msg_timestamp,
             rssi = pkt.rssi,
             snr = pkt.snr,
+            -- Outer-packet hop count. Surfaced by mesh_bindings.cpp's
+            -- group-packet callback (pkt.hop_count == pathLen, which
+            -- equals hops because PATH_HASH_SIZE=1).
+            hop_count = pkt.hop_count or 0,
             is_self = is_self,
         }
 

--- a/lua/services/direct_messages.lua
+++ b/lua/services/direct_messages.lua
@@ -397,6 +397,26 @@ local RECV_DEDUP_WINDOW_S = 60
 -- messages only merge when they arrive within the retransmit window,
 -- so the mesh-level ACK retry (every ~10-15 s) is hidden but a true
 -- second message from the peer isn't.
+-- Track running signal-quality ranges across collapsed duplicate
+-- receptions (different repeaters relaying the same DM). Mirrors the
+-- helper in services/channels.lua. Only inbound messages dedupe, but
+-- we seed the range on every new message so the context menu can show
+-- a one-line value for count == 1 without a special case.
+local function fold_signal(target, src)
+    if src.rssi then
+        target.rssi_min = math.min(target.rssi_min or src.rssi, src.rssi)
+        target.rssi_max = math.max(target.rssi_max or src.rssi, src.rssi)
+    end
+    if src.snr then
+        target.snr_min = math.min(target.snr_min or src.snr, src.snr)
+        target.snr_max = math.max(target.snr_max or src.snr, src.snr)
+    end
+    if src.hop_count then
+        target.hops_min = math.min(target.hops_min or src.hop_count, src.hop_count)
+        target.hops_max = math.max(target.hops_max or src.hop_count, src.hop_count)
+    end
+end
+
 store_message = function(pub_key_hex, msg)
     if not conversations[pub_key_hex] then
         conversations[pub_key_hex] = {}
@@ -410,11 +430,13 @@ store_message = function(pub_key_hex, msg)
                 and (msg.timestamp or 0) - (last.timestamp or 0) <= RECV_DEDUP_WINDOW_S then
             last.count = (last.count or 1) + 1
             last.timestamp = msg.timestamp
+            fold_signal(last, msg)
             return last
         end
     end
 
     msg.count = 1
+    fold_signal(msg, msg)
     h[#h + 1] = msg
     while #h > MAX_HISTORY do
         table.remove(h, 1)
@@ -758,6 +780,8 @@ function dm.init()
                                     timestamp = msg_timestamp,
                                     rssi = pkt.rssi,
                                     snr = pkt.snr,
+                                    -- 1-byte path hashes -> #path == hops.
+                                    hop_count = pkt.path and #pkt.path or 0,
                                     is_self = false,
                                 }
 

--- a/src/lua/bindings/mesh_bindings.cpp
+++ b/src/lua/bindings/mesh_bindings.cpp
@@ -515,7 +515,8 @@ static void pushNodeTable(lua_State* L, const NodeInfo& node) {
 
 // Helper: Push group packet info as Lua table onto stack
 static void pushGroupPacketTable(lua_State* L, uint8_t channelHash, const uint8_t* data, size_t dataLen,
-                                  uint8_t senderHash, float rssi, float snr) {
+                                  uint8_t senderHash, float rssi, float snr,
+                                  uint8_t hopCount) {
     lua_newtable(L);
 
     lua_pushinteger(L, channelHash);
@@ -532,6 +533,12 @@ static void pushGroupPacketTable(lua_State* L, uint8_t channelHash, const uint8_
 
     lua_pushnumber(L, snr);
     lua_setfield(L, -2, "snr");
+
+    // Outer-packet path length. With PATH_HASH_SIZE=1 every hop is a
+    // single byte, so this is the hop count -- exposed so the channel
+    // service can track per-receipt hop range when duplicates collapse.
+    lua_pushinteger(L, hopCount);
+    lua_setfield(L, -2, "hop_count");
 }
 
 // Helper: Push parsed packet info as Lua table onto stack
@@ -622,7 +629,7 @@ LUA_FUNCTION(l_mesh_on_node_discovered) {
 // @description Registers a callback for receiving GRP_TXT and GRP_DATA packets.
 // The callback receives pre-parsed group packet data including the encrypted payload.
 // Also posts to message bus "mesh/group_packet". Pass nil to remove the callback.
-// @param callback Function(packet_table) called with {channel_hash, data, sender_hash, rssi, snr}
+// @param callback Function(packet_table) called with {channel_hash, data, sender_hash, rssi, snr, hop_count}
 // @note When this callback is set, Lua takes over channel handling
 // @example
 // ez.mesh.on_group_packet(function(pkt)
@@ -642,11 +649,13 @@ LUA_FUNCTION(l_mesh_on_group_packet) {
 
         if (mesh) {
             mesh->setGroupPacketCallback([](uint8_t channelHash, const uint8_t* data, size_t dataLen,
-                                           uint8_t senderHash, float rssi, float snr) {
+                                           uint8_t senderHash, float rssi, float snr,
+                                           uint8_t hopCount) {
                 lua_State* LS = LUA_STATE;
                 if (LS && groupPacketCallbackRef != LUA_NOREF) {
                     lua_rawgeti(LS, LUA_REGISTRYINDEX, groupPacketCallbackRef);
-                    pushGroupPacketTable(LS, channelHash, data, dataLen, senderHash, rssi, snr);
+                    pushGroupPacketTable(LS, channelHash, data, dataLen, senderHash, rssi, snr,
+                                         hopCount);
 
                     if (lua_pcall(LS, 1, 0, 0) != LUA_OK) {
                         Serial.printf("[Lua] Group packet callback error: %s\n",
@@ -659,9 +668,9 @@ LUA_FUNCTION(l_mesh_on_group_packet) {
                 // Copy data since it won't survive beyond this callback
                 std::vector<uint8_t> dataCopy(data, data + dataLen);
                 MessageBus::instance().postTable("mesh/group_packet",
-                    [channelHash, dataCopy, senderHash, rssi, snr](lua_State* L) {
+                    [channelHash, dataCopy, senderHash, rssi, snr, hopCount](lua_State* L) {
                         pushGroupPacketTable(L, channelHash, dataCopy.data(), dataCopy.size(),
-                                           senderHash, rssi, snr);
+                                           senderHash, rssi, snr, hopCount);
                     });
             });
         }

--- a/src/mesh/meshcore.cpp
+++ b/src/mesh/meshcore.cpp
@@ -397,7 +397,8 @@ void MeshCore::handleGroupTextPacket(const MeshPacket& packet, const RxMetadata&
 
     // Pass to Lua callback for decryption and handling
     if (_onGroupPacket) {
-        _onGroupPacket(channelIdx, encryptedData, encryptedLen, senderHash, meta.rssi, meta.snr);
+        _onGroupPacket(channelIdx, encryptedData, encryptedLen, senderHash, meta.rssi, meta.snr,
+                       packet.pathLen);
     }
 }
 

--- a/src/mesh/meshcore.h
+++ b/src/mesh/meshcore.h
@@ -65,9 +65,14 @@ struct ParsedPacket {
 // Callback types
 using MessageCallback = std::function<void(const Message&)>;
 using NodeCallback = std::function<void(const NodeInfo&)>;
-// Raw group packet callback for Lua - receives encrypted data before decryption
+// Raw group packet callback for Lua - receives encrypted data before
+// decryption. hopCount is the outer mesh packet's pathLen (with
+// PATH_HASH_SIZE=1 every hop is a single byte, so pathLen == hops);
+// surfaced so services/channels.lua can fold per-receipt hop range
+// into a duplicate-collapsed message.
 using GroupPacketCallback = std::function<void(uint8_t channelHash, const uint8_t* data, size_t dataLen,
-                                                uint8_t senderHash, float rssi, float snr)>;
+                                                uint8_t senderHash, float rssi, float snr,
+                                                uint8_t hopCount)>;
 // Generic packet callback - returns true if Lua handled it (skip C++ handling),
 // second bool is whether to rebroadcast
 using PacketCallback = std::function<std::pair<bool, bool>(const ParsedPacket& packet)>;


### PR DESCRIPTION
## Summary

Closes #54. When the same message arrives multiple times via different repeaters, the dedup logic in `services/channels.lua` (and `direct_messages.lua`) collapses them into one bubble with a `count`. The bubble's context menu used to lose all per-receipt signal data and just show the most recent RSSI. This PR keeps running min/max ranges for **RSSI**, **hops**, and **SNR**, then surfaces them in the menu when `count > 1`:

```
From: alice (3 repeats)
RSSI: -110..-82 dBm
Hops: 1..4
SNR:  3.0..9.5 dB
```

Single-receipt messages keep the one-line `Signal: -94 dBm` subtitle.

## Changes

- `services/channels.lua` -- new `fold_signal()` helper, called both on dedup-collapse and on first store. Adds `hop_count` to the stored msg.
- `services/direct_messages.lua` -- mirrors the same fold helper + adds `hop_count` to the inbound msg from `#pkt.path` (DMs already had path info on `pkt`).
- `screens/chat/channel_chat.lua` and `dm_conversation.lua` -- bubble context-menu builder branches on `count > 1` to render the range items, otherwise unchanged.
- `src/mesh/meshcore.{h,cpp}` -- `GroupPacketCallback` gains a `uint8_t hopCount`, populated from `packet.pathLen` at dispatch.
- `src/lua/bindings/mesh_bindings.cpp` -- `pushGroupPacketTable` adds `hop_count` to the Lua packet table; both call sites (direct callback + bus topic) updated.

## Test plan

- [x] Builds clean
- [x] Bubble menu UI verified on-device with a synthetic msg pushed via `ez_remote.py -e` (screenshot in PR thread)
- [x] One-line subtitle path unchanged for `count == 1`
- [ ] Real OTA repeat path: needs a second repeater within range -- couldn't validate in this loop, but the fold helper is exercised on every store so the range fields get seeded for single-receipt messages too.

## Screenshot

Synthetic bubble menu rendering with all four lines visible (3 repeats, RSSI/Hops/SNR ranges).

## Notes for reviewers

- Per-repeater attribution is out-of-scope (MeshCore packets don't carry repeater identity in the standard types).
- New `hop_count` field on group-packet table is a binding shape change; no other callers depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)