### PR TITLE
fix(shooter): pool particles/popups/bullets to kill per-frame GC stalls

### DIFF
--- a/lua/screens/games/shooter.lua
+++ b/lua/screens/games/shooter.lua
@@ -64,6 +64,18 @@ local GUN_MISSILE = 4
 
 local GUN_NAMES = { "Blaster", "Spread", "Rapid", "Missile" }
 
+-- Hot-path constants. These were previously table literals built
+-- inside `spawn` closures / apply_input on every fire frame, churning
+-- the GC.
+local SPREAD_ANGLES = { -0.28, 0, 0.28 }
+local HEAVY_BURST_ANGLES = { -0.3, 0, 0.3 }
+local GUN_SFX_NAMES = {
+    [1] = "blaster",  -- GUN_BLASTER
+    [2] = "spread",   -- GUN_SPREAD
+    [3] = "rapid",    -- GUN_RAPID
+    [4] = "missile",  -- GUN_MISSILE
+}
+
 -- Per-gun: cooldown in frames, bullet damage, spawn pattern.
 -- Kept table-driven so adding a gun is purely data.
 -- Each gun links to a sound in sfx. Sound plays in apply_input when
@@ -71,34 +83,40 @@ local GUN_NAMES = { "Blaster", "Spread", "Rapid", "Missile" }
 -- just the key press, which would spam when the gun's on cooldown.
 local GUNS = {
     [GUN_BLASTER] = { cooldown = 7,  damage = 2, sound = sfx.blaster,
-                      spawn = function(px, py, bullets)
-                          bullets[#bullets + 1] = {
-                              x = px, y = py - 10, vx = 0, vy = -6,
-                              dmg = 2, color = rgb(240, 230, 100), kind = "blaster" }
+                      spawn = function(px, py, acquire)
+                          local b = acquire(); if not b then return end
+                          b.x = px; b.y = py - 10
+                          b.vx = 0; b.vy = -6
+                          b.dmg = 2; b.color = rgb(240, 230, 100)
+                          b.kind = "blaster"
                       end },
     [GUN_SPREAD]  = { cooldown = 12, damage = 2, sound = sfx.spread,
-                      spawn = function(px, py, bullets)
-                          for _, a in ipairs({-0.28, 0, 0.28}) do
-                              bullets[#bullets + 1] = {
-                                  x = px, y = py - 10,
-                                  vx = sin(a) * 6, vy = -cos(a) * 6,
-                                  dmg = 2, color = rgb(160, 240, 140), kind = "spread" }
+                      spawn = function(px, py, acquire)
+                          for _, a in ipairs(SPREAD_ANGLES) do
+                              local b = acquire(); if not b then return end
+                              b.x = px; b.y = py - 10
+                              b.vx = sin(a) * 6; b.vy = -cos(a) * 6
+                              b.dmg = 2; b.color = rgb(160, 240, 140)
+                              b.kind = "spread"
                           end
                       end },
     [GUN_RAPID]   = { cooldown = 3,  damage = 1, sound = sfx.rapid,
-                      spawn = function(px, py, bullets)
-                          bullets[#bullets + 1] = {
-                              x = px, y = py - 10, vx = 0, vy = -8,
-                              dmg = 1, color = rgb(90, 200, 240), kind = "rapid" }
+                      spawn = function(px, py, acquire)
+                          local b = acquire(); if not b then return end
+                          b.x = px; b.y = py - 10
+                          b.vx = 0; b.vy = -8
+                          b.dmg = 1; b.color = rgb(90, 200, 240)
+                          b.kind = "rapid"
                       end },
     -- Missile is slower but homing + high damage.
     [GUN_MISSILE] = { cooldown = 18, damage = 5, sound = sfx.missile,
-                      spawn = function(px, py, bullets)
-                          bullets[#bullets + 1] = {
-                              x = px, y = py - 10, vx = 0, vy = -3,
-                              dmg = 5, color = rgb(240, 120, 60), kind = "missile",
-                              home = true,
-                              ttl = 120 }
+                      spawn = function(px, py, acquire)
+                          local b = acquire(); if not b then return end
+                          b.x = px; b.y = py - 10
+                          b.vx = 0; b.vy = -3
+                          b.dmg = 5; b.color = rgb(240, 120, 60)
+                          b.kind = "missile"
+                          b.home = true; b.ttl = 120
                       end },
 }
 
