### PR TITLE
fix: address review feedback from PR #63

### DIFF
--- a/changelog/versions.json
+++ b/changelog/versions.json
@@ -1000,7 +1000,7 @@
           {
             "type": "tetris",
             "scope": null,
-            "description": "address review feedback — closure capture + lines split",
+            "description": "address review feedback - closure capture + lines split",
             "commit": "bf33a58",
             "author": "Bas van den Aakster",
             "breaking": false,
@@ -1958,7 +1958,7 @@
           {
             "type": "tetris",
             "scope": null,
-            "description": "address review feedback — closure capture + lines split",
+            "description": "address review feedback - closure capture + lines split",
             "commit": "bf33a58",
             "author": "Bas van den Aakster",
             "breaking": false,

--- a/lua/docs/changelog.json
+++ b/lua/docs/changelog.json
@@ -976,7 +976,7 @@
           {
             "type": "tetris",
             "scope": null,
-            "description": "address review feedback — closure capture + lines split",
+            "description": "address review feedback - closure capture + lines split",
             "commit": "bf33a58",
             "author": "Bas van den Aakster",
             "breaking": false,
@@ -1934,7 +1934,7 @@
           {
             "type": "tetris",
             "scope": null,
-            "description": "address review feedback — closure capture + lines split",
+            "description": "address review feedback - closure capture + lines split",
             "commit": "bf33a58",
             "author": "Bas van den Aakster",
             "breaking": false,

--- a/lua/ezui/screen.lua
+++ b/lua/ezui/screen.lua
@@ -33,8 +33,11 @@ screen.status_interval = 5000  -- poll hardware every 5s
 screen.status_last = -10000    -- negative so the first update() runs the poll immediately
 
 -- Screensaver: overlay drawn on top of the current screen after idle
--- timeout to exercise subpixels. Dismissed on any keypress.
-screen.last_input_time = 0     -- millis() of last keypress
+-- timeout to exercise subpixels. Dismissed on any keypress. Seeded
+-- to the boot timestamp (rather than 0) so the activation gate fires
+-- even if the device sits idle from boot without a keypress -- which
+-- is exactly the scenario the screensaver is designed for.
+screen.last_input_time = ez.system.millis()  -- millis() of last keypress (or boot)
 
 -- Node reused every frame to render the global status bar. Keeping one
 -- instance avoids a garbage-generating allocation per frame.

--- a/lua/screens/games/pool.lua
+++ b/lua/screens/games/pool.lua
@@ -56,15 +56,21 @@ local BALL_R       = 4              -- 8 px diameter; tight but legible
 local POCKET_R     = 7              -- forgiving for the small playfield
 
 -- Six pockets at corners and rail mid-points. Coords are pocket
--- centres in screen-space, used both for drawing and for "did the ball
--- fall in" tests.
+-- centres in screen-space, used both for drawing and for "did the
+-- ball fall in" tests. The cushion-bounce code in step_physics()
+-- clamps every ball to [PLAY_X0+BALL_R .. PLAY_X1-BALL_R] before
+-- pocket_check() runs, so the pocket centres must sit on the play
+-- area boundary (not the outer rail) -- otherwise no clamped ball
+-- ever lands within POCKET_R of a pocket and the game becomes
+-- unwinnable. With pockets at PLAY_*: corner ball is ~5.7 px away
+-- and side ball is ~4 px away, both inside POCKET_R = 7.
 local POCKETS = {
-    { x = TABLE_X,             y = TABLE_Y },
-    { x = TABLE_X + TABLE_W/2, y = TABLE_Y - 1 },
-    { x = TABLE_X + TABLE_W,   y = TABLE_Y },
-    { x = TABLE_X,             y = TABLE_Y + TABLE_H },
-    { x = TABLE_X + TABLE_W/2, y = TABLE_Y + TABLE_H + 1 },
-    { x = TABLE_X + TABLE_W,   y = TABLE_Y + TABLE_H },
+    { x = PLAY_X0,             y = PLAY_Y0 },
+    { x = TABLE_X + TABLE_W/2, y = PLAY_Y0 },
+    { x = PLAY_X1,             y = PLAY_Y0 },
+    { x = PLAY_X0,             y = PLAY_Y1 },
+    { x = TABLE_X + TABLE_W/2, y = PLAY_Y1 },
+    { x = PLAY_X1,             y = PLAY_Y1 },
 }
 
 -- Ball IDs follow standard pool numbering. 0 is the cue, 1-7 solids,

--- a/lua/screens/games/shooter.lua
+++ b/lua/screens/games/shooter.lua
@@ -233,9 +233,12 @@ local boss_announce_frames -- HUD banner timer ("BOSS — XYZ"), 0 = idle
 -- gen_run, and the kill-path closures refer to spawn_particle_burst
 -- and spawn_popup. Without these forward decls the closures
 -- capture them as globals that resolve to nil at call time.
+-- spawn_enemy() (defined before wave_difficulty) calls into it for
+-- per-wave HP/speed scaling, so it needs the same treatment.
 local gen_run
 local spawn_particle_burst
 local spawn_popup
+local wave_difficulty
 -- Bullets are pool-allocated to avoid the per-shot table churn that
 -- showed up as visible GC stalls during combat. acquire_bullet()
 -- finds the next free slot (with `dead == true`) and returns it for
@@ -507,7 +510,7 @@ end
 -- Compute difficulty for a given wave index. Ramps linearly 0→1 over
 -- the first 30 waves, then continues to climb logarithmically so
 -- late-game waves stay fresh: wave 60 ≈ 1.3, wave 120 ≈ 1.6.
-local function wave_difficulty(i)
+wave_difficulty = function(i)
     if i <= DIFF_RAMP_OVER then
         return (i - 1) / DIFF_RAMP_OVER
     end

--- a/lua/screens/settings/whats_new.lua
+++ b/lua/screens/settings/whats_new.lua
@@ -6,6 +6,30 @@ local ui = require("ezui")
 
 local WhatsNew = { title = "What's New", granular_scroll = true }
 
+-- Sanitise commit-message-derived strings before they hit text_widget.
+-- The on-device fonts only cover printable ASCII (0x20..0x7E); anything
+-- else renders as a [] missing-glyph box. Commit messages routinely
+-- include em-dashes, curly quotes, ellipses, and the like, so we map
+-- the common ones to ASCII and strip the rest.
+local function ascii_safe(s)
+    if not s or s == "" then return s end
+    -- Common typographic substitutions first (applied to the raw UTF-8
+    -- byte sequences so we don't have to decode codepoints).
+    s = s:gsub("\xE2\x80\x94", "--")  -- em-dash
+    s = s:gsub("\xE2\x80\x93", "-")   -- en-dash
+    s = s:gsub("\xE2\x80\xA6", "...") -- ellipsis
+    s = s:gsub("\xE2\x80\x98", "'")   -- left single quote
+    s = s:gsub("\xE2\x80\x99", "'")   -- right single quote
+    s = s:gsub("\xE2\x80\x9C", '"')   -- left double quote
+    s = s:gsub("\xE2\x80\x9D", '"')   -- right double quote
+    s = s:gsub("\xE2\x80\xA2", "*")   -- bullet
+    s = s:gsub("\xC2\xB7", "*")       -- middle dot
+    -- Strip any remaining bytes outside printable ASCII (covers leftover
+    -- multi-byte sequences from non-Latin scripts, control chars, etc.).
+    s = s:gsub("[^\x20-\x7E\t\n]", "")
+    return s
+end
+
 -- Parse the versions.json content. Returns a list of version entries
 -- sorted newest-first, or nil on error.
 local function parse_versions(json_str)
@@ -64,7 +88,7 @@ function WhatsNew.build_version_list(versions, current_sha)
                         font = "small_aa", color = "TEXT_SEC",
                     }))
                 for _, entry in ipairs(group) do
-                    local desc = entry.description or "?"
+                    local desc = ascii_safe(entry.description) or "?"
                     if entry.scope and entry.scope ~= "" then
                         desc = entry.scope .. ": " .. desc
                     end

--- a/lua/services/migrations.lua
+++ b/lua/services/migrations.lua
@@ -9,15 +9,34 @@
 --   2. Set `version` to the version that introduces the change.
 --   3. Write a `run()` function that performs the data/prefs migration.
 --
--- Version comparison is lexicographic (works for semver and
--- commit-count versions like "0.0.71"). Migrations whose version is
--- <= the last-migrated version are skipped.
+-- Version comparison is numeric per dotted segment (so "0.0.10" sorts
+-- after "0.0.9", and "0.10.0" after "0.2.0"). Migrations whose version
+-- is <= the last-migrated version are skipped.
 
 local migrations = {}
 
 -- Pref key that stores the last version migrations ran for.
 -- 15 chars max for NVS.
 local PREF_KEY = "migrated_ver"
+
+-- Compare two dotted version strings numerically. Returns true iff
+-- a < b. Missing trailing segments are treated as 0, so "0.1" < "0.1.0"
+-- is false (they compare equal). Lex comparison would silently break
+-- at any digit-boundary rollover (e.g. "0.0.100" < "0.0.71"); this
+-- one stays correct for the project's "0.0.<N>" commit-count tags.
+local function version_lt(a, b)
+    local function parts(v)
+        local t = {}
+        for n in v:gmatch("%d+") do t[#t + 1] = tonumber(n) end
+        return t
+    end
+    local pa, pb = parts(a), parts(b)
+    for i = 1, math.max(#pa, #pb) do
+        local ai, bi = pa[i] or 0, pb[i] or 0
+        if ai ~= bi then return ai < bi end
+    end
+    return false
+end
 
 -- Ordered list of migrations. Each entry:
 --   { version = "x.y.z", description = "...", run = function() ... end }
@@ -50,7 +69,7 @@ function migrations.run()
 
     for _, m in ipairs(MIGRATIONS) do
         -- Skip migrations already applied (version <= last migrated)
-        if last ~= "" and m.version <= last then
+        if last ~= "" and not version_lt(last, m.version) then
             -- already applied
         else
             ez.log("[Migrations] Running " .. m.version .. ": " .. (m.description or ""))

--- a/src/lua/bindings/ota_bindings.cpp
+++ b/src/lua/bindings/ota_bindings.cpp
@@ -1297,6 +1297,14 @@ void pullFullTask(void* arg) {
     auto active = [](uint32_t s) { return s == 0xFFFFFFFF ? 0u : s; };
     uint32_t max_seq = std::max(active(seq0), active(seq1));
     uint32_t new_seq = max_seq + 1;
+    // The IDF bootloader picks the boot app via `(ota_seq - 1) % ota_app_count`
+    // -- not by which physical otadata sector holds the entry. On a freshly
+    // flashed device both sectors are blank (0xFFFFFFFF -> treated as 0),
+    // so `new_seq = 1` always selects app0; if the OTA target was app1,
+    // the post-write `esp_ota_get_boot_partition` check below trips with
+    // "boot partition did not switch". Nudge the sequence by one so its
+    // parity matches the target slot before writing.
+    if (((new_seq - 1) % 2u) != (uint32_t)slot) new_seq += 1;
 
     uint8_t entry[32];
     memset(entry, 0xFF, sizeof(entry));


### PR DESCRIPTION
Addresses the open review comments on #63 (test -> main).

## Fixes
- **shooter** — forward-declare `wave_difficulty` so `spawn_enemy` finds it (would crash on first enemy spawn with nil-call).
- **pool** — move pocket centres inside the cushion so balls can actually be pocketed (clamped balls were 11–14 px from any pocket, well outside `POCKET_R = 7`).
- **migrations** — replace lexicographic version comparison with numeric per-segment compare (`"0.0.100" <= "0.0.71"` was true, would silently skip migrations past a digit rollover).
- **ota** — nudge `ota_seq` parity to match the target slot before writing otadata, so the first OTA on a blank-otadata device activates the right partition instead of failing the post-write boot-partition check.
- **screensaver** — seed `screen.last_input_time` to `ez.system.millis()` at boot so the activation gate fires for an idle-from-boot device (previously stayed `0`, gate never passed).
- **whats_new** — sanitise commit-message-derived strings to printable ASCII before rendering. Em-dashes, curly quotes, ellipses etc. were rendering as `[]` boxes per CLAUDE.md's font character-set note. Source em-dashes in `changelog/versions.json` and the embedded `lua/docs/changelog.json` are also fixed; the sanitiser is the durable defence against regeneration.

## Test plan
- [x] `pio run` clean
- [x] `pio run -t upload` flashed; device boots normally
- [x] Shooter loads and reaches Wave 4 with enemies on screen (would have crashed on first spawn before)
- [x] Pool menu loads; pocket math verified by hand: corner ball (30,32) <-> pocket (26,28) -> distance² = 32 ≤ 49 = POCKET_R²
- [x] What's New screen renders without errors
- [x] `screen.last_input_time` non-zero post-boot before any keypress (verified via Lua)

🤖 Generated with [Claude Code](https://claude.com/claude-code)