### PR TITLE
fix(release): fetch tags so xtr-changelog can advance the version

### DIFF
--- a/.github/workflows/main-artifacts.yml
+++ b/.github/workflows/main-artifacts.yml
@@ -37,6 +37,14 @@ jobs:
         with:
           ssh-key: ${{ secrets.RELEASE_PUSH_KEY }}
           persist-credentials: true
+          # xtr-changelog reads the latest `v*` tag locally to pick
+          # `previousVersion`; without this the action fetches
+          # depth=1 with no tags and falls back to package.json
+          # (which doesn't move), so every release re-stamps the
+          # same patch number. fetch-depth: 0 also gives the tool
+          # the full commit list it needs to build the changelog.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -75,12 +83,12 @@ jobs:
         id: changelog
         run: |
           npm ci
-          # --push pushes the release commit + tag back to main so
-          # versions.json[0].commit advances each run. Without this,
-          # subsequent runs all compute "next version" against a frozen
-          # anchor and the published version label drifts non-
-          # monotonically; the version-bump-required PR gate also has
-          # nothing real to anchor against.
+          # --push pushes the release commit + tag back to main so the
+          # next run sees the freshly-created `vX.Y.Z` tag, which is
+          # how xtr-changelog picks `previousVersion` (it greps local
+          # tags, hence the `fetch-tags: true` on checkout). Without
+          # the tag fetch, every run falls back to package.json#version
+          # and re-stamps the same patch number.
           #
           # [skip ci] in the message keeps the resulting push from
           # re-triggering this workflow (paths-ignore above is the

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -37,6 +37,14 @@ jobs:
         with:
           ssh-key: ${{ secrets.RELEASE_PUSH_KEY }}
           persist-credentials: true
+          # xtr-changelog reads the latest `v*` tag locally to pick
+          # `previousVersion`; without this the action fetches
+          # depth=1 with no tags and falls back to package.json
+          # (which doesn't move), so every release re-stamps the
+          # same patch number. fetch-depth: 0 also gives the tool
+          # the full commit list it needs to build the changelog.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -75,12 +83,12 @@ jobs:
         id: changelog
         run: |
           npm ci
-          # Push the release commit + tag back to the branch so
-          # versions.json[0].commit advances and the next run computes
-          # the next version against the freshly-released anchor (not
-          # against the original f2370c9 hand-edit). Without this the
-          # version label drifts non-monotonically and the
-          # version-bump-required PR gate has no real anchor.
+          # Push the release commit + tag back to the branch so the
+          # next run sees the freshly-created `vX.Y.Z` tag (which is
+          # how xtr-changelog picks `previousVersion` -- it greps
+          # local tags, hence the `fetch-tags: true` on checkout).
+          # Without the tag fetch, every run falls back to
+          # package.json#version and re-stamps the same patch number.
           #
           # [skip ci] in the commit message keeps the resulting push
           # from re-triggering this workflow on top of the paths-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,14 @@
 # Changelog
 
