### PR TITLE
fix(screensaver): dismiss-and-consume on touch, like keyboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,48 @@ require("module.name")      -- Standard Lua require (loads embedded scripts firs
 spawn(fn)                   -- Run function in coroutine
 ```
 
+### Touch input and the screensaver wake gate
+
+`lua/ezui/touch_input.lua` is the global touch-to-widget bridge. It
+subscribes once at boot to `touch/down` / `touch/move` / `touch/up`
+and turns single-finger taps into focus-chain activations on the
+widget under the finger. Most screens get touch for free.
+
+Two developer-facing APIs participate in the screensaver wake-event
+flow and must be used by anyone writing new touch code:
+
+- **`screen.notify_input()`** (`lua/ezui/screen.lua`) -- bumps
+  `last_input_time` and, if the screensaver overlay is currently
+  drawn, dismisses it. Returns `true` when the screensaver was just
+  dismissed so the caller can swallow the originating event. The
+  keyboard read loop calls this; you usually don't, but it's the
+  single chokepoint if you ever need to synthesise a wake.
+
+- **`touch_input.is_wake_event()`** -- predicate that returns true
+  for ~250 ms after a touch dismissed the screensaver. The bridge
+  sets the timestamp from inside its own `screensaver_swallow()`
+  guard. Call this **at the top of every `touch/*` bus subscriber a
+  screen registers**:
+
+  ```lua
+  ez.bus.subscribe("touch/down", function(_, data)
+      if require("ezui.touch_input").is_wake_event() then return end
+      -- ... real handler
+  end)
+  ```
+
+  Without this guard, a tap that wakes the device from the
+  screensaver also fires the screen's handler -- a wake-tap on the
+  desktop would launch an icon, a wake-tap in Paint would seed a
+  stroke, etc. The bus broadcasts to every subscriber, so the
+  bridge can't suppress them on its own; each direct subscriber
+  has to opt in.
+
+  `touch/tap` and `touch/long_press` subscribers (games, custom
+  views) are **not** affected -- those are synthesised inside the
+  bridge's own `on_up`, which already returns early on a wake
+  event, so they're covered transitively.
+
 ### Settings
 
 Settings are stored via `ez.storage.set_pref(key, value)` and restored in

--- a/lua/ezui/screen.lua
+++ b/lua/ezui/screen.lua
@@ -437,18 +437,29 @@ end
 screen.last_pop_time = 0
 screen.pop_cooldown_ms = 500
 
-function screen.handle_input()
-    local key = ez.keyboard.read()
-    if not key or not key.valid then return false end
-
-    -- Reset idle timer on any input
+-- Reset the idle timer and, if the screensaver is currently up,
+-- dismiss it. Returns true when the screensaver was just dismissed
+-- so the caller can swallow the originating event (key or touch) --
+-- a tap that wakes the device should not also activate whatever sat
+-- under the overlay. Called from the keyboard path here and from
+-- ezui/touch_input.lua's on_down/move/up.
+function screen.notify_input()
     screen.last_input_time = ez.system.millis()
-
-    -- Dismiss screensaver overlay on any key (consume the key)
     local ss_ok, ss = pcall(require, "screens.tools.screensaver")
     if ss_ok and ss.is_active() then
         ss.stop()
         screen.dirty = true
+        return true
+    end
+    return false
+end
+
+function screen.handle_input()
+    local key = ez.keyboard.read()
+    if not key or not key.valid then return false end
+
+    -- Reset idle timer + dismiss-and-consume any active screensaver.
+    if screen.notify_input() then
         return true  -- consume the key that woke the screen
     end
 

--- a/lua/ezui/touch_input.lua
+++ b/lua/ezui/touch_input.lua
@@ -177,8 +177,46 @@ local function fire_tap_event(sx, sy, duration_ms)
     ez.bus.post(topic, { x = sx, y = sy, duration_ms = duration_ms })
 end
 
+-- Reset the idle timer + check the screensaver gate. Returns true
+-- when the gesture should be swallowed (screensaver was active and
+-- has just been dismissed -- the touch only served to wake the
+-- device, it must not also activate whatever sat under the overlay).
+--
+-- Also stamps M._wake_until_ms forward so per-screen touch
+-- subscribers (e.g. menu.lua's tab-strip drag, game tap-to-play
+-- handlers) can call M.is_wake_event() and skip the activation
+-- branch -- the bus broadcasts to every subscriber, so the bridge
+-- can't suppress them on its own.
+local _WAKE_GUARD_MS = 250
+local function screensaver_swallow()
+    local ok, screen = pcall(require, "ezui.screen")
+    if not ok or not screen.notify_input then return false end
+    if screen.notify_input() then
+        M._wake_until_ms = ez.system.millis() + _WAKE_GUARD_MS
+        return true
+    end
+    return false
+end
+
+M._wake_until_ms = 0
+
+-- Did a recent touch event just wake the device from the
+-- screensaver? Per-screen `touch/*` subscribers should check this
+-- and bail before treating the event as a real interaction.
+function M.is_wake_event()
+    return ez.system.millis() < M._wake_until_ms
+end
+
 local function on_down(_topic, data)
     if type(data) ~= "table" or not data.x or not data.y then return end
+
+    if screensaver_swallow() then
+        -- Drop any in-flight gesture so the matching touch/up
+        -- doesn't fire an activation when the screen wakes.
+        _pending = nil
+        _mouse_pending = nil
+        return
+    end
 
     if M.mouse_mode then
         -- Capture the start of the drag and the cursor position
@@ -237,6 +275,16 @@ local function on_down(_topic, data)
 end
 
 local function on_move(_topic, data)
+    -- Keep the idle timer warm during long drags (paint, slider scrub,
+    -- map pan) so the screensaver doesn't pop while the user is
+    -- actively interacting. Also catches the rare case where on_down
+    -- was missed but on_move arrives with the screensaver still up.
+    if screensaver_swallow() then
+        _pending = nil
+        _mouse_pending = nil
+        return
+    end
+
     if M.mouse_mode then
         if not _mouse_pending or type(data) ~= "table" then return end
         local dx = data.x - _mouse_pending.start_x
@@ -311,6 +359,12 @@ local function on_move(_topic, data)
 end
 
 local function on_up(_topic, data)
+    if screensaver_swallow() then
+        _pending = nil
+        _mouse_pending = nil
+        return
+    end
+
     if M.mouse_mode then
         local p = _mouse_pending
         _mouse_pending = nil

--- a/lua/screens/apps/editor.lua
+++ b/lua/screens/apps/editor.lua
@@ -554,6 +554,7 @@ function Editor:on_enter()
         table.insert(self._touch_subs,
             ez.bus.subscribe("touch/down", function(_, data)
                 if type(data) ~= "table" then return end
+                if require("ezui.touch_input").is_wake_event() then return end
                 local n = me._editor_node
                 if not n then return end
                 local row, col = touch_to_cursor(n, data.x, data.y)

--- a/lua/screens/apps/paint.lua
+++ b/lua/screens/apps/paint.lua
@@ -1127,16 +1127,27 @@ function Paint:_install_touch_handlers()
         end
     end
 
+    -- Wake-event guard on all three: a tap that just dismissed the
+    -- screensaver shouldn't seed a stroke, hit a header button, or
+    -- fire end_stroke (which would commit a phantom one-pixel stroke
+    -- to the undo stack).
     table.insert(self._touch_subs, ez.bus.subscribe("touch/down",
         function(_, data)
+            if require("ezui.touch_input").is_wake_event() then return end
             end_stroke()
             header_touch(data)
             paint_touch(data, true)
         end))
     table.insert(self._touch_subs, ez.bus.subscribe("touch/move",
-        function(_, data) paint_touch(data, false) end))
+        function(_, data)
+            if require("ezui.touch_input").is_wake_event() then return end
+            paint_touch(data, false)
+        end))
     table.insert(self._touch_subs, ez.bus.subscribe("touch/up",
-        function(_, _) end_stroke() end))
+        function(_, _)
+            if require("ezui.touch_input").is_wake_event() then return end
+            end_stroke()
+        end))
 end
 
 -- ---------------------------------------------------------------------------

--- a/lua/screens/chat/contacts.lua
+++ b/lua/screens/chat/contacts.lua
@@ -236,6 +236,7 @@ function Contacts:on_enter()
     -- there; we hit-test against the persisted node's drawn rect.
     self._sub_touch = ez.bus.subscribe("touch/down", function(_, data)
         if type(data) ~= "table" then return end
+        if require("ezui.touch_input").is_wake_event() then return end
         local n = self._tab_bar_node
         if not n or not n._x then return end
         if data.y < n._y or data.y >= n._y + (n._ah or 0) then return end

--- a/lua/screens/chat/messages.lua
+++ b/lua/screens/chat/messages.lua
@@ -298,6 +298,7 @@ function Messages:on_enter()
     -- half of the bar's width contains the touch x".
     self._sub_touch = ez.bus.subscribe("touch/down", function(_, data)
         if type(data) ~= "table" then return end
+        if require("ezui.touch_input").is_wake_event() then return end
         local n = self._tab_bar_node
         if not n or not n._x then return end
         if data.y < n._y or data.y >= n._y + (n._ah or 0) then return end

--- a/lua/screens/menu.lua
+++ b/lua/screens/menu.lua
@@ -534,6 +534,13 @@ function Menu:on_enter()
         table.insert(self._touch_subs, ez.bus.subscribe("touch/down",
             function(_, data)
                 if type(data) ~= "table" then return end
+                -- A touch that just woke the screensaver shouldn't
+                -- also start a tab-strip drag. The bridge has already
+                -- bumped the idle timer; we just bail.
+                if touch_input.is_wake_event() then
+                    pending = nil
+                    return
+                end
                 local strip = me._tab_strip_node
                 if not in_strip_hit(strip, data.x, data.y) then
                     pending = nil

--- a/lua/screens/tools/logs.lua
+++ b/lua/screens/tools/logs.lua
@@ -198,6 +198,7 @@ function Logs:on_enter()
     table.insert(self._touch_subs, ez.bus.subscribe("touch/down",
         function(_, d)
             if type(d) ~= "table" then return end
+            if require("ezui.touch_input").is_wake_event() then return end
             local v = me._view
             if not v._x then return end  -- not laid out yet
             -- Reject touches that started in the title bar so back-


### PR DESCRIPTION
## Summary

Closes #73.

Touch was bypassing the screensaver: a tap meant to wake the device flowed straight through to the underlying screen (e.g. dock icon → app launch) while the overlay was still drawn. Touch also didn't bump the idle timer, so the screensaver could pop mid-interaction.

- New `screen.notify_input()` is a single choke point that bumps `last_input_time` and, if the screensaver is active, dismisses it and returns true so the caller can swallow the event. Keyboard path now goes through it (no behaviour change).
- `ezui/touch_input.lua`'s `on_down` / `on_move` / `on_up` call it first; on a wake event they drop the in-flight gesture and return without firing focus-chain activation.
- Per-screen `touch/*` subscribers can't be suppressed by the bridge (bus broadcasts), so expose `touch_input.is_wake_event()` as a 250 ms guard. The only nav-triggering direct subscriber today (menu.lua's tab strip) consults it. Solitaire and minesweeper subscribe to the synthesised `touch/tap` -- fired from the bridge's own `on_up`, which already bails on wake -- so they're covered transitively.

## Test plan

- [x] Build + flash (`pio run -t upload`)
- [x] With `ss_timeout=5`, force screensaver active on Desktop, post `touch/down` over a dock icon → screensaver dismisses, depth stays at 1, no app launched.
- [x] Repeat: `_wake_until_ms` advances on each wake; `is_wake_event()` returns true within the 250 ms guard window and false after it expires.
- [ ] Real-finger sanity: tap to wake the screensaver from Desktop, confirm no app launches.
- [ ] Long drag (paint canvas / map pan): confirm screensaver no longer pops mid-drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)