@@ -179,8 +197,13 @@ local enemies          -- list
 local bullets          -- list { x, y, vx, vy, dmg, color, kind, home?, ttl? }
 local items            -- list { x, y, vy, kind }
 local stars            -- background dots; {x, y, vy, color}
-local particles        -- short-lived sparks: {x, y, vx, vy, life, color}
-local popups           -- score popups: {x, y, life, text, color}
+-- Pool-allocated to avoid per-spawn table churn that was triggering
+-- visible GC stalls during combat. life <= 0 marks a free slot.
+local PARTICLE_POOL = 96
+local POPUP_POOL    = 24
+local BULLET_POOL   = 96
+local particles        -- pool of {x, y, vx, vy, life, color}
+local popups           -- pool of {x, y, life, max_life, text, color}
 local asteroids        -- destructible obstacles: {x, y, vy, hp, size, rot, rot_speed}
 local spawn_timer
 local wave
@@ -198,6 +221,10 @@ local status_text = ""
 local run_seed
 local encounter_plan
 local encounter_idx
+-- Cached resolution of encounter_plan[encounter_idx]. The plan uses a
+-- lazy __index metamethod, so reading it every frame dispatches a
+-- function call. Refresh only when encounter_idx advances.
+local current_encounter
 local encounter_pos        -- frames since the current encounter started
 local next_entry_idx       -- index into the current encounter's entries
 local boss_announce_frames -- HUD banner timer ("BOSS — XYZ"), 0 = idle
@@ -209,6 +236,12 @@ local boss_announce_frames -- HUD banner timer ("BOSS — XYZ"), 0 = idle
 local gen_run
 local spawn_particle_burst
 local spawn_popup
+-- Bullets are pool-allocated to avoid the per-shot table churn that
+-- showed up as visible GC stalls during combat. acquire_bullet()
+-- finds the next free slot (with `dead == true`) and returns it for
+-- the caller to populate; nil if the pool is exhausted (drop the
+-- shot — much less visible than a frame stutter).
+local acquire_bullet
 
 -- Generator difficulty envelope. The first ~30 encounters ramp from
 -- 0 → 1 (gentle on-ramp); past that, difficulty continues to climb
@@ -292,9 +325,22 @@ local function reset_world(n_players)
     end
     enemies = {}
     bullets = {}
+    for i = 1, BULLET_POOL do
+        bullets[i] = { x = 0, y = 0, vx = 0, vy = 0,
+                       dmg = 0, color = 0, kind = "blaster",
+                       hostile = false, home = false, ttl = nil,
+                       dead = true }
+    end
     items   = {}
     particles = {}
-    popups    = {}
+    for i = 1, PARTICLE_POOL do
+        particles[i] = { x = 0, y = 0, vx = 0, vy = 0, life = 0, color = 0 }
+    end
+    popups = {}
+    for i = 1, POPUP_POOL do
+        popups[i] = { x = 0, y = 0, life = 0, max_life = 1,
+                      text = "", color = 0 }
+    end
     asteroids = {}
     wave = 1
     spawn_timer = 0
@@ -309,6 +355,7 @@ local function reset_world(n_players)
     run_seed = ez.system.millis()
     encounter_plan = gen_run(run_seed)
     encounter_idx  = 1
+    current_encounter = encounter_plan[1]
     encounter_pos  = 0
     next_entry_idx = 1
     boss_announce_frames = 0
@@ -320,6 +367,24 @@ local function reset_world(n_players)
     math.randomseed(ez.system.millis())
 end
 
