### PR TITLE
docs(release): document DeployKey bypass actor for branch rulesets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,21 +182,40 @@ scope. The "GitHub Actions" identity does not appear in the bypass
 picker on the free org plan, so we can't put it on the bypass list.
 
 Workaround in use: a write-enabled **deploy key** (`auto-release-push`,
-private half stored in repo secret `RELEASE_PUSH_KEY`). Deploy-key
-pushes bypass branch rulesets by design. Both `*-artifacts.yml`
+private half stored in repo secret `RELEASE_PUSH_KEY`) **plus a
+DeployKey bypass actor on each ruleset**. Both `*-artifacts.yml`
 workflows load the key into ssh-agent via `webfactory/ssh-agent`
 and check the repo out over SSH so the subsequent `git push` from
-xtr-changelog flows through the same key.
+xtr-changelog flows through the same key, and the bypass actor
+on `ezos-branch-main` / `ezos-branch-test` lets that push land
+despite the `pull_request` rule. **Deploy keys do NOT bypass
+rulesets implicitly** -- the bypass actor must be present, of
+type `DeployKey` (which covers any deploy key on the repo, so the
+API stores it with `actor_id: null`).
 
 If OTA releases ever stop publishing, check the failing workflow
 run's "Generate changelog, sync version, and push back" step. A
 GH013 / "Changes must be made through a pull request" error means
-the SSH push fell back to HTTPS+GITHUB_TOKEN -- usually because the
-checkout step's `ssh-key` input was lost or the secret was rotated
-without updating the deploy key. Regenerate the keypair with
-`ssh-keygen -t ed25519`, register the public half via
-`POST /repos/ezmesh/ezos/keys` with `read_only: false`, and re-upload
-the private half to the `RELEASE_PUSH_KEY` secret.
+the push reached GitHub but the `pull_request` rule fired anyway.
+The two common causes:
+
+1. The DeployKey bypass entry is missing from the ruleset's
+   `bypass_actors`. Re-run `scripts/branch-protection.sh` (which
+   includes it now), or add it manually:
+   ```sh
+   gh api repos/ezmesh/ezos/rulesets        # find the ruleset id
+   gh api -X PUT repos/ezmesh/ezos/rulesets/<id> -f \
+       'bypass_actors[][actor_type]=DeployKey' \
+       -f 'bypass_actors[][bypass_mode]=always' ...
+   ```
+   (Pass the full ruleset payload; the PUT replaces it.)
+2. The SSH push genuinely fell back to HTTPS+GITHUB_TOKEN because
+   the deploy key is missing or the secret was rotated. Regenerate
+   the keypair with `ssh-keygen -t ed25519`, register the public
+   half via `POST /repos/ezmesh/ezos/keys` with `read_only: false`,
+   and re-upload the private half to `RELEASE_PUSH_KEY`. The
+   `webfactory/ssh-agent` step's log lines (`Identity added: ...`,
+   key fingerprint) confirm whether auth got off the ground.
 
 ## Project Structure
 

--- a/scripts/branch-protection.sh
+++ b/scripts/branch-protection.sh
@@ -14,13 +14,18 @@
 # Bypass for the auto-release workflow:
 #   The "GitHub Actions" identity does not appear in the bypass-actor
 #   picker on the free org plan, so the runner can't be added to the
-#   rulesets' bypass list. The auto-release workflow instead pushes
+#   rulesets' bypass list directly. The auto-release workflow pushes
 #   over SSH using a write-enabled deploy key (repo secret
 #   RELEASE_PUSH_KEY, public half registered as deploy key
-#   "auto-release-push"). Deploy-key pushes bypass branch rulesets by
-#   design, so `bypass_actors` here stays empty -- there is no actor
-#   to preserve across re-runs. See CLAUDE.md "Rolling OTA updates"
-#   for the wiring.
+#   "auto-release-push") and we add a DeployKey bypass actor here so
+#   the push lands. (Deploy keys do NOT bypass rulesets implicitly
+#   on GitHub today; the `pull_request` rule fires on every push,
+#   including SSH/deploy-key auth, unless an explicit DeployKey
+#   bypass actor is in `bypass_actors`. The actor_type `DeployKey`
+#   covers any deploy key registered on the repo, so a single entry
+#   bypasses all of them -- there is no per-key id to set, and the
+#   API returns `actor_id: null`.) See CLAUDE.md "Rolling OTA
+#   updates" for the wiring.
 #
 # Why rulesets, not classic branch protection:
 #   Classic protection's "required_status_checks" applies to *every*
@@ -77,7 +82,9 @@ create_ruleset() {
   "name": "ezos-branch-${branch}",
   "target": "branch",
   "enforcement": "active",
-  "bypass_actors": [],
+  "bypass_actors": [
+    { "actor_id": null, "actor_type": "DeployKey", "bypass_mode": "always" }
+  ],
   "conditions": {
     "ref_name": {
       "include": ["refs/heads/${branch}"],


### PR DESCRIPTION
## Summary

The auto-release workflow's `git push origin test` started failing with `GH013: Changes must be made through a pull request` (see https://github.com/ezmesh/ezos/actions/runs/25639862347). The deploy-key auth was working fine -- key loaded via `webfactory/ssh-agent`, SSH remote configured by `actions/checkout`, deploy key registered write-enabled on the repo. The `pull_request` rule on `ezos-branch-test` fired anyway.

Both `CLAUDE.md` and `scripts/branch-protection.sh` assumed deploy-key pushes bypass branch rulesets *implicitly*. That's not how rulesets work today: the bypass actor must be present in the ruleset, of type `DeployKey` (which covers any deploy key on the repo, so the API stores it with `actor_id: null`).

## Already done

The two live rulesets (`ezos-branch-test`, `ezos-branch-main`) have been patched via `gh api` to add the DeployKey bypass actor. **Rolling-test release `0.0.71` published successfully** after the patch -- end-to-end verified.

## What this PR does

Brings the script and docs in line with the live ruleset state, so the next re-run of `scripts/branch-protection.sh` doesn't wipe the bypass:

- `scripts/branch-protection.sh`: include the `DeployKey` bypass actor in the `create_ruleset` payload, update the comment block to drop the "deploy keys bypass by design" claim.
- `CLAUDE.md` "Branch ruleset push gate" / "If OTA releases ever stop publishing": document the DeployKey bypass requirement and expand the troubleshooting recipe with the new likeliest cause (missing bypass actor) before the SSH-fell-back-to-HTTPS case.

## Test plan

- [x] Patch the two live rulesets with the DeployKey bypass actor.
- [x] Re-trigger the failing run; confirmed only the original (stale-commit) re-run hit a non-FF, while the fresh run for the next merge (#79) succeeded and published rolling-test 0.0.71.
- [ ] After this PR merges, future merges to `test` / `main` continue to auto-release without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)