### PR TITLE
feat(notifications): wire DM/file/battery/SD/panic events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,10 @@ Services are initialized in order in `lua/boot.lua`:
 6. **custom_packets** — Custom (non-MeshCore) packet handlers
 7. **file_transfer** — Mesh-based file send/receive
 8. **ui_sounds** — UI sound effects via the audio engine
-9. **notifications** — Bus subscriber for OTA / system notifications
+9. **notifications** — Toast queue + bus subscribers for OTA, DMs,
+   file transfer, low battery, SD connect/disconnect, and panic /
+   brownout recovery. See "Notifications service" below for the
+   public API and per-source mute pref namespace.
 10. **apps** — Registered file-type → screen handlers (used by the file manager)
 11. **gps** — `gps_svc.start_sync_loop()` is always called; the loop itself
     respects the user's "never / at boot / hourly" pref and is a no-op when
@@ -309,6 +312,36 @@ After services start, `migrations.run()` runs version migrations and an
 `ntp` sync is kicked. Other modules under `lua/services/` (e.g.
 `map_archive`, `prefs_registry`, `signal_test`) are loaded on demand by
 the screens that need them.
+
+### Notifications service
+
+`services/notifications` is an in-memory toast queue. The bus topic
+`notifications/changed` fires on every change; `ezui/screen.lua`
+subscribes once and renders the most recent entry as a toast.
+
+Public API:
+
+- `notifications.post(opts)` — `{ title, body?, source?, sticky?,
+  action? = { label, on_press }, read? }`. Returns the new id, or
+  nil if suppressed (muted source, missing title). `title` and
+  `body` are sanitized to printable ASCII before being stored — the
+  on-device fonts can't render anything else (see "On-device font
+  character set" above), and titles/bodies often come from
+  peer-originated mesh data.
+- `notifications.post_unless_focused(opts, predicate)` — posts only
+  when `predicate(top_screen_inst)` returns false. Use for events
+  that lead to a screen the user might already be looking at (the
+  DM message → DM conversation flow is the canonical example).
+- `notifications.dismiss(id)` / `notifications.dismiss_source(s)` /
+  `notifications.list()` / `notifications.unread_count()` /
+  `notifications.mark_all_read()`.
+
+Per-source mute pref: every `post()` consults `notify_<source>` in
+NVS (default `"1"` = on). Setting `notify_dm = "0"`, for instance,
+silences every DM toast without touching the wiring. The namespace
+is meant for a future Settings panel; pref keys must stay under
+NVS's 15-character limit, so source tags should be short
+(`dm`, `file`, `battery`, `sd`, `ota`, `channel`, `system`).
 
 ### Module Loading
 

--- a/lua/boot.lua
+++ b/lua/boot.lua
@@ -208,12 +208,14 @@ local function boot_sequence()
     local ui_sounds = require("services.ui_sounds")
     ui_sounds.init()
 
-    -- Notifications service + OTA hookup. The service is just an
+    -- Notifications service + integrations. The service is just an
     -- in-memory queue; the toast overlay in ezui.screen subscribes to
     -- "notifications/changed" and shows the latest one for a few
-    -- seconds. Hooking ota/progress here means a successful OTA push
-    -- announces itself wherever the user happens to be.
+    -- seconds. Hooking events here means they announce themselves
+    -- wherever the user happens to be.
     local notifications = require("services.notifications")
+
+    -- ---- OTA ----
     ez.bus.subscribe("ota/progress", function(_topic, data)
         if type(data) ~= "table" then return end
         if data.phase == "end" and not data.error then
@@ -236,6 +238,172 @@ local function boot_sequence()
             })
         end
     end)