+-- Defined here (after reset_world's local definitions of `bullets`
+-- via the upvalue) and assigned with `=` to bind to the forward decl.
+acquire_bullet = function()
+    for i = 1, #bullets do
+        local b = bullets[i]
+        if b.dead then
+            b.dead = false
+            -- Clear optional fields so a previously-missile slot
+            -- doesn't accidentally home / TTL-out as a blaster shot.
+            b.hostile = false
+            b.home = false
+            b.ttl = nil
+            return b
+        end
+    end
+    return nil
+end
+
 -- Spawn N small spark particles flying out from (x, y) in random
 -- directions, tinted to match the source. Used for enemy deaths and
 -- bullet impacts. Particles are cheap (8 floats each), stepped in
@@ -328,16 +393,29 @@ end
 -- the top bind to the same upvalue.
 spawn_particle_burst = function(x, y, count, color, speed)
     speed = speed or 2.5
+    local pool_size = #particles
+    local search = 1
     for _ = 1, count do
+        -- Find the next free slot (life <= 0). If the pool is full,
+        -- silently drop the spark — a few missed pixels during a
+        -- mega-burst is invisible; a per-frame GC stall is not.
+        local slot = nil
+        for j = search, pool_size do
+            if particles[j].life <= 0 then
+                slot = j
+                search = j + 1
+                break
+            end
+        end
+        if not slot then break end
         local a = rand() * math.pi * 2
         local s = speed * (0.4 + rand() * 0.8)
-        particles[#particles + 1] = {
-            x = x, y = y,
-            vx = math.cos(a) * s,
-            vy = math.sin(a) * s,
-            life = 25 + math.floor(rand() * 12),
-            color = color,
-        }
+        local p = particles[slot]
+        p.x = x; p.y = y
+        p.vx = math.cos(a) * s
+        p.vy = math.sin(a) * s
+        p.life = 25 + math.floor(rand() * 12)
+        p.color = color
     end
 end
 
@@ -345,11 +423,18 @@ end
 -- it goes. Cheap and a noticeable hit of feedback every time the
 -- player gets a kill.
 spawn_popup = function(x, y, text, color)
-    popups[#popups + 1] = {
-        x = x, y = y,
-        life = 32, max_life = 32,
-        text = text, color = color or rgb(255, 240, 180),
-    }
+    for i = 1, #popups do
+        local p = popups[i]
+        if p.life <= 0 then
+            p.x = x; p.y = y
+            p.life = 32; p.max_life = 32
+            p.text = text
+            p.color = color or rgb(255, 240, 180)
+            return
+        end
+    end
+    -- Pool exhausted: drop the popup. The HUD score still updates;
+    -- losing one floating "+25" during a kill spree is invisible.
 end
 
 ---------------------------------------------------------------------------
@@ -591,7 +676,7 @@ gen_run = function(seed)
 end
 
 local function step_encounter_plan()
-    local enc = encounter_plan and encounter_plan[encounter_idx]
+    local enc = current_encounter
     if not enc then return end
     encounter_pos = encounter_pos + 1
 
@@ -621,8 +706,8 @@ local function step_encounter_plan()
         wave = encounter_idx
         status_text = "Wave " .. wave
         play_sfx("wave_up", sfx.wave_up, 75)
-        local nxt = encounter_plan[encounter_idx]
-        if nxt and nxt.title then
+        current_encounter = encounter_plan[encounter_idx]
+        if current_encounter and current_encounter.title then
             boss_announce_frames = 90
         end
     end
@@ -678,25 +763,29 @@ local function step_enemy(e)
         -- Periodic bomb drop (modeled as a downward bullet on the
         -- same list so the same vs-player logic handles it).
         if e.t % 60 == 30 then
