### PR TITLE
fix: address PR #63 round-2 review feedback

### DIFF
--- a/.github/workflows/main-artifacts.yml
+++ b/.github/workflows/main-artifacts.yml
@@ -17,7 +17,6 @@ on:
 
 permissions:
   contents: write
-  actions: write
 
 jobs:
   build:
@@ -247,6 +246,13 @@ jobs:
   prune:
     needs: build
     runs-on: ubuntu-latest
+    # actions: write lives only on this job (the one that calls
+    # deleteArtifact) so a supply-chain compromise during the build
+    # job's npm/pip installs can't silently delete other workflow
+    # artifacts. contents: write is inherited from the workflow
+    # level but isn't used here.
+    permissions:
+      actions: write
     steps:
       - name: Keep only the 3 most recent main builds
         uses: actions/github-script@v7

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -17,7 +17,6 @@ on:
 
 permissions:
   contents: write
-  actions: write
 
 jobs:
   build:
@@ -234,6 +233,13 @@ jobs:
   prune:
     needs: build
     runs-on: ubuntu-latest
+    # actions: write lives only on this job (the one that calls
+    # deleteArtifact) so a supply-chain compromise during the build
+    # job's npm/pip installs can't silently delete other workflow
+    # artifacts. contents: write is inherited from the workflow
+    # level but isn't used here.
+    permissions:
+      actions: write
     steps:
       - name: Keep only the 3 most recent test builds
         uses: actions/github-script@v7

--- a/lua/screens/chat/channel_chat.lua
+++ b/lua/screens/chat/channel_chat.lua
@@ -123,7 +123,13 @@ local function show_context_menu(self, channel, msg)
     end
 
     function MenuDef:handle_key(k)
-        if k.character == "q" or k.special == "ESCAPE" then
+        -- BACKSPACE is the on-device back-arrow; ESCAPE is the
+        -- remote-tool synonym. Without BACKSPACE the user has no way
+        -- to dismiss this menu on the T-Deck (no Esc key exists).
+        if k.character == "q"
+            or k.special == "ESCAPE"
+            or k.special == "BACKSPACE"
+        then
             return "pop"
         end
         return nil

--- a/lua/screens/settings/firmware_update.lua
+++ b/lua/screens/settings/firmware_update.lua
@@ -163,6 +163,23 @@ local function fetch_manifest(self, tag)
             return
         end
 
+        -- Cross-check the signed channel tag against the channel the
+        -- user picked. Without this, a network-position attacker can
+        -- swap a rolling-test manifest in for a rolling-main request:
+        -- both are signed by the same key, signature verification
+        -- passes, and the device silently installs the wrong build.
+        -- The tag field is part of the signed payload, so checking
+        -- here adds no new trust assumption.
+        if manifest.tag ~= tag then
+            this:set_state({
+                loading = false,
+                error   = "Manifest channel mismatch (got '"
+                          .. tostring(manifest.tag) .. "', expected '"
+                          .. tag .. "') -- update refused.",
+            })
+            return
+        end
+
         this:set_state({
             loading  = false,
             verified = true,


### PR DESCRIPTION
Follow-up to #69 — addresses the remaining open comments on PR #63.

## Fixes
- **chat (channel context menu)** — accept `BACKSPACE` in addition to `ESCAPE` and `q`. The T-Deck has no Esc key; the back-arrow sends BACKSPACE, so on-device users had no way out of the menu (pre-fix only the remote tool could dismiss it).
- **ota (security)** — verify `manifest.tag` matches the requested channel after JSON parse. Both rolling-main and rolling-test manifests are signed by the same key; without this check a network-position attacker could swap a test-channel manifest in for a main-channel fetch and the device would silently install the wrong build.
- **workflows (supply-chain hardening)** — move `actions: write` from workflow-level (inherited by the build job that runs `npm ci` / `pip install` / `npx xtr-changelog`) down to the `prune` job that actually calls `deleteArtifact`. Applied to both `test-artifacts.yml` and `main-artifacts.yml`.

## Out-of-scope follow-ups
A repo-wide audit shows ~20 other screens with the same `ESCAPE`-only handler pattern (e.g. `screens/games/wasteland.lua`, `screens/games/sudoku.lua`, `screens/tools/file_manager.lua`, several `ezui/widgets.lua` overlays). This PR fixes only the one the reviewer flagged; a sweep across the rest is best done as a focused follow-up so the diff stays reviewable.

## Test plan
- [x] `pio run` clean
- [x] `pio run -t upload` flashed; device boots normally (uptime check passes post-flash)
- [x] Workflow YAMLs validate (`yaml.safe_load`)
- [x] `lua/screens/chat/channel_chat.lua` syntax-checks (`luac32 -p`)
- [x] `lua/screens/settings/firmware_update.lua` syntax-checks
- [x] CI emits `tag: 'rolling-main'` / `tag: 'rolling-test'` in the signed manifest (verified in workflow source) so the new check has a value to compare against

🤖 Generated with [Claude Code](https://claude.com/claude-code)