+
+    -- ---- Direct messages ----
+    -- Skip the toast when the user is already in the conversation
+    -- with that contact -- the screen itself shows the new bubble.
+    ez.bus.subscribe("dm/message", function(_topic, msg)
+        if type(msg) ~= "table" or msg.is_self then return end
+        local key  = msg.sender_key
+        local name = msg.sender_name or "Unknown"
+        local body = msg.text and msg.text:sub(1, 80) or nil
+        notifications.post_unless_focused({
+            title  = name,
+            body   = body,
+            source = "dm",
+            action = {
+                label    = "Open",
+                on_press = function()
+                    local screen   = require("ezui.screen")
+                    local DMConv   = require("screens.chat.dm_conversation")
+                    screen.push(screen.create(DMConv, { contact_key = key }))
+                end,
+            },
+        }, function(inst)
+            -- Suppress when the active screen is the DM conversation
+            -- with this very contact.
+            return inst._state and inst._state.contact_key == key
+        end)
+    end)
+    ez.bus.subscribe("dm/status", function(_topic, data)
+        if type(data) ~= "table" then return end
+        if data.status ~= "unconfirmed" then return end
+        notifications.post({
+            title  = "DM not delivered",
+            body   = "No ACK received -- recipient may be offline.",
+            source = "dm",
+        })
+    end)
+
+    -- ---- File transfer ----
+    local function open_transfer_screen()
+        local screen = require("ezui.screen")
+        local FT     = require("screens.tools.file_transfer")
+        screen.push(screen.create(FT, {}))
+    end
+    ez.bus.subscribe("file/offer", function(_topic, data)
+        if type(data) ~= "table" then return end
+        local who = data.sender_name or (data.sender_pub
+                       and data.sender_pub:sub(1, 8)) or "someone"
+        notifications.post({
+            title  = "File offered",
+            body   = string.format("%s -- %s", data.name or "?", who),
+            source = "file",
+            action = { label = "Open", on_press = open_transfer_screen },
+        })
+    end)
+    ez.bus.subscribe("file/done", function(_topic, data)
+        -- Only RX completions are user-facing -- the sender already
+        -- saw their progress bar fill.
+        if type(data) ~= "table" or data.role ~= "rx" then return end
+        local name = data.path and data.path:match("([^/]+)$") or "file"
+        notifications.post({
+            title  = "Received " .. name,
+            body   = data.bytes and (data.bytes .. " bytes") or nil,
+            source = "file",
+            action = { label = "Open", on_press = open_transfer_screen },
+        })
+    end)
+    ez.bus.subscribe("file/error", function(_topic, data)
+        if type(data) ~= "table" or data.role ~= "rx" then return end
+        notifications.post({
+            title  = "File transfer failed",
+            body   = data.error or data.reason,
+            source = "file",
+        })
+    end)
+
+    -- ---- Battery + SD polling ----
+    -- One periodic timer covers both: cheap polls (one ADC + one
+    -- bool), and there's no driver-side bus event for either today.
+    -- 30 s is fast enough that an SD swap or a steep battery drop
+    -- surfaces well before the user notices a missing map tile.
+    local battery_state = { last_threshold = nil }   -- last crossed threshold int
+    local sd_state      = { present = nil }          -- nil until the first poll
+    local function check_battery()
+        if not (ez.system and ez.system.get_battery_percent) then return end
+        local pct = ez.system.get_battery_percent()
+        if not pct or pct < 0 then return end
+        local charging = ez.system.is_charging and ez.system.is_charging() or false
+        -- Climbing back up (or plugged in) clears the latch so a
+        -- subsequent dip will warn again.
+        if charging or pct > 25 then
+            battery_state.last_threshold = nil
+            return
+        end
+        local thresholds = { 5, 10, 20 }   -- check most-severe first
+        for _, t in ipairs(thresholds) do
+            if pct <= t and battery_state.last_threshold ~= t then
+                battery_state.last_threshold = t
+                notifications.dismiss_source("battery")
+                notifications.post({
+                    title  = "Battery low",
+                    body   = string.format("%d%% remaining", pct),
+                    source = "battery",
+                    sticky = (t <= 5),
+                })
+                return
+            end
+        end
+    end
+    local function check_sd()
+        if not (ez.storage and ez.storage.is_sd_available) then return end
+        local now = ez.storage.is_sd_available()
+        if sd_state.present == nil then
+            sd_state.present = now
+            return                          -- seed only; no notification
+        end
+        if now == sd_state.present then return end
+        sd_state.present = now
+        if now then
+            notifications.post({
+                title  = "SD card connected",
+                source = "sd",
+            })
+        else
+            notifications.post({
+                title  = "SD card removed",
+                body   = "Maps and large transfers will be unavailable.",
+                source = "sd",
+            })
+        end
+    end
+    local POLL_MS = 30000
+    local function poll_tick()
+        check_battery()
+        check_sd()
+        ez.system.set_timer(POLL_MS, poll_tick)
+    end
+    -- First poll at +5 s so the value isn't read mid-init while the
+    -- ADC is still settling, then every POLL_MS thereafter.
+    ez.system.set_timer(5000, poll_tick)
+
+    -- ---- Reset reason ----
+    -- Surface a panic / brownout from the previous boot once. The
+    -- log_persist init wrote the reset reason to flash; here we just
+    -- raise a sticky toast that takes the user to the on-device log
+    -- so they can see what happened. Action loads the screen lazily
+    -- to avoid pulling it into memory at boot.
+    if ez.system.get_reset_reason then
+        local reason = ez.system.get_reset_reason()
+        if reason == "panic" or reason == "brownout" then
+            notifications.post({
+                title  = (reason == "panic") and "Recovered from crash"
+                                              or "Recovered from brownout",
+                body   = "Tap to view the log.",
+                source = "system",
+                sticky = true,
+                action = {
+                    label    = "Logs",
+                    on_press = function()
+                        local screen = require("ezui.screen")
+                        local Logs   = require("screens.tools.logs")
+                        screen.push(screen.create(Logs, {}))
+                    end,
+                },
+            })
+        end
+    end
 
     -- Apps registry: file-type → handler for the file manager. Built-in
     -- handlers register themselves here; screens opened from the registry