-            bullets[#bullets + 1] = {
-                x = e.x, y = e.y + def.size,
-                vx = 0, vy = 3.0,
-                dmg = 1, color = rgb(240, 120, 40), kind = "bomb",
-                hostile = true,
-            }
+            local b = acquire_bullet()
+            if b then
+                b.x = e.x; b.y = e.y + def.size
+                b.vx = 0; b.vy = 3.0
+                b.dmg = 1; b.color = rgb(240, 120, 40)
+                b.kind = "bomb"
+                b.hostile = true
+            end
         end
     elseif e.kind == E_HEAVY then
         e.y = e.y + def.speed
         e.x = e.x + sin((e.t + e.phase) * 0.05) * 0.8
         if e.t % 40 == 0 then
             -- Three-bullet burst aimed roughly downward.
-            for _, a in ipairs({-0.3, 0, 0.3}) do
-                bullets[#bullets + 1] = {
-                    x = e.x, y = e.y + def.size,
-                    vx = sin(a) * 3, vy = cos(a) * 3,
-                    dmg = 1, color = rgb(240, 80, 80), kind = "bomb",
-                    hostile = true,
-                }
+            for _, a in ipairs(HEAVY_BURST_ANGLES) do
+                local b = acquire_bullet()
+                if b then
+                    b.x = e.x; b.y = e.y + def.size
+                    b.vx = sin(a) * 3; b.vy = cos(a) * 3
+                    b.dmg = 1; b.color = rgb(240, 80, 80)
+                    b.kind = "bomb"
+                    b.hostile = true
+                end
             end
         end
     elseif e.kind == E_DRONE then
@@ -753,10 +842,15 @@ local function step_bullet(b)
 end
 
 local function step_items()
-    for i = #items, 1, -1 do
+    local n = #items
+    for i = n, 1, -1 do
         local it = items[i]
         it.y = it.y + it.vy
-        if it.y > SH + 8 then table.remove(items, i) end
+        if it.y > SH + 8 then
+            -- swap-pop: O(1) instead of O(n) shift; order doesn't
+            -- matter for the items list.
+            items[i] = items[n]; items[n] = nil; n = n - 1
+        end
     end
 end
 
@@ -774,25 +868,28 @@ end
 -- Drag also bounds speed enough that long-lived particles don't
 -- drift fully off-screen by life=0.
 local function step_particles()
-    for i = #particles, 1, -1 do
+    for i = 1, #particles do
         local p = particles[i]
-        p.x = p.x + p.vx
-        p.y = p.y + p.vy
-        p.vx = p.vx * 0.92
-        p.vy = p.vy * 0.92
-        p.life = p.life - 1
-        if p.life <= 0 then table.remove(particles, i) end
+        if p.life > 0 then
+            p.x = p.x + p.vx
+            p.y = p.y + p.vy
+            p.vx = p.vx * 0.92
+            p.vy = p.vy * 0.92
+            p.life = p.life - 1
+            -- life ticks to 0 here; stays "free" until reused.
+        end
     end
 end
 
 -- Popups drift upward at a fixed slow rate; life ticks down each
 -- frame and the renderer fades the colour proportional to it.
 local function step_popups()
-    for i = #popups, 1, -1 do
+    for i = 1, #popups do
         local p = popups[i]
-        p.y = p.y - 0.6
-        p.life = p.life - 1
-        if p.life <= 0 then table.remove(popups, i) end
+        if p.life > 0 then
+            p.y = p.y - 0.6
+            p.life = p.life - 1
+        end
     end
 end
 
@@ -939,7 +1036,7 @@ local function apply_input(p, in_left, in_right, in_up, in_down, in_fire)
     if in_fire then
         if p.cooldown <= 0 then
             local g = GUNS[p.gun]
-            g.spawn(p.x, p.y, bullets)
+            g.spawn(p.x, p.y, acquire_bullet)
             -- Stackable rate modifier: lower rate_mod = shorter
             -- cooldown = faster fire. Floor at 1 so we never hit a
             -- zero-frame cooldown that lets the gun spam every tick.
@@ -954,13 +1051,7 @@ local function apply_input(p, in_left, in_right, in_up, in_down, in_fire)
             -- absent. Keeping this lookup local so g.sound stays the
             -- single source of truth for the legacy path.
             if p.id == 1 then
