### PR TITLE
fix(release): packageJson must be an object, not the literal true

### DIFF
--- a/changelog.config.json
+++ b/changelog.config.json
@@ -9,6 +9,6 @@
     "markdown": {
       "path": "CHANGELOG.md"
     },
-    "packageJson": true
+    "packageJson": { "path": "package.json" }
   }
 }


### PR DESCRIPTION
## Summary

Hotfix for the failing auto-release after #85 merged: https://github.com/ezmesh/ezos/actions/runs/25640748955.

I set `output.packageJson: true` in #85 to enable the package.json sync as a fallback signal. xtr-changelog parses that field inconsistently:

- Read fallback (line 611) treats `true` like the string default `"package.json"`.
- Write fallback (line 691) does `resolveOutputPath(cwd, config.output.packageJson.path)` -- which is `path.join(cwd, undefined)` when `packageJson` is the literal `true`, and throws `The "paths[1]" argument must be of type string. Received undefined`.

Use the object form `{ "path": "package.json" }` so both code paths get a real string.

## Verified

`npx xtr-changelog release --execute` (without --commit/--push) on origin/test:

```
OK released 0.0.80 → 0.0.82 (patch)
  * wrote /home/bastiaan/ezos/changelog/versions.json
  * wrote /home/bastiaan/ezos/CHANGELOG.md
  * wrote /home/bastiaan/ezos/package.json
```

Both the version computation (0.0.80 -> 0.0.82, counting the two new commits since the `v0.0.80` tag) and the package.json write now succeed.

## Test plan

- [x] `npx xtr-changelog release --execute` succeeds locally on this branch's tree.
- [ ] After merge, the auto-release workflow on `test` produces a clean `0.0.82` (or `0.0.83+` if more commits accumulate), versions.json gets a single new entry, and the rolling-test release publishes with the right version label.

Cross-noted on xtr-dev/changelog#8 (the upstream issue) -- the parser should accept `true` for both read and write paths consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)