--- a/lua/boot.lua
+++ b/lua/boot.lua
@@ -331,17 +331,28 @@ local function boot_sequence()
             battery_state.last_threshold = nil
             return
         end
-        local thresholds = { 5, 10, 20 }   -- check most-severe first
+        -- Check most-severe (lowest %) first. A new toast only
+        -- fires when crossing into a *more-severe* threshold than
+        -- the one currently latched -- ratcheting downward, never
+        -- back up. Without that gate, partial recovery from 4% to
+        -- 7% (still below 25, still discharging) would replace the
+        -- sticky 5% warning with a non-sticky 10% one. Iteration
+        -- always stops at the first matching threshold so we
+        -- don't fall through to a less-severe row.
+        local thresholds = { 5, 10, 20 }
         for _, t in ipairs(thresholds) do
-            if pct <= t and battery_state.last_threshold ~= t then
-                battery_state.last_threshold = t
-                notifications.dismiss_source("battery")
-                notifications.post({
-                    title  = "Battery low",
-                    body   = string.format("%d%% remaining", pct),
-                    source = "battery",
-                    sticky = (t <= 5),
-                })
+            if pct <= t then
+                local last = battery_state.last_threshold
+                if last == nil or last > t then
+                    battery_state.last_threshold = t
+                    notifications.dismiss_source("battery")
+                    notifications.post({
+                        title  = "Battery low",
+                        body   = string.format("%d%% remaining", pct),
+                        source = "battery",
+                        sticky = (t <= 5),
+                    })
+                end
                 return
             end
         end

--- a/lua/services/notifications.lua
+++ b/lua/services/notifications.lua
@@ -41,6 +41,18 @@ local function source_muted(source)
     return v == "0" or v == 0 or v == false
 end
 
+-- The on-device bitmap fonts only cover printable ASCII 0x20..0x7E
+-- (see CLAUDE.md "On-device font character set"); anything else
+-- renders as `[]` boxes. Notification title/body strings often come
+-- from peer-originated mesh data (contact names, DM bodies, file
+-- names) where there's no upstream guarantee on character set, so
+-- sanitize centrally here rather than asking every call site to
+-- remember.
+local function ascii_safe(s)
+    if type(s) ~= "string" then return s end
+    return (s:gsub("[^\32-\126]", "?"))
+end
+
 function notifications.post(opts)
     opts = opts or {}
     if not opts.title or opts.title == "" then return nil end