-                local gun_names = {
-                    [GUN_BLASTER] = "blaster",
-                    [GUN_SPREAD]  = "spread",
-                    [GUN_RAPID]   = "rapid",
-                    [GUN_MISSILE] = "missile",
-                }
-                play_sfx(gun_names[p.gun] or "blaster", g.sound, 70)
+                play_sfx(GUN_SFX_NAMES[p.gun] or "blaster", g.sound, 70)
             end
         end
     end
@@ -993,14 +1084,17 @@ local function step_authoritative()
         end
     end
 
-    -- Bullets.
-    for i = #bullets, 1, -1 do
+    -- Bullets. Pool-allocated; mark dead in place rather than
+    -- table.remove so we don't churn the GC every off-screen frame.
+    for i = 1, #bullets do
         local b = bullets[i]
-        step_bullet(b)
-        if b.y < FIELD_TOP - 8 or b.y > SH + 8
-                or b.x < -8 or b.x > SW + 8
-                or (b.ttl and b.ttl <= 0) then
-            table.remove(bullets, i)
+        if not b.dead then
+            step_bullet(b)
+            if b.y < FIELD_TOP - 8 or b.y > SH + 8
+                    or b.x < -8 or b.x > SW + 8
+                    or (b.ttl and b.ttl <= 0) then
+                b.dead = true
+            end
         end
     end
 
@@ -1011,14 +1105,15 @@ local function step_authoritative()
 
     -- Collisions: bullets vs enemies (player-fired) and bullets vs
     -- players (enemy-fired). The `hostile` flag separates the two.
-    for bi = #bullets, 1, -1 do
+    for bi = 1, #bullets do
         local b = bullets[bi]
+        if b.dead then goto next_bullet end
         if b.hostile then
             for _, p in ipairs(players) do
                 if p.alive and circle_aabb(b.x, b.y, 4,
                         p.x - PLAYER_HW, p.y - 8, PLAYER_HW * 2, 14) then
                     damage_player(p, b.dmg)
-                    table.remove(bullets, bi)
+                    b.dead = true
                     goto next_bullet
                 end
             end
@@ -1030,7 +1125,7 @@ local function step_authoritative()
                 local dy = b.y - e.y
                 if dx * dx + dy * dy <= def.size * def.size then
                     e.hp = e.hp - b.dmg
-                    table.remove(bullets, bi)
+                    b.dead = true
                     if e.hp <= 0 then
                         -- Credit score to player 1 for simplicity — a
                         -- real MP would track which bullet came from
@@ -1091,13 +1186,16 @@ local function step_authoritative()
     end
 
     -- Player vs items.
-    for ii = #items, 1, -1 do
+    local n_items = #items
+    for ii = n_items, 1, -1 do
         local it = items[ii]
         for _, p in ipairs(players) do
             if p.alive and circle_aabb(it.x, it.y, 6,
                     p.x - PLAYER_HW, p.y - 8, PLAYER_HW * 2, 14) then
                 apply_item(p, it.kind)
-                table.remove(items, ii)
+                items[ii] = items[n_items]
+                items[n_items] = nil
+                n_items = n_items - 1
                 break
             end
         end
@@ -1125,24 +1223,40 @@ end
 -- Rendering
 ---------------------------------------------------------------------------
 
+-- HUD strings only change when the underlying stats change; cache
+-- them so the per-frame redraw doesn't allocate two fresh strings via
+-- string.format every tick.
+local hud_p1_txt, hud_p1_key = "", nil
+local hud_p2_txt, hud_p2_txt_w, hud_p2_key = "", 0, nil
+
 local function draw_hud(d)
     d.fill_rect(0, 0, SW, HUD_H, rgb(0, 0, 0))
     theme.set_font("small_aa")
     local p1 = players and players[1]
     if p1 then