-## [0.0.71] - 2026-05-10
+## [0.0.80] - 2026-05-10
 
 ### Other
 - **release:** add DeployKey bypass actor to branch rulesets (#84) (afc57b3)
 
-## [0.0.71] - 2026-05-10
-
-### Other
-- **release:** add DeployKey bypass actor to branch rulesets (#84) (afc57b3)
-
-## [0.0.71] - 2026-05-10
+## [0.0.79] - 2026-05-10
 
 ### Features
 - **notifications:** wire DM/file/battery/SD/panic events (#79) (5478bde)
-
-## [0.0.71] - 2026-05-10
-
-### Other
-- **branch-protection:** drop required-status-checks enforcement (84da3d7)
 
 ## [0.0.78] - 2026-05-09
 

--- a/changelog.config.json
+++ b/changelog.config.json
@@ -9,6 +9,6 @@
     "markdown": {
       "path": "CHANGELOG.md"
     },
-    "packageJson": false
+    "packageJson": true
   }
 }

--- a/changelog/versions.json
+++ b/changelog/versions.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "versions": [
     {
-      "version": "0.0.71",
+      "version": "0.0.80",
       "date": "2026-05-10",
       "commit": "afc57b3",
       "breaking": false,
@@ -27,7 +27,7 @@
       }
     },
     {
-      "version": "0.0.71",
+      "version": "0.0.79",
       "date": "2026-05-10",
       "commit": "5478bde",
       "breaking": false,
@@ -43,30 +43,6 @@
             "notes": [
               {
                 "title": "Co-authored-by",
-                "text": "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "version": "0.0.71",
-      "date": "2026-05-10",
-      "commit": "84da3d7",
-      "breaking": false,
-      "groups": {
-        "other": [
-          {
-            "type": "ci",
-            "scope": "branch-protection",
-            "description": "drop required-status-checks enforcement",
-            "commit": "84da3d7",
-            "author": "Bas van den Aakster",
-            "breaking": false,
-            "notes": [
-              {
-                "title": "Co-Authored-By",
                 "text": "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
               }
             ]

--- a/lua/docs/changelog.json
+++ b/lua/docs/changelog.json
@@ -3,6 +3,54 @@
   "schemaVersion": 2,
   "versions": [
     {
+      "version": "0.0.80",
+      "date": "2026-05-10",
+      "commit": "afc57b3",
+      "breaking": false,
+      "groups": {
+        "other": [
+          {
+            "type": "docs",
+            "scope": "release",
+            "description": "add DeployKey bypass actor to branch rulesets (#84)",
+            "commit": "afc57b3",
+            "author": "XTR Bas",
+            "breaking": false,
+            "notes": [
+              {
+                "title": "Co-authored-by",
+                "text": "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "version": "0.0.79",
+      "date": "2026-05-10",
+      "commit": "5478bde",
+      "breaking": false,
+      "groups": {
+        "features": [
+          {
+            "type": "feat",
+            "scope": "notifications",
+            "description": "wire DM/file/battery/SD/panic events (#79)",
+            "commit": "5478bde",
+            "author": "XTR Bas",
+            "breaking": false,
+            "notes": [
+              {
+                "title": "Co-authored-by",
+                "text": "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "version": "0.0.78",
       "date": "2026-05-09",
       "commit": "f2370c9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ezos",
-  "version": "0.0.70",
+  "version": "0.0.80",
   "description": "A complete embedded operating system for the **LilyGo T-Deck Plus** (ESP32-S3 with LoRa), featuring encrypted mesh networking, offline maps, and a Lua-scripted user interface.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## Summary

The on-device firmware updater was showing the same `0.0.71` version every time. Root cause: both auto-release workflows checked out with the action's defaults (`fetch-depth: 1`, `fetch-tags: false`). xtr-changelog reads the latest local `v*` tag to pick `previousVersion` (`getLastTag` -> `git tag --list 'v*'`), saw none, fell back to `package.json#version` (which never moved because `output.packageJson` was false), and incremented `0.0.70 + 1 = 0.0.71` on every run. Three different commits on `test` (`afc57b3`, `5478bde`, `84da3d7`) all got stamped `0.0.71` and the rolling-test `versions.json` accumulated three duplicate entries.

The workflow comment also misattributed the mechanism -- it claimed monotonicity came from "pushing the release commit so `versions.json[0].commit` advances", but the tool actually keys off git tags. Fixed the comment too.

## Workflow

- Add `fetch-depth: 0` and `fetch-tags: true` to the `actions/checkout` step in both `*-artifacts.yml`. The next release run will see `v0.0.80` (already pushed to origin) and produce `0.0.81`.
- Rewrite the comment block above `npx xtr-changelog`.

## Config

- Flip `output.packageJson` to `true` in `changelog.config.json` so a future tag-fetch failure still advances `package.json#version` as a fallback. Catches a regression as a normal monotonic bump rather than a silent re-stamp.

## Repo state

- Renumber the duplicate active entries in `changelog/versions.json`: `afc57b3` -> `0.0.80`, `5478bde` -> `0.0.79`. Drop the orphan `84da3d7` entry (its content was already covered in the `0.0.78` release group from before; it got re-released by the bug).
- Bump `package.json#version` to `0.0.80` to match the new latest.
- Regenerate `CHANGELOG.md` from the corrected `versions.json`.
- Sync `lua/docs/changelog.json` (the embedded copy used by the on-device updater) to match.

## Out-of-band already done

- Deleted misplaced `v0.0.71` tag from origin.
- Created `v0.0.79` (at `b775bee`) and `v0.0.80` (at `0fd0ba9`) on origin.
- Re-uploaded the corrected `versions.json` to the `rolling-test` GitHub Release. Verified live -> firmware updater on existing devices now sees four distinct entries instead of three duplicate `0.0.71`s.
- The published `manifest.json` still says `version: "0.0.71"` -- can't be edited (Ed25519-signed). The next release run will produce a fresh manifest with `0.0.81`.

## Out of scope

- Workflow's `sed` on `platformio.ini` and `cp` to `lua/docs/changelog.json` happen *after* `xtr-changelog --commit` runs, so those changes never land in the repo (the release commit only carries `changelog/versions.json` + `CHANGELOG.md`). Result: `lua/docs/changelog.json` lags by one release in the repo. Worth a follow-up.
- Filing an upstream issue at xtr-dev/changelog for `--push` non-atomicity (already tracked in workflow comments) and considering a `previousVersion` fallback hierarchy.

## Test plan

- [x] Build passes locally with the new `versions.json` and bumped `package.json`.
- [x] Tag changes pushed; rolling-test `versions.json` updated; verified via curl.
- [ ] Once this PR merges, the next workflow run on `test` produces `0.0.81` (or `0.0.82` if there's a follow-up commit), with a single entry in `versions.json`. Updater shows the new version label and a clean changelog list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)