@@ -48,8 +60,8 @@ function notifications.post(opts)
 
     local n = {
         id        = _next_id,
-        title     = opts.title,
-        body      = opts.body,
+        title     = ascii_safe(opts.title),
+        body      = ascii_safe(opts.body),
         source    = opts.source or "system",
         sticky    = opts.sticky and true or false,
         action    = opts.action,

--- a/lua/services/notifications.lua
+++ b/lua/services/notifications.lua
@@ -30,9 +30,21 @@ end
 --   action  table   { label, on_press } -- shown in the center
 --   read    bool    initial read state (default false)
 -- Returns the new notification's id.
+-- Per-source mute: read `notify_<source>` (default "1" = on). Setting
+-- the pref to "0" silences every post with that source tag without
+-- needing to touch the calling site. Lets a Settings panel offer a
+-- "Mute battery / DMs / file transfers" toggle later without churn.
+local function source_muted(source)
+    if not source or source == "" then return false end
+    if not (ez and ez.storage and ez.storage.get_pref) then return false end
+    local v = ez.storage.get_pref("notify_" .. source, "1")
+    return v == "0" or v == 0 or v == false
+end
+
 function notifications.post(opts)
     opts = opts or {}
     if not opts.title or opts.title == "" then return nil end
+    if source_muted(opts.source) then return nil end
 
     local n = {
         id        = _next_id,
@@ -49,6 +61,32 @@ function notifications.post(opts)
     while #_items > _max_items do table.remove(_items) end
     emit_changed()
     return n.id
+end
+
+-- Variant of post() that suppresses the notification when the user is
+-- already looking at the screen the notification would lead them to.
+-- Useful for e.g. DM message notifications: if the user is sitting in
+-- the conversation with that contact, a toast would be redundant
+-- (and the screen itself already shows the new message).
+--
+-- `predicate` receives the current top screen instance and should
+-- return true to suppress the post. When the screen stack is empty,
+-- or no instance is on top yet, the post goes through unconditionally
+-- so we never lose a notification during boot.
+--
+-- Returns the new notification id, or nil when suppressed.
+function notifications.post_unless_focused(opts, predicate)
+    if type(predicate) == "function" then
+        local ok, screen = pcall(require, "ezui.screen")
+        if ok and screen.peek then
+            local inst = screen.peek()
+            if inst then
+                local pred_ok, suppress = pcall(predicate, inst)
+                if pred_ok and suppress then return nil end
+            end
+        end
+    end
+    return notifications.post(opts)
 end
 
 function notifications.dismiss(id)


### PR DESCRIPTION
## Summary

Closes #71.

The notifications service has been a one-customer queue (just OTA). The plumbing -- queue, toast overlay, source-based dedupe, sticky/action support -- is general-purpose, so this wires the first slice from the issue: DMs + file transfer + low battery + SD connect/disconnect, plus panic/brownout recovery.

`services/notifications` gains:
- `post_unless_focused(opts, predicate)` -- suppresses the post when the active screen would make the toast redundant.
- A per-source mute pref (`notify_<source>`, default on) read inside `post()`, so a future Settings panel can silence a category without touching the wiring.

`boot.lua` wires:
- `dm/message` -- "Sender -- text" + Open action that pushes the conversation. Suppressed when the user is already in that contact's DM screen (predicate matches `contact_key`).
- `dm/status` with `status=unconfirmed` -- delivery failure after retries.
- `file/offer` / `file/done` (rx) / `file/error` (rx) -- announce inbound transfers; action opens the transfer screen.
- Battery -- 30 s poll, 20 / 10 / 5 % thresholds, latched so successive polls don't spam, `dismiss_source` replaces higher warning with the lower one, plug-in or climb above 25 % clears the latch. 5 % is sticky.
- SD connect / disconnect -- same poll watches `is_sd_available()` and posts on transitions.
- Panic / brownout -- one sticky toast at boot with a Logs action.

## Test plan

- [x] Build + flash, `post_unless_focused` and the integration helper resolve.
- [x] `dm/message` posts a toast; pushing the matching DM conversation suppresses subsequent dm/messages for that contact while letting other contacts' messages through.
- [x] `file/offer`, `file/done` (rx), `file/error` (rx) each generate toasts.
- [x] Setting `notify_file=0` mutes file events; removing the pref restores them.
- [ ] Real-radio sanity: send a DM to the test device while sitting on Desktop, confirm toast appears with sender name + body and the Open action lands in the right conversation.
- [ ] Real-radio sanity: send a file from the companion, confirm offer / done toasts.
- [ ] Yank the SD card while running, confirm "SD card removed" toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)