-        local txt = string.format("P1 %s  HP:%d  L:%d  %d",
-            GUN_NAMES[p1.gun], math.max(0, p1.hp), math.max(0, p1.lives),
-            p1.score)
-        d.draw_text(4, 4, txt, rgb(200, 230, 200))
+        local hp = math.max(0, p1.hp)
+        local lives = math.max(0, p1.lives)
+        local key = p1.gun * 1e9 + hp * 1e6 + lives * 1e4 + p1.score
+        if key ~= hud_p1_key then
+            hud_p1_txt = string.format("P1 %s  HP:%d  L:%d  %d",
+                GUN_NAMES[p1.gun], hp, lives, p1.score)
+            hud_p1_key = key
+        end
+        d.draw_text(4, 4, hud_p1_txt, rgb(200, 230, 200))
     end
     if players and players[2] then
         local p2 = players[2]
         theme.set_font("tiny_aa")
-        local txt = string.format("P2 %s HP:%d L:%d %d",
-            GUN_NAMES[p2.gun], math.max(0, p2.hp), math.max(0, p2.lives),
-            p2.score)
-        local tw = theme.text_width(txt)
-        d.draw_text(SW - tw - 4, 4, txt, rgb(180, 200, 240))
+        local hp = math.max(0, p2.hp)
+        local lives = math.max(0, p2.lives)
+        local key = p2.gun * 1e9 + hp * 1e6 + lives * 1e4 + p2.score
+        if key ~= hud_p2_key then
+            hud_p2_txt = string.format("P2 %s HP:%d L:%d %d",
+                GUN_NAMES[p2.gun], hp, lives, p2.score)
+            hud_p2_txt_w = theme.text_width(hud_p2_txt)
+            hud_p2_key = key
+        end
+        d.draw_text(SW - hud_p2_txt_w - 4, 4, hud_p2_txt, rgb(180, 200, 240))
     end
     theme.set_font("tiny_aa")
     if status_text and status_text ~= "" then
@@ -1349,13 +1463,16 @@ end
 -- text strings that fade as they age.
 local function draw_particles(d)
     if not particles then return end
-    for _, p in ipairs(particles) do
-        local px, py = floor(p.x), floor(p.y)
-        d.fill_rect(px, py, 2, 2, p.color)
-        if p.life > 18 then
-            -- Brighter core in the early phase so the spark "snaps"
-            -- before fading to match the death timing.
-            d.fill_rect(px, py, 1, 1, rgb(255, 255, 255))
+    for i = 1, #particles do
+        local p = particles[i]
+        if p.life > 0 then
+            local px, py = floor(p.x), floor(p.y)
+            d.fill_rect(px, py, 2, 2, p.color)
+            if p.life > 18 then
+                -- Brighter core in the early phase so the spark "snaps"
+                -- before fading to match the death timing.
+                d.fill_rect(px, py, 1, 1, rgb(255, 255, 255))
+            end
         end
     end
 end
@@ -1363,8 +1480,11 @@ end
 local function draw_popups(d)
     if not popups then return end
     theme.set_font("tiny_aa")
-    for _, p in ipairs(popups) do
-        d.draw_text(floor(p.x) - 6, floor(p.y), p.text, p.color)
+    for i = 1, #popups do
+        local p = popups[i]
+        if p.life > 0 then
+            d.draw_text(floor(p.x) - 6, floor(p.y), p.text, p.color)
+        end
     end
 end
 
@@ -1373,7 +1493,7 @@ end
 -- banner, slid below the HUD.
 local function draw_boss_banner(d)
     if boss_announce_frames <= 0 then return end
-    local enc = encounter_plan and encounter_plan[encounter_idx]
+    local enc = current_encounter
     if not (enc and enc.title) then return end
     theme.set_font("medium_aa", "bold")
     local t = enc.title
@@ -1439,7 +1559,12 @@ local function render(d)
     else
         draw_stars(d)
         for _, e in ipairs(enemies or {}) do draw_enemy(d, e) end
-        for _, b in ipairs(bullets or {}) do draw_bullet(d, b) end
+        if bullets then
+            for i = 1, #bullets do
+                local b = bullets[i]
+                if not b.dead then draw_bullet(d, b) end
+            end
+        end
         for _, it in ipairs(items   or {}) do draw_item(d, it) end
         for _, p in ipairs(players  or {}) do draw_player(d, p) end
         -- Particles draw above ships so a tight burst reads as
@@ -1576,14 +1701,24 @@ local function encode_snapshot()
         local e = enemies[i]
         out[#out + 1] = string.pack("<BHH", e.kind, floor(e.x), floor(e.y))
     end
-    -- Bullets
-    out[#out + 1] = string.char(math.min(#bullets, 40))
-    for i = 1, math.min(#bullets, 40) do
+    -- Bullets (skip pool slots marked dead).
+    local live_n = 0
+    for i = 1, #bullets do
+        if not bullets[i].dead then live_n = live_n + 1 end
+    end
+    if live_n > 40 then live_n = 40 end
+    out[#out + 1] = string.char(live_n)
+    local written = 0
+    for i = 1, #bullets do
+        if written >= live_n then break end
         local b = bullets[i]
-        local c = b.hostile and 1 or 0
-        out[#out + 1] = string.pack("<BBHH", c,
-            (b.kind == "missile") and 1 or 0,
-            floor(b.x), floor(b.y))
+        if not b.dead then
+            local c = b.hostile and 1 or 0
+            out[#out + 1] = string.pack("<BBHH", c,
+                (b.kind == "missile") and 1 or 0,
+                floor(b.x), floor(b.y))
+            written = written + 1
+        end
     end
     -- Items
     out[#out + 1] = string.char(math.min(#items, 20))


### PR DESCRIPTION
## Summary
- Reported symptom: Starshot game "feels like it's stuck every couple frames", suggesting per-frame work failing or pausing.
- Root cause: per-frame Lua allocations from particle / popup / bullet table literals were churning the allocator at ~6 KB/sec during play. Incremental GC (10 KB/2s) couldn't keep up, so Lua's auto GC fired periodic ~240 KB collections that produced visible hitches on the 30Hz tick.
- Fix: pool the three high-churn arrays + hoist hot-path literals + cache the lazy encounter lookup + cache HUD strings + swap-pop on items.

## Changes (single file: \`lua/screens/games/shooter.lua\`)
- **Pool particles (96), popups (24), bullets (96)**. \`spawn_*\` helpers find a free slot (life<=0 / dead=true) and overwrite in place; \`step_*\` and collision loops iterate numerically and skip dead slots. Pool-exhaustion silently drops the spawn -- one missed spark during a mega-burst is invisible; a frame hitch isn't.
- **Hoist hot-path literals** to module scope: \`SPREAD_ANGLES\`, \`HEAVY_BURST_ANGLES\`, \`GUN_SFX_NAMES\` were re-built every fire-frame.
- **Cache \`current_encounter\`** outside the lazy-\`__index\` metatable so the per-frame plan lookup is a direct local read.
- **Cache HUD stat strings**; rebuild only when underlying values change. Drops two \`string.format\` allocations per frame.
- **Swap-pop** for \`step_items\` and the player-vs-items collision instead of \`table.remove\`'s O(n) shift.
- **\`encode_snapshot\`** (host mode) now skips dead bullet slots and writes only the live count.

## Test plan
- [x] Builds and flashes cleanly on T-Deck Plus.
- [x] Game launches, renders correctly (HUD, ship, stars, wave banner all present).
- [ ] On-device feel: stutter should be substantially reduced. Idle baseline (main menu) is ~0.6 KB/sec heap growth; in-game now also drops sharply but still has some growth from non-game paths (audio engine, ezui rebuild). If stutter persists after this change, those are the next places to look.
- [ ] Verify game-over restart still works (HUD strings rebuild on stat-key mismatch).
- [ ] Verify host/join multiplayer if you have a second device handy: \`encode_snapshot\` now writes the live-bullet count rather than the pool size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)