### PR TITLE
feat(audio): wire up onboard ES7210 microphone for audio recording

### DIFF
--- a/lua/boot.lua
+++ b/lua/boot.lua
@@ -463,6 +463,20 @@ local function boot_sequence()
         end)
     end)
 
+    -- MIC side key: if the voice-notes screen is already on top it
+    -- handles its own MIC key locally (to toggle record without
+    -- racing this global handler). From anywhere else, the side key
+    -- opens the voice-notes screen so the user can start a clip
+    -- without navigating into Apps -> Voice notes manually.
+    ez.bus.subscribe("key/down", function(_topic, k)
+        if type(k) ~= "table" or k.special ~= "MIC" then return end
+        local screen_mod = require("ezui.screen")
+        local top = screen_mod.peek and screen_mod.peek()
+        local VoiceNotes = require("screens.tools.voice_notes")
+        if top and top._def == VoiceNotes then return end
+        screen_mod.push(screen_mod.create(VoiceNotes, {}))
+    end)
+
     -- Apps registry: file-type → handler for the file manager. Built-in
     -- handlers register themselves here; screens opened from the registry
     -- are loaded lazily on first `open()` so unused apps don't pull their

--- a/lua/docs/manual/index.md
+++ b/lua/docs/manual/index.md
@@ -11,6 +11,7 @@ work even with no SD card and no network.
 - Key bindings
 - Mesh basics
 - Maps
+- Voice notes
 - Settings
 - Customization (advanced)
 

--- a/lua/docs/manual/voice-notes.md
+++ b/lua/docs/manual/voice-notes.md
@@ -1,0 +1,47 @@
+# Voice notes
+
+Voice notes records short audio clips from the onboard microphone and
+stores them as WAV files on the SD card under `/sd/recordings/`. The
+T-Deck Plus has a MEMS microphone routed through an ES7210 codec --
+recording requires an SD card and a populated mic.
+
+## Recording
+
+Open Apps -> Voice notes, or press the dedicated **MIC side key** from
+anywhere to open the screen. Once it is on top, the MIC key toggles
+recording on/off. The same toggle works with **alt+R** on the keyboard.
+
+While a clip is being captured the screen shows "Recording... N s" in
+red. Press MIC again to stop and save. A safety cap stops the
+recording at five minutes if you forget.
+
+Each clip is named with the current wall-clock time, so newest
+recordings sort to the top. If the clock has not been set (no NTP
+sync, no RTC) the name falls back to `note_boot_<millis>.wav`.
+
+## Playing back
+
+Press Enter on a clip in the list to play it through the speaker.
+Press M to open the actions menu:
+
+- Play: play the clip.
+- Delete: remove it from the SD card.
+
+Recordings are mono 16-bit PCM at 16 kHz. Playback uses the same WAV
+decoder as the Audio app, so any 16-bit PCM WAV under
+`/sd/recordings/` will work.
+
+## If recording fails
+
+- "No microphone": the codec did not acknowledge on the I2C bus.
+  Either the board has no mic populated or the codec is wedged --
+  reboot the device.
+- "Empty clip": the recording stopped immediately with zero bytes
+  written. Usually means the I2S RX path could not bring up the
+  codec. Check the System Log under Diagnostics.
+
+## Disk space
+
+A one-minute clip at 16 kHz / 16-bit mono is roughly 1.9 MB. Delete
+old recordings from the list (M -> Delete) or via the Files app under
+the `/sd/recordings/` folder.

--- a/lua/screens/menu.lua
+++ b/lua/screens/menu.lua
@@ -62,6 +62,8 @@ local CATEGORIES = {
               icon = icons.folder, mod = "screens.tools.file_manager" },
             { title = "Map", subtitle = "Offline maps",
               icon = icons.map, mod = "screens.tools.map_loader" },
+            { title = "Voice notes", subtitle = "Record clips with the onboard mic",
+              icon = icons.volume, mod = "screens.tools.voice_notes" },
         },
     },
     {

--- a/lua/screens/tools/voice_notes.lua
+++ b/lua/screens/tools/voice_notes.lua
@@ -1,0 +1,303 @@
+-- Voice notes: record short WAV clips to /sd/recordings/ and play
+-- them back. Recording uses the onboard ES7210 codec (see
+-- audio/mic.cpp on the firmware side); playback reuses
+-- ez.audio.play_wav which already understands 16-bit mono.
+--
+-- Keys:
+--   ENTER on a clip       -> play
+--   M                     -> per-clip actions menu (play, delete)
+--   alt+R / MIC side key  -> toggle record
+--   BACKSPACE             -> back
+
+local ui          = require("ezui")
+local theme       = require("ezui.theme")
+local screen_mod  = require("ezui.screen")
+
+local Voice = { title = "Voice notes" }
+
+-- ez.storage.list_dir treats "/sd/recordings/" (trailing slash) and
+-- "/sd/recordings" differently: the slashy form returns 0 entries on
+-- the SD-card mount, while the non-slashy form returns the real
+-- contents. Build the directory path without a trailing slash and
+-- glue the slash on only when joining a filename.
+local REC_DIR  = "/sd/recordings"
+local REC_FILE = REC_DIR .. "/"
+
+local function format_size(bytes)
+    if bytes >= 1048576 then
+        return string.format("%.1f MB", bytes / 1048576)
+    elseif bytes >= 1024 then
+        return string.format("%.1f KB", bytes / 1024)
+    else
+        return bytes .. " B"
+    end
+end
+
+local function ensure_dir()
+    -- list_dir on a missing path returns nil; mkdir is idempotent.
+    local entries = ez.storage.list_dir(REC_DIR)
+    if not entries then
+        ez.storage.mkdir(REC_DIR)
+    end
+end
+
+local function load_clips()
+    ensure_dir()
+    local entries = ez.storage.list_dir(REC_DIR) or {}
+    local clips = {}
+    for _, e in ipairs(entries) do
+        if not e.is_dir and e.name:lower():match("%.wav$") then
+            clips[#clips + 1] = {
+                name = e.name,
+                path = REC_FILE .. e.name,
+                size = e.size or 0,
+            }
+        end
+    end
+    -- Newest first (filenames embed a sortable timestamp).
+    table.sort(clips, function(a, b) return a.name > b.name end)
+    return clips
+end
+
+local function next_clip_path()
+    -- Prefer a wall-clock filename so the clip list stays sorted in
+    -- recording order. If the clock hasn't been set yet (no NTP, no
+    -- RTC) fall back to a millisecond counter so a fresh boot still
+    -- produces unique names.
+    local t = ez.system.get_time()
+    if t and t.year then
+        return string.format("%snote_%04d%02d%02d_%02d%02d%02d.wav",
+            REC_FILE,
+            t.year, t.month, t.day, t.hour, t.minute, t.second)
+    end
+    return string.format("%snote_boot_%010d.wav", REC_FILE, ez.system.millis())
+end
+
+local function show_clip_menu(self, clip)
+    local MenuDef = { title = clip.name }
+
+    function MenuDef:build(state)
+        local items = {}
+        items[#items + 1] = ui.title_bar(clip.name, { back = true })
+        local actions = {
+            ui.list_item({
+                title = "Play",
+                on_press = function()
+                    screen_mod.pop()
+                    ez.audio.play_wav(clip.path)
+                end,
+            }),
+            ui.list_item({
+                title = "Delete",
+                subtitle = "Remove this clip",
+                on_press = function()
+                    ez.storage.remove(clip.path)
+                    screen_mod.pop()
+                    self:set_state({ clips = load_clips() })
+                end,
+            }),
+            ui.list_item({
+                title = format_size(clip.size),
+                disabled = true,
+            }),
+        }
+        items[#items + 1] = ui.scroll({ grow = 1 }, ui.vbox({ gap = 0 }, actions))
+        return ui.vbox({ gap = 0, bg = "BG" }, items)
+    end
+
+    function MenuDef:handle_key(k)
+        if k.special == "BACKSPACE" or k.special == "ESCAPE" or k.character == "q" then
+            return "pop"
+        end
+        return nil
+    end
+
+    screen_mod.push(screen_mod.create(MenuDef, {}))
+end
+
+local function start_record(self)
+    if ez.audio.is_recording() then return end
+    if not ez.audio.mic_available() then
+        require("services.notifications").post({
+            title = "No microphone",
+            body  = "ES7210 not detected on this device.",
+            source = "voice_notes",
+            ttl_ms = 3000,
+        })
+        return
+    end
+    local path = next_clip_path()
+    if not ez.audio.record(path, { sample_rate = 16000, gain_db = 24 }) then
+        require("services.notifications").post({
+            title = "Recording failed",
+            body  = "Could not start capture",
+            source = "voice_notes",
+            ttl_ms = 3000,
+        })
+        return
+    end
+    self:set_state({
+        recording      = true,
+        recording_path = path,
+        record_started = ez.system.millis(),
+    })
+end
+
+local function stop_record(self)
+    if not ez.audio.is_recording() then return end
+    local bytes = ez.audio.stop_record()
+    self:set_state({
+        recording      = false,
+        recording_path = nil,
+        record_started = nil,
+        clips          = load_clips(),
+    })
+    if not bytes or bytes == 0 then
+        require("services.notifications").post({
+            title = "Empty clip",
+            body  = "No audio captured",
+            source = "voice_notes",
+            ttl_ms = 3000,
+        })
+    end
+end
+
+function Voice:initial_state()
+    return { clips = load_clips(), recording = false }
+end
+
+function Voice:on_enter()
+    self:set_state({ clips = load_clips() })
+    local me = self
+    -- Tick twice a second while recording so the timer label updates.
+    -- invalidate() repaints the existing tree; we need _rebuild() so
+    -- build() runs again and recomputes the "Recording... N s" text
+    -- from the live millis() delta.
+    self._tick = ez.system.set_interval(500, function()
+        if me._state and me._state.recording then
+            me:_rebuild()
+            require("ezui.screen").invalidate()
+        end
+    end)
+    -- Listen for the MIC side key. We grab it at the screen level so
+    -- the on-screen "Record" button doesn't need focus.
+    self._mic_sub = ez.bus.subscribe("key/down", function(_, k)
+        if not k then return end
+        if k.special == "MIC" then
+            if me._state.recording then
+                stop_record(me)
+            else
+                start_record(me)
+            end
+        end
+    end)
+end
+
+function Voice:on_exit()
+    if self._tick then
+        ez.system.cancel_timer(self._tick)
+        self._tick = nil
+    end
+    if self._mic_sub then
+        ez.bus.unsubscribe(self._mic_sub)
+        self._mic_sub = nil
+    end
+    -- Make sure we don't strand the codec/I2S if the user backs out
+    -- mid-record.
+    if ez.audio.is_recording() then
+        ez.audio.stop_record()
+    end
+end
+
+function Voice:build(state)
+    local items = {}
+    items[#items + 1] = ui.title_bar("Voice notes", { back = true })
+
+    -- Status / record bar.
+    local me = self
+    local status
+    if state.recording then
+        local secs = math.max(0,
+            math.floor((ez.system.millis() - (state.record_started or 0)) / 1000))
+        status = ui.padding({ 8, 8, 8, 8 },
+            ui.vbox({ gap = 4 }, {
+                ui.text_widget(string.format("Recording... %d s", secs),
+                    { color = "ERROR" }),
+                ui.text_widget("Press MIC or Enter to stop",
+                    { color = "TEXT_MUTED", font = "small_aa" }),
+            })
+        )
+    else
+        status = ui.padding({ 8, 8, 8, 8 },
+            ui.button("Record", {
+                on_press = function() start_record(me) end,
+            })
+        )
+    end
+    items[#items + 1] = status
+
+    local clips = state.clips or {}
+    if #clips == 0 then
+        items[#items + 1] = ui.padding({ 16, 12, 12, 12 },
+            ui.text_widget(
+                "No recordings yet. Press Record (or the MIC side key) to capture.",
+                { wrap = true, color = "TEXT_MUTED", font = "small_aa" })
+        )
+    else
+        local rows = {}
+        for _, c in ipairs(clips) do
+            local clip = c
+            rows[#rows + 1] = ui.list_item({
+                title    = clip.name,
+                subtitle = format_size(clip.size),
+                _clip    = clip,
+                on_press = function()
+                    if state.recording then
+                        stop_record(me)
+                    else
+                        ez.audio.play_wav(clip.path)
+                    end
+                end,
+            })
+        end
+        items[#items + 1] = ui.scroll({ grow = 1 }, ui.vbox({ gap = 0 }, rows))
+    end
+
+    items[#items + 1] = ui.padding({ 4, 8, 2, 8 },
+        ui.text_widget("MIC: toggle record  |  M: actions",
+            { color = "TEXT_MUTED", font = "tiny_aa" })
+    )
+
+    return ui.vbox({ gap = 0, bg = "BG" }, items)
+end
+
+function Voice:handle_key(key)
+    -- Alt+R as a keyboard alternative to the MIC side key.
+    if key.alt and (key.character == "r" or key.character == "R") then
+        if self._state.recording then stop_record(self) else start_record(self) end
+        return "handled"
+    end
+    -- ENTER while recording: stop. We only intercept it here because
+    -- the on-screen Record button (which lives in the focus chain
+    -- while idle) already handles ENTER to *start* a recording; once
+    -- recording begins the button is gone and ENTER would otherwise
+    -- fall through with nothing to do.
+    if key.special == "ENTER" and self._state.recording then
+        stop_record(self)
+        return "handled"
+    end
+    if key.character == "m" or key.character == "M" then
+        local focus_mod = require("ezui.focus")
+        local n = focus_mod.current()
+        if n and n._clip then
+            show_clip_menu(self, n._clip)
+            return "handled"
+        end
+    end
+    if key.special == "BACKSPACE" or key.special == "ESCAPE" then
+        return "pop"
+    end
+    return nil
+end
+
+return Voice

--- a/lua/screens/tools/voice_notes.lua
+++ b/lua/screens/tools/voice_notes.lua
@@ -121,7 +121,7 @@ local function start_record(self)
         require("services.notifications").post({
             title = "No microphone",
             body  = "ES7210 not detected on this device.",
-            source = "voice_notes",
+            source = "voice",
             ttl_ms = 3000,
         })
         return
@@ -131,7 +131,7 @@ local function start_record(self)
         require("services.notifications").post({
             title = "Recording failed",
             body  = "Could not start capture",
-            source = "voice_notes",
+            source = "voice",
             ttl_ms = 3000,
         })
         return
@@ -156,7 +156,7 @@ local function stop_record(self)
         require("services.notifications").post({
             title = "Empty clip",
             body  = "No audio captured",
-            source = "voice_notes",
+            source = "voice",
             ttl_ms = 3000,
         })
     end
@@ -191,6 +191,22 @@ function Voice:on_enter()
             end
         end
     end)
+    -- The 5-minute safety cap (audio/mic.cpp) self-terminates the capture
+    -- task and posts this event after the WAV is finalised. Reflect that
+    -- in the screen state so the live timer flips off and the new clip
+    -- appears in the list -- otherwise the UI would show "Recording... N s"
+    -- climbing past the actual cutoff with no way to stop short of leaving
+    -- the screen.
+    self._overflow_sub = ez.bus.subscribe("audio/recording_stopped", function()
+        if me._state and me._state.recording then
+            me:set_state({
+                recording      = false,
+                recording_path = nil,
+                record_started = nil,
+                clips          = load_clips(),
+            })
+        end
+    end)
 end
 
 function Voice:on_exit()
@@ -201,6 +217,10 @@ function Voice:on_exit()
     if self._mic_sub then
         ez.bus.unsubscribe(self._mic_sub)
         self._mic_sub = nil
+    end
+    if self._overflow_sub then
+        ez.bus.unsubscribe(self._overflow_sub)
+        self._overflow_sub = nil
     end
     -- Make sure we don't strand the codec/I2S if the user backs out
     -- mid-record.

--- a/src/audio/mic.cpp
+++ b/src/audio/mic.cpp
@@ -1,0 +1,384 @@
+// ES7210 + I2S RX implementation. See mic.h for the contract.
+//
+// Init sequence is derived from the ES7210 datasheet (Everest Semi
+// rev 1.0). The codec is wired as I2S slave -- ESP32 supplies MCLK,
+// BCLK, LRCK on I2S_NUM_1 in master mode. Only MIC1 is enabled to
+// keep the data stream mono; the chip can do up to 4 channels but
+// that's a follow-up.
+//
+// Clock plan @ 16 kHz: MCLK = 256*fs = 4.096 MHz, BCLK = 32*fs (16-bit
+// stereo frame so LRCK toggles per word and we read the L slot only).
+// We let the ESP32 I2S peripheral derive MCLK from the APLL so the
+// codec sees a clean clock independent of the CPU PLL.
+
+#include "mic.h"
+#include "../config.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <SD.h>
+#include <driver/i2s.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+namespace ezos {
+namespace mic {
+
+namespace {
+
+constexpr i2s_port_t kRxPort = I2S_NUM_1;
+
+// ES7210 register addresses we touch. The chip has ~0x4F regs in
+// total; these are the ones needed for "boot, single mic channel,
+// I2S slave, 16-bit @ 16 kHz".
+constexpr uint8_t REG_RESET        = 0x00;
+constexpr uint8_t REG_CLK_ON       = 0x01;
+constexpr uint8_t REG_MCLK_CTL     = 0x02;
+constexpr uint8_t REG_MCLK_DIV     = 0x03;
+constexpr uint8_t REG_LRCK_DIV_H   = 0x04;
+constexpr uint8_t REG_LRCK_DIV_L   = 0x05;
+constexpr uint8_t REG_OSR          = 0x07;
+constexpr uint8_t REG_MODE         = 0x08;
+constexpr uint8_t REG_DIGI_PWR     = 0x06;
+constexpr uint8_t REG_SDP_FMT      = 0x11;
+constexpr uint8_t REG_SDP_LRCK     = 0x12;
+constexpr uint8_t REG_ADC_AUTOMUTE = 0x14;
+constexpr uint8_t REG_ADC_DIGI_VOL = 0x15;
+constexpr uint8_t REG_ANA_PWR      = 0x3F;
+constexpr uint8_t REG_MIC12_PWR    = 0x41;
+constexpr uint8_t REG_MIC34_PWR    = 0x42;
+constexpr uint8_t REG_MIC1_GAIN    = 0x43;
+constexpr uint8_t REG_MIC2_GAIN    = 0x44;
+constexpr uint8_t REG_MIC1_BIAS    = 0x47;
+constexpr uint8_t REG_MIC2_BIAS    = 0x48;
+constexpr uint8_t REG_MIC1_PGA     = 0x4B;
+constexpr uint8_t REG_MIC2_PGA     = 0x4C;
+
+bool i2c_write(uint8_t reg, uint8_t val) {
+    Wire.beginTransmission(ES7210_I2C_ADDR);
+    Wire.write(reg);
+    Wire.write(val);
+    return Wire.endTransmission() == 0;
+}
+
+bool i2c_read(uint8_t reg, uint8_t* out) {
+    Wire.beginTransmission(ES7210_I2C_ADDR);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) return false;
+    if (Wire.requestFrom((uint8_t)ES7210_I2C_ADDR, (uint8_t)1) != 1) return false;
+    *out = Wire.read();
+    return true;
+}
+
+// Gain selector mapping. ES7210 PGA gain register field (0x43, bits 3:0)
+// is in 3 dB steps from 0 dB (0x00) to 36 dB (0x0E). We clamp into the
+// usable range; values above 36 dB on this codec saturate quickly.
+uint8_t pga_step_for_db(uint8_t db) {
+    if (db > 36) db = 36;
+    return (uint8_t)(db / 3);
+}
+
+// Full ES7210 power-on init for 16-bit, 1-channel, slave-mode capture.
+bool codec_init(uint32_t sample_rate, uint8_t gain_db) {
+    // Soft reset, hold ~1 ms, then clear reset.
+    if (!i2c_write(REG_RESET, 0xFF)) return false;
+    delay(1);
+    if (!i2c_write(REG_RESET, 0x32)) return false;
+    delay(1);
+    i2c_write(REG_RESET, 0x00);
+
+    // Clock manager: enable MCLK/ADC clock, MCLK from MCLK pin.
+    i2c_write(REG_CLK_ON,   0x3F);
+    // MCLK source = from external pin (we drive it from the ESP32
+    // I2S peripheral), no inversion, normal divider path.
+    i2c_write(REG_MCLK_CTL, 0xC1);
+
+    // Clock dividers for 16 kHz @ 256*fs MCLK.
+    // OSR = 64 (default), LRCK divider = MCLK / fs = 256.
+    // 256 = 0x0100 -> high=0x01, low=0x00.
+    i2c_write(REG_MCLK_DIV, 0x02);
+    i2c_write(REG_LRCK_DIV_H, 0x01);
+    i2c_write(REG_LRCK_DIV_L, 0x00);
+    i2c_write(REG_OSR, 0x20);
+    // Mode: slave, normal phase.
+    i2c_write(REG_MODE, 0x14);
+    // Digital power: enable ADC channel 1 only.
+    i2c_write(REG_DIGI_PWR, 0x00);
+
+    // Serial port: I2S, 16-bit, MSB first.
+    // 0x11 = [7:4 word len][3:0 fmt]. Word len 16-bit = 0b0011, fmt I2S = 0b0000.
+    i2c_write(REG_SDP_FMT, 0x30);
+    // LRCK active high, BCLK normal phase.
+    i2c_write(REG_SDP_LRCK, 0x00);
+
+    // Auto-mute disabled, digital volume = 0 dB.
+    i2c_write(REG_ADC_AUTOMUTE, 0x00);
+    i2c_write(REG_ADC_DIGI_VOL, 0xC0);  // 0xC0 = 0 dB after lookup table
+
+    // Analog power on (full chip), enable MIC1+MIC2 PGAs and bias.
+    i2c_write(REG_ANA_PWR, 0x00);
+    i2c_write(REG_MIC12_PWR, 0x00);
+    i2c_write(REG_MIC34_PWR, 0xFF);  // MIC3/4 off (T-Deck has 1 mic)
+    i2c_write(REG_MIC1_BIAS, 0x08);  // ~2.6V bias for the MEMS element
+    i2c_write(REG_MIC2_BIAS, 0x08);
+
+    uint8_t pga = pga_step_for_db(gain_db);
+    i2c_write(REG_MIC1_GAIN, 0x10 | pga);
+    i2c_write(REG_MIC2_GAIN, 0x10 | pga);
+    i2c_write(REG_MIC1_PGA, 0x00);
+    i2c_write(REG_MIC2_PGA, 0x00);
+
+    (void)sample_rate;  // currently fixed by the dividers above
+    return true;
+}
+
+bool i2s_rx_install(uint32_t sample_rate) {
+    i2s_config_t cfg = {
+        .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX),
+        .sample_rate = sample_rate,
+        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
+        .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
+        .communication_format = I2S_COMM_FORMAT_STAND_I2S,
+        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
+        .dma_buf_count = 4,
+        .dma_buf_len = 512,
+        .use_apll = true,
+        .tx_desc_auto_clear = false,
+        .fixed_mclk = (int)(sample_rate * 256),
+    };
+    esp_err_t err = i2s_driver_install(kRxPort, &cfg, 0, nullptr);
+    if (err != ESP_OK) {
+        Serial.printf("[Mic] I2S install failed: %d\n", err);
+        return false;
+    }
+
+    i2s_pin_config_t pins = {
+        .mck_io_num   = ES7210_MCLK,
+        .bck_io_num   = ES7210_SCK,
+        .ws_io_num    = ES7210_LRCK,
+        .data_out_num = I2S_PIN_NO_CHANGE,
+        .data_in_num  = ES7210_DIN,
+    };
+    err = i2s_set_pin(kRxPort, &pins);
+    if (err != ESP_OK) {
+        Serial.printf("[Mic] I2S set_pin failed: %d\n", err);
+        i2s_driver_uninstall(kRxPort);
+        return false;
+    }
+    i2s_zero_dma_buffer(kRxPort);
+    return true;
+}
+
+void i2s_rx_uninstall() {
+    i2s_driver_uninstall(kRxPort);
+}
+
+// WAV header for 16-bit PCM mono. Sizes are placeholders -- the
+// session keeps a running data-bytes counter and patches the header
+// on stop.
+struct WavHeader {
+    char     riff[4]      = {'R','I','F','F'};
+    uint32_t riff_size    = 36;
+    char     wave[4]      = {'W','A','V','E'};
+    char     fmt_id[4]    = {'f','m','t',' '};
+    uint32_t fmt_size     = 16;
+    uint16_t audio_format = 1;        // PCM
+    uint16_t num_channels = 1;
+    uint32_t sample_rate  = 16000;
+    uint32_t byte_rate    = 32000;    // sr * ch * bytes
+    uint16_t block_align  = 2;        // ch * bytes
+    uint16_t bits_per_sample = 16;
+    char     data_id[4]   = {'d','a','t','a'};
+    uint32_t data_size    = 0;
+};
+
+}  // namespace
+
+struct MicSession {
+    File          file;
+    uint32_t      sample_rate;
+    uint32_t      data_bytes;
+    TaskHandle_t  task;
+    volatile bool stop_requested;
+    volatile bool task_alive;
+    SemaphoreHandle_t done_sem;
+};
+
+static MicSession* g_session = nullptr;
+
+bool is_recording() {
+    return g_session != nullptr;
+}
+
+bool probe() {
+    Wire.beginTransmission(ES7210_I2C_ADDR);
+    return Wire.endTransmission() == 0;
+}
+
+static void capture_task(void* arg) {
+    auto* sess = static_cast<MicSession*>(arg);
+    sess->task_alive = true;
+
+    constexpr size_t kBufBytes = 1024;
+    uint8_t* buf = (uint8_t*)heap_caps_malloc(kBufBytes, MALLOC_CAP_DMA);
+    if (!buf) {
+        Serial.println("[Mic] capture_task: buf alloc failed");
+        sess->task_alive = false;
+        xSemaphoreGive(sess->done_sem);
+        vTaskDelete(nullptr);
+        return;
+    }
+
+    while (!sess->stop_requested) {
+        size_t bytes_read = 0;
+        esp_err_t err = i2s_read(kRxPort, buf, kBufBytes, &bytes_read, pdMS_TO_TICKS(100));
+        if (err == ESP_OK && bytes_read > 0) {
+            size_t w = sess->file.write(buf, bytes_read);
+            sess->data_bytes += (uint32_t)w;
+            if (w != bytes_read) {
+                Serial.printf("[Mic] short write: wrote %u of %u\n",
+                              (unsigned)w, (unsigned)bytes_read);
+                break;
+            }
+        }
+        // Cap individual recordings at ~5 minutes of 16k/16-bit mono.
+        // Real cap is "what fits on SD" but this stops a runaway
+        // session from filling the card if a screen forgets to call
+        // stop_recording().
+        if (sess->data_bytes > 5UL * 60 * sess->sample_rate * 2) {
+            Serial.println("[Mic] hit 5-min cap, auto-stop");
+            break;
+        }
+    }
+
+    free(buf);
+    sess->task_alive = false;
+    xSemaphoreGive(sess->done_sem);
+    vTaskDelete(nullptr);
+}
+
+MicSession* start_recording(const char* wav_path, const RecordOpts& opts) {
+    if (g_session) {
+        Serial.println("[Mic] start_recording: already active");
+        return nullptr;
+    }
+    if (!probe()) {
+        Serial.println("[Mic] start_recording: ES7210 not present on I2C");
+        return nullptr;
+    }
+
+    if (!codec_init(opts.sample_rate, opts.gain_db)) {
+        Serial.println("[Mic] codec_init failed");
+        return nullptr;
+    }
+    if (!i2s_rx_install(opts.sample_rate)) {
+        return nullptr;
+    }
+
+    auto* sess = new MicSession();
+    sess->sample_rate = opts.sample_rate;
+    sess->data_bytes = 0;
+    sess->task = nullptr;
+    sess->stop_requested = false;
+    sess->task_alive = false;
+    sess->done_sem = xSemaphoreCreateBinary();
+
+    // SD.open() is mounted at /; callers pass the Lua-side
+    // convention "/sd/..." so we strip the prefix the same way
+    // play_wav / play_mp3 do (audio_bindings.cpp).
+    const char* fs_path = wav_path;
+    if (strncmp(wav_path, "/sd/", 4) == 0) fs_path = wav_path + 3;
+    sess->file = SD.open(fs_path, FILE_WRITE);
+    if (!sess->file) {
+        Serial.printf("[Mic] failed to open %s\n", fs_path);
+        vSemaphoreDelete(sess->done_sem);
+        delete sess;
+        i2s_rx_uninstall();
+        return nullptr;
+    }
+
+    WavHeader hdr;
+    hdr.sample_rate = opts.sample_rate;
+    hdr.byte_rate   = opts.sample_rate * 2;
+    sess->file.write(reinterpret_cast<const uint8_t*>(&hdr), sizeof(hdr));
+
+    g_session = sess;
+    if (xTaskCreatePinnedToCore(capture_task, "mic_cap", 4096, sess,
+                                4, &sess->task, 1) != pdPASS) {
+        Serial.println("[Mic] failed to spawn capture_task");
+        sess->file.close();
+        SD.remove(fs_path);
+        vSemaphoreDelete(sess->done_sem);
+        delete sess;
+        i2s_rx_uninstall();
+        g_session = nullptr;
+        return nullptr;
+    }
+    return sess;
+}
+
+bool stop_recording(MicSession* sess, uint32_t* out_bytes_written) {
+    if (!sess || sess != g_session) return false;
+
+    sess->stop_requested = true;
+    // Wait up to 1s for the capture task to drain and exit. After
+    // that we tear down regardless -- the task will check stop_requested
+    // again on its next i2s_read timeout.
+    xSemaphoreTake(sess->done_sem, pdMS_TO_TICKS(1000));
+
+    // Patch the WAV header now that we know the final size.
+    uint32_t data_size = sess->data_bytes;
+    uint32_t riff_size = data_size + 36;
+    sess->file.seek(4);
+    sess->file.write(reinterpret_cast<const uint8_t*>(&riff_size), 4);
+    sess->file.seek(40);
+    sess->file.write(reinterpret_cast<const uint8_t*>(&data_size), 4);
+    sess->file.flush();
+    sess->file.close();
+
+    i2s_rx_uninstall();
+
+    if (out_bytes_written) *out_bytes_written = data_size;
+
+    vSemaphoreDelete(sess->done_sem);
+    delete sess;
+    g_session = nullptr;
+    return true;
+}
+
+int16_t* capture_buffer(uint32_t duration_ms, const RecordOpts& opts,
+                        size_t* out_size) {
+    if (g_session) {
+        Serial.println("[Mic] capture_buffer: session already active");
+        return nullptr;
+    }
+    if (!probe()) return nullptr;
+    if (!codec_init(opts.sample_rate, opts.gain_db)) return nullptr;
+    if (!i2s_rx_install(opts.sample_rate)) return nullptr;
+
+    size_t total_samples = (opts.sample_rate * duration_ms) / 1000;
+    size_t total_bytes = total_samples * 2;
+    int16_t* buf = (int16_t*)ps_malloc(total_bytes);
+    if (!buf) {
+        i2s_rx_uninstall();
+        return nullptr;
+    }
+
+    size_t written = 0;
+    while (written < total_bytes) {
+        size_t got = 0;
+        size_t want = total_bytes - written;
+        if (want > 1024) want = 1024;
+        esp_err_t err = i2s_read(kRxPort, (uint8_t*)buf + written, want,
+                                 &got, pdMS_TO_TICKS(200));
+        if (err != ESP_OK || got == 0) break;
+        written += got;
+    }
+
+    i2s_rx_uninstall();
+    if (out_size) *out_size = written;
+    return buf;
+}
+
+}  // namespace mic
+}  // namespace ezos

--- a/src/audio/mic.cpp
+++ b/src/audio/mic.cpp
@@ -13,6 +13,7 @@
 
 #include "mic.h"
 #include "../config.h"
+#include "../lua/bindings/bus_bindings.h"
 
 #include <Arduino.h>
 #include <Wire.h>
@@ -79,54 +80,64 @@ uint8_t pga_step_for_db(uint8_t db) {
 }
 
 // Full ES7210 power-on init for 16-bit, 1-channel, slave-mode capture.
+// Every register write is checked. If any of them NAKs (loose connection,
+// bus contention with keyboard / touch on the same I2C bus, codec held in
+// reset), bail out -- a partially-configured codec captures silence or
+// garbage with no surface indication of the underlying fault.
 bool codec_init(uint32_t sample_rate, uint8_t gain_db) {
+    auto W = [](uint8_t reg, uint8_t val) -> bool {
+        if (i2c_write(reg, val)) return true;
+        Serial.printf("[Mic] codec_init: I2C write failed at reg 0x%02X\n", reg);
+        return false;
+    };
+
     // Soft reset, hold ~1 ms, then clear reset.
-    if (!i2c_write(REG_RESET, 0xFF)) return false;
+    if (!W(REG_RESET, 0xFF)) return false;
     delay(1);
-    if (!i2c_write(REG_RESET, 0x32)) return false;
+    if (!W(REG_RESET, 0x32)) return false;
     delay(1);
-    i2c_write(REG_RESET, 0x00);
+    if (!W(REG_RESET, 0x00)) return false;
 
     // Clock manager: enable MCLK/ADC clock, MCLK from MCLK pin.
-    i2c_write(REG_CLK_ON,   0x3F);
+    if (!W(REG_CLK_ON,   0x3F)) return false;
     // MCLK source = from external pin (we drive it from the ESP32
     // I2S peripheral), no inversion, normal divider path.
-    i2c_write(REG_MCLK_CTL, 0xC1);
+    if (!W(REG_MCLK_CTL, 0xC1)) return false;
 
     // Clock dividers for 16 kHz @ 256*fs MCLK.
     // OSR = 64 (default), LRCK divider = MCLK / fs = 256.
     // 256 = 0x0100 -> high=0x01, low=0x00.
-    i2c_write(REG_MCLK_DIV, 0x02);
-    i2c_write(REG_LRCK_DIV_H, 0x01);
-    i2c_write(REG_LRCK_DIV_L, 0x00);
-    i2c_write(REG_OSR, 0x20);
+    if (!W(REG_MCLK_DIV, 0x02))   return false;
+    if (!W(REG_LRCK_DIV_H, 0x01)) return false;
+    if (!W(REG_LRCK_DIV_L, 0x00)) return false;
+    if (!W(REG_OSR, 0x20))        return false;
     // Mode: slave, normal phase.
-    i2c_write(REG_MODE, 0x14);
+    if (!W(REG_MODE, 0x14))       return false;
     // Digital power: enable ADC channel 1 only.
-    i2c_write(REG_DIGI_PWR, 0x00);
+    if (!W(REG_DIGI_PWR, 0x00))   return false;
 
     // Serial port: I2S, 16-bit, MSB first.
     // 0x11 = [7:4 word len][3:0 fmt]. Word len 16-bit = 0b0011, fmt I2S = 0b0000.
-    i2c_write(REG_SDP_FMT, 0x30);
+    if (!W(REG_SDP_FMT, 0x30))    return false;
     // LRCK active high, BCLK normal phase.
-    i2c_write(REG_SDP_LRCK, 0x00);
+    if (!W(REG_SDP_LRCK, 0x00))   return false;
 
     // Auto-mute disabled, digital volume = 0 dB.
-    i2c_write(REG_ADC_AUTOMUTE, 0x00);
-    i2c_write(REG_ADC_DIGI_VOL, 0xC0);  // 0xC0 = 0 dB after lookup table
+    if (!W(REG_ADC_AUTOMUTE, 0x00)) return false;
+    if (!W(REG_ADC_DIGI_VOL, 0xC0)) return false;  // 0xC0 = 0 dB after lookup table
 
     // Analog power on (full chip), enable MIC1+MIC2 PGAs and bias.
-    i2c_write(REG_ANA_PWR, 0x00);
-    i2c_write(REG_MIC12_PWR, 0x00);
-    i2c_write(REG_MIC34_PWR, 0xFF);  // MIC3/4 off (T-Deck has 1 mic)
-    i2c_write(REG_MIC1_BIAS, 0x08);  // ~2.6V bias for the MEMS element
-    i2c_write(REG_MIC2_BIAS, 0x08);
+    if (!W(REG_ANA_PWR,   0x00)) return false;
+    if (!W(REG_MIC12_PWR, 0x00)) return false;
+    if (!W(REG_MIC34_PWR, 0xFF)) return false;  // MIC3/4 off (T-Deck has 1 mic)
+    if (!W(REG_MIC1_BIAS, 0x08)) return false;  // ~2.6V bias for the MEMS element
+    if (!W(REG_MIC2_BIAS, 0x08)) return false;
 
     uint8_t pga = pga_step_for_db(gain_db);
-    i2c_write(REG_MIC1_GAIN, 0x10 | pga);
-    i2c_write(REG_MIC2_GAIN, 0x10 | pga);
-    i2c_write(REG_MIC1_PGA, 0x00);
-    i2c_write(REG_MIC2_PGA, 0x00);
+    if (!W(REG_MIC1_GAIN, 0x10 | pga)) return false;
+    if (!W(REG_MIC2_GAIN, 0x10 | pga)) return false;
+    if (!W(REG_MIC1_PGA, 0x00))        return false;
+    if (!W(REG_MIC2_PGA, 0x00))        return false;
 
     (void)sample_rate;  // currently fixed by the dividers above
     return true;
@@ -229,6 +240,7 @@ static void capture_task(void* arg) {
         return;
     }
 
+    bool auto_stopped = false;
     while (!sess->stop_requested) {
         size_t bytes_read = 0;
         esp_err_t err = i2s_read(kRxPort, buf, kBufBytes, &bytes_read, pdMS_TO_TICKS(100));
@@ -247,6 +259,7 @@ static void capture_task(void* arg) {
         // stop_recording().
         if (sess->data_bytes > 5UL * 60 * sess->sample_rate * 2) {
             Serial.println("[Mic] hit 5-min cap, auto-stop");
+            auto_stopped = true;
             break;
         }
     }
@@ -254,6 +267,17 @@ static void capture_task(void* arg) {
     free(buf);
     sess->task_alive = false;
     xSemaphoreGive(sess->done_sem);
+
+    // If the task self-terminated (5-minute cap), nothing in the Lua
+    // layer knows it should clean up. Post a bus event so a subscriber
+    // can call ez.audio.stop_record() and finalise the WAV header,
+    // close the file, uninstall I2S, and clear the binding's mirror
+    // of g_session. The actual teardown all happens through the
+    // existing stop_recording() path -- this just kicks it.
+    if (auto_stopped) {
+        MessageBus::instance().post("audio/recording_overflow", "");
+    }
+
     vTaskDelete(nullptr);
 }
 
@@ -321,10 +345,17 @@ bool stop_recording(MicSession* sess, uint32_t* out_bytes_written) {
     if (!sess || sess != g_session) return false;
 
     sess->stop_requested = true;
-    // Wait up to 1s for the capture task to drain and exit. After
-    // that we tear down regardless -- the task will check stop_requested
-    // again on its next i2s_read timeout.
-    xSemaphoreTake(sess->done_sem, pdMS_TO_TICKS(1000));
+    // Wait unconditionally for the capture task to finish. The task
+    // wakes at most ~100 ms after stop_requested goes true (the i2s_read
+    // timeout), but an in-flight SD write can stall for hundreds of ms
+    // when FAT flushes. A finite timeout here used to race against
+    // that: we tore down sess->file, the I2S driver, and the semaphore
+    // while the task was still inside i2s_read or file.write, which
+    // is undefined behaviour (use-after-free / double-free of the
+    // semaphore handle). The task always signals done_sem before
+    // exiting -- including on the 5-minute auto-stop path -- so this
+    // wait is bounded in practice.
+    xSemaphoreTake(sess->done_sem, portMAX_DELAY);
 
     // Patch the WAV header now that we know the final size.
     uint32_t data_size = sess->data_bytes;

--- a/src/audio/mic.cpp
+++ b/src/audio/mic.cpp
@@ -1,15 +1,25 @@
 // ES7210 + I2S RX implementation. See mic.h for the contract.
 //
-// Init sequence is derived from the ES7210 datasheet (Everest Semi
-// rev 1.0). The codec is wired as I2S slave -- ESP32 supplies MCLK,
-// BCLK, LRCK on I2S_NUM_1 in master mode. Only MIC1 is enabled to
-// keep the data stream mono; the chip can do up to 4 channels but
-// that's a follow-up.
+// Board wiring (T-Deck Plus): the codec is on I2C (SDA=18, SCL=8, addr
+// 0x40) and its SDOUT2 line is wired to GPIO 14 -- SDOUT1 is *not*
+// connected. We therefore have to route the on-board MEMS mic's data
+// through SDOUT2 to be able to read it at all.
 //
-// Clock plan @ 16 kHz: MCLK = 256*fs = 4.096 MHz, BCLK = 32*fs (16-bit
-// stereo frame so LRCK toggles per word and we read the L slot only).
-// We let the ESP32 I2S peripheral derive MCLK from the APLL so the
-// codec sees a clean clock independent of the CPU PLL.
+// Codec config: 4-channel TDM mode (REG_SDP_INTERFACE2 = 0x02). In
+// non-TDM mode MIC1/MIC2 go on SDOUT1 (unreadable on this board), but
+// in TDM mode all four ADC channels are time-multiplexed onto SDOUT2
+// and we can pick out the slot that carries the mic. The init
+// sequence is modelled on LilyGo's own T-Deck mic example
+// (Xinyuan-LilyGO/T-Deck examples/Microphone) plus the esp-adf
+// ES7210 driver -- both are authoritative references for this chip.
+//
+// I2S RX: standard stereo (not TDM at the ESP32 side), 16-bit per
+// channel. The TDM frame on the wire has 4 ADC slots per LRCK; the
+// ESP32 in stereo mode only consumes 2 slots per LRCK, which halves
+// the effective rate. To get the user-requested LRCK out the other
+// side, we configure the I2S sample_rate at 2x and the capture task
+// extracts CH0 (MIC1's slot) into a mono PCM stream. Result: caller
+// asks for 16 kHz mono and gets a 16 kHz mono WAV.
 
 #include "mic.h"
 #include "../config.h"
@@ -29,31 +39,44 @@ namespace {
 
 constexpr i2s_port_t kRxPort = I2S_NUM_1;
 
-// ES7210 register addresses we touch. The chip has ~0x4F regs in
-// total; these are the ones needed for "boot, single mic channel,
-// I2S slave, 16-bit @ 16 kHz".
-constexpr uint8_t REG_RESET        = 0x00;
-constexpr uint8_t REG_CLK_ON       = 0x01;
-constexpr uint8_t REG_MCLK_CTL     = 0x02;
-constexpr uint8_t REG_MCLK_DIV     = 0x03;
-constexpr uint8_t REG_LRCK_DIV_H   = 0x04;
-constexpr uint8_t REG_LRCK_DIV_L   = 0x05;
-constexpr uint8_t REG_OSR          = 0x07;
-constexpr uint8_t REG_MODE         = 0x08;
-constexpr uint8_t REG_DIGI_PWR     = 0x06;
-constexpr uint8_t REG_SDP_FMT      = 0x11;
-constexpr uint8_t REG_SDP_LRCK     = 0x12;
-constexpr uint8_t REG_ADC_AUTOMUTE = 0x14;
-constexpr uint8_t REG_ADC_DIGI_VOL = 0x15;
-constexpr uint8_t REG_ANA_PWR      = 0x3F;
-constexpr uint8_t REG_MIC12_PWR    = 0x41;
-constexpr uint8_t REG_MIC34_PWR    = 0x42;
-constexpr uint8_t REG_MIC1_GAIN    = 0x43;
-constexpr uint8_t REG_MIC2_GAIN    = 0x44;
-constexpr uint8_t REG_MIC1_BIAS    = 0x47;
-constexpr uint8_t REG_MIC2_BIAS    = 0x48;
-constexpr uint8_t REG_MIC1_PGA     = 0x4B;
-constexpr uint8_t REG_MIC2_PGA     = 0x4C;
+// ES7210 register addresses we touch. Names and addresses follow
+// Espressif's ESP-ADF es7210 driver (the authoritative reference for
+// this codec). An earlier version of this file used hand-rolled names
+// with several mis-mapped addresses (REG_ANA_PWR at 0x3F instead of
+// 0x40, MIC POWER and BIAS swapped, etc.), which left the analog
+// front-end in its default powered-down state and the ADC streamed
+// zeros forever. If you're tempted to "clean up" these names, cross-
+// check against ES7210.h in esp-adf first.
+constexpr uint8_t REG_RESET           = 0x00;
+constexpr uint8_t REG_CLOCK_OFF       = 0x01;  // per-channel ADC clock gating
+constexpr uint8_t REG_MAINCLK         = 0x02;  // adc_div / doubler / dll
+constexpr uint8_t REG_MASTER_CLK      = 0x03;  // MCLK source + SCLK division
+constexpr uint8_t REG_LRCK_DIVH       = 0x04;
+constexpr uint8_t REG_LRCK_DIVL       = 0x05;
+constexpr uint8_t REG_POWER_DOWN      = 0x06;  // digital power-down mask
+constexpr uint8_t REG_OSR             = 0x07;
+constexpr uint8_t REG_MODE_CONFIG     = 0x08;  // master/slave + channels
+constexpr uint8_t REG_TIME_CONTROL0   = 0x09;
+constexpr uint8_t REG_TIME_CONTROL1   = 0x0A;
+constexpr uint8_t REG_SDP_INTERFACE1  = 0x11;  // word length + I2S format
+constexpr uint8_t REG_SDP_INTERFACE2  = 0x12;  // TDM mode
+constexpr uint8_t REG_ADC34_HPF2      = 0x20;
+constexpr uint8_t REG_ADC34_HPF1      = 0x21;
+constexpr uint8_t REG_ADC12_HPF1      = 0x22;
+constexpr uint8_t REG_ADC12_HPF2      = 0x23;
+constexpr uint8_t REG_ANALOG_PWR      = 0x40;  // analog power + VMID
+constexpr uint8_t REG_MIC12_BIAS      = 0x41;  // MIC1/2 bias voltage
+constexpr uint8_t REG_MIC34_BIAS      = 0x42;  // MIC3/4 bias voltage
+constexpr uint8_t REG_MIC1_GAIN       = 0x43;  // PGA enable (bit 4) + 4-bit gain
+constexpr uint8_t REG_MIC2_GAIN       = 0x44;
+constexpr uint8_t REG_MIC3_GAIN       = 0x45;
+constexpr uint8_t REG_MIC4_GAIN       = 0x46;
+constexpr uint8_t REG_MIC1_POWER      = 0x47;  // per-channel analog power
+constexpr uint8_t REG_MIC2_POWER      = 0x48;
+constexpr uint8_t REG_MIC3_POWER      = 0x49;
+constexpr uint8_t REG_MIC4_POWER      = 0x4A;
+constexpr uint8_t REG_MIC12_POWER     = 0x4B;  // MIC1/2 PGA + ADC power (0 = on)
+constexpr uint8_t REG_MIC34_POWER     = 0x4C;
 
 bool i2c_write(uint8_t reg, uint8_t val) {
     Wire.beginTransmission(ES7210_I2C_ADDR);
@@ -71,6 +94,14 @@ bool i2c_read(uint8_t reg, uint8_t* out) {
     return true;
 }
 
+bool i2c_update(uint8_t reg, uint8_t mask, uint8_t val) {
+    uint8_t cur = 0;
+    if (!i2c_read(reg, &cur)) return false;
+    uint8_t next = (cur & ~mask) | (val & mask);
+    if (next == cur) return true;
+    return i2c_write(reg, next);
+}
+
 // Gain selector mapping. ES7210 PGA gain register field (0x43, bits 3:0)
 // is in 3 dB steps from 0 dB (0x00) to 36 dB (0x0E). We clamp into the
 // usable range; values above 36 dB on this codec saturate quickly.
@@ -80,83 +111,133 @@ uint8_t pga_step_for_db(uint8_t db) {
 }
 
 // Full ES7210 power-on init for 16-bit, 1-channel, slave-mode capture.
-// Every register write is checked. If any of them NAKs (loose connection,
-// bus contention with keyboard / touch on the same I2C bus, codec held in
-// reset), bail out -- a partially-configured codec captures silence or
-// garbage with no surface indication of the underlying fault.
+// Sequence mirrors esp-adf's es7210_adc_init + mic_select + start path
+// for MIC1, 16-bit I2S, fs=16 kHz, MCLK=256*fs. Every write is checked:
+// if any NAKs (loose connection, bus contention with the keyboard /
+// touch controller on the same I2C bus, codec held in reset), bail
+// out so a partially-configured codec can't silently stream garbage.
 bool codec_init(uint32_t sample_rate, uint8_t gain_db) {
     auto W = [](uint8_t reg, uint8_t val) -> bool {
         if (i2c_write(reg, val)) return true;
         Serial.printf("[Mic] codec_init: I2C write failed at reg 0x%02X\n", reg);
         return false;
     };
+    auto U = [](uint8_t reg, uint8_t mask, uint8_t val) -> bool {
+        if (i2c_update(reg, mask, val)) return true;
+        Serial.printf("[Mic] codec_init: I2C rmw failed at reg 0x%02X\n", reg);
+        return false;
+    };
 
-    // Soft reset, hold ~1 ms, then clear reset.
-    if (!W(REG_RESET, 0xFF)) return false;
+    // Soft reset, then bring the chip back up with all ADC clocks gated.
+    if (!W(REG_RESET, 0xFF))     return false;
     delay(1);
-    if (!W(REG_RESET, 0x32)) return false;
-    delay(1);
-    if (!W(REG_RESET, 0x00)) return false;
+    if (!W(REG_RESET, 0x41))     return false;
+    if (!W(REG_CLOCK_OFF, 0x3F)) return false;
 
-    // Clock manager: enable MCLK/ADC clock, MCLK from MCLK pin.
-    if (!W(REG_CLK_ON,   0x3F)) return false;
-    // MCLK source = from external pin (we drive it from the ESP32
-    // I2S peripheral), no inversion, normal divider path.
-    if (!W(REG_MCLK_CTL, 0xC1)) return false;
+    // Power-on / state-machine timing.
+    if (!W(REG_TIME_CONTROL0, 0x30)) return false;
+    if (!W(REG_TIME_CONTROL1, 0x30)) return false;
 
-    // Clock dividers for 16 kHz @ 256*fs MCLK.
-    // OSR = 64 (default), LRCK divider = MCLK / fs = 256.
-    // 256 = 0x0100 -> high=0x01, low=0x00.
-    if (!W(REG_MCLK_DIV, 0x02))   return false;
-    if (!W(REG_LRCK_DIV_H, 0x01)) return false;
-    if (!W(REG_LRCK_DIV_L, 0x00)) return false;
-    if (!W(REG_OSR, 0x20))        return false;
-    // Mode: slave, normal phase.
-    if (!W(REG_MODE, 0x14))       return false;
-    // Digital power: enable ADC channel 1 only.
-    if (!W(REG_DIGI_PWR, 0x00))   return false;
+    // HPF defaults for both ADC pairs ("quick setup" values from the
+    // reference driver -- enables HPF, reasonable cutoff).
+    if (!W(REG_ADC12_HPF2, 0x2A)) return false;
+    if (!W(REG_ADC12_HPF1, 0x0A)) return false;
+    if (!W(REG_ADC34_HPF2, 0x0A)) return false;
+    if (!W(REG_ADC34_HPF1, 0x2A)) return false;
 
-    // Serial port: I2S, 16-bit, MSB first.
-    // 0x11 = [7:4 word len][3:0 fmt]. Word len 16-bit = 0b0011, fmt I2S = 0b0000.
-    if (!W(REG_SDP_FMT, 0x30))    return false;
-    // LRCK active high, BCLK normal phase.
-    if (!W(REG_SDP_LRCK, 0x00))   return false;
+    // Slave mode: ESP32 drives MCLK / BCLK / LRCK. Bit 0 = master enable.
+    if (!U(REG_MODE_CONFIG, 0x01, 0x00)) return false;
 
-    // Auto-mute disabled, digital volume = 0 dB.
-    if (!W(REG_ADC_AUTOMUTE, 0x00)) return false;
-    if (!W(REG_ADC_DIGI_VOL, 0xC0)) return false;  // 0xC0 = 0 dB after lookup table
+    // Analog power up + MIC bias rails. Skipping this register (it sits
+    // at 0x40, NOT 0x3F) is what kept the previous version of this code
+    // silent -- the analog front-end stayed in default power-down and
+    // the ADC streamed zeros. 0xC3 (bit 7 set = internal regulator
+    // enabled) is what LilyGo's own T-Deck example uses; esp-adf's
+    // 0x43 leaves the regulator off and the codec runs dry on this
+    // board even though I2C still ACKs.
+    if (!W(REG_ANALOG_PWR, 0xC3)) return false;
+    if (!W(REG_MIC12_BIAS, 0x70)) return false;  // 2.87 V bias for MIC1/2
+    if (!W(REG_MIC34_BIAS, 0x70)) return false;
 
-    // Analog power on (full chip), enable MIC1+MIC2 PGAs and bias.
-    if (!W(REG_ANA_PWR,   0x00)) return false;
-    if (!W(REG_MIC12_PWR, 0x00)) return false;
-    if (!W(REG_MIC34_PWR, 0xFF)) return false;  // MIC3/4 off (T-Deck has 1 mic)
-    if (!W(REG_MIC1_BIAS, 0x08)) return false;  // ~2.6V bias for the MEMS element
-    if (!W(REG_MIC2_BIAS, 0x08)) return false;
+    // Clocking for 16 kHz with MCLK = 256*fs = 4.096 MHz, sourced from
+    // the ESP32 I2S APLL. Values from coeff_div[] in esp-adf for
+    // {mclk=4_096_000, lrck=16_000}: adc_div=1, doubler=1, dll=1,
+    // osr=0x20, lrckh=1, lrckl=0 (LRCK divider = 256).
+    if (!W(REG_OSR, 0x20))     return false;
+    // MAINCLK: dll<<7 | doubler<<6 | adc_div. Esp-adf's coefficient
+    // table uses 0xC1 (doubler ON) for {MCLK=4.096 MHz, LRCK=16 kHz}
+    // but on this board that produces LRCK ~= 7.4 kHz. Clearing the
+    // doubler bit (0x81) gives the correct 16 kHz LRCK.
+    if (!W(REG_MAINCLK, 0x81)) return false;
+    if (!W(REG_LRCK_DIVH, 0x01)) return false;
+    if (!W(REG_LRCK_DIVL, 0x00)) return false;
 
-    uint8_t pga = pga_step_for_db(gain_db);
-    if (!W(REG_MIC1_GAIN, 0x10 | pga)) return false;
-    if (!W(REG_MIC2_GAIN, 0x10 | pga)) return false;
-    if (!W(REG_MIC1_PGA, 0x00))        return false;
-    if (!W(REG_MIC2_PGA, 0x00))        return false;
+    // Serial port: I2S format (bits[1:0]=00), 16-bit word length
+    // (bits[7:5]=011). The earlier 0x30 value misread the layout as
+    // a 4+4 split and ended up selecting a wider word length, which
+    // bit-slipped against the I2S RX's 16-bit framing.
+    if (!W(REG_SDP_INTERFACE1, 0x60)) return false;
+    // TDM mode (0x02): time-multiplex all four ADCs onto SDOUT2,
+    // which is the codec data pin actually wired to GPIO 14 on
+    // T-Deck Plus. Non-TDM puts ADC1/2 on SDOUT1 (unconnected on
+    // this board) and ADC3/4 on SDOUT2, but empirically MIC3/MIC4
+    // produce no signal here, so we use TDM and pick MIC1's slot
+    // out of the TDM stream in capture_task.
+    if (!W(REG_SDP_INTERFACE2, 0x02)) return false;
 
-    (void)sample_rate;  // currently fixed by the dividers above
+    // Digital power up (clear power-down mask).
+    if (!W(REG_POWER_DOWN, 0x00)) return false;
+
+    // Per-channel analog power: 0x00 = fully powered.
+    if (!W(REG_MIC1_POWER, 0x00)) return false;
+    if (!W(REG_MIC2_POWER, 0x00)) return false;
+    if (!W(REG_MIC3_POWER, 0x00)) return false;
+    if (!W(REG_MIC4_POWER, 0x00)) return false;
+
+    // Ungate all four ADC clocks so the TDM stream has every slot
+    // filled.
+    if (!W(REG_CLOCK_OFF, 0x00))   return false;
+    if (!W(REG_MIC12_POWER, 0x00)) return false;
+    if (!W(REG_MIC34_POWER, 0x00)) return false;
+
+    // PGAs all enabled at the user-requested gain. The capture task
+    // only keeps MIC1's slot but enabling the others fills the rest
+    // of the TDM frame so BCLK timing stays correct.
+    uint8_t gain_step = pga_step_for_db(gain_db);
+    if (!W(REG_MIC1_GAIN, 0x10 | gain_step)) return false;
+    if (!W(REG_MIC2_GAIN, 0x10 | gain_step)) return false;
+    if (!W(REG_MIC3_GAIN, 0x10 | gain_step)) return false;
+    if (!W(REG_MIC4_GAIN, 0x10 | gain_step)) return false;
+
+    (void)sample_rate;  // clock dividers above are fixed for 16 kHz
     return true;
 }
 
 bool i2s_rx_install(uint32_t sample_rate) {
-    i2s_config_t cfg = {
-        .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX),
-        .sample_rate = sample_rate,
-        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
-        .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
-        .communication_format = I2S_COMM_FORMAT_STAND_I2S,
-        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
-        .dma_buf_count = 4,
-        .dma_buf_len = 512,
-        .use_apll = true,
-        .tx_desc_auto_clear = false,
-        .fixed_mclk = (int)(sample_rate * 256),
-    };
+    // I2S RX config for ES7210 in TDM mode. The codec packs its ADC
+    // channels onto SDOUT2 (the line wired to GPIO 14 on T-Deck Plus
+    // -- SDOUT1 is unconnected, which is why non-TDM mode produced
+    // all-zero recordings). We capture two TDM channels: CH0 = MIC1
+    // (the on-board MEMS element) and CH1 = MIC2 (unused on this
+    // board). The capture_task discards CH1 and writes CH0 as mono
+    // PCM. This matches the I2S config in LilyGo's own T-Deck mic
+    // example (examples/Microphone).
+    i2s_config_t cfg = {};
+    cfg.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX);
+    cfg.sample_rate = sample_rate;
+    cfg.bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT;
+    cfg.channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT;
+    cfg.communication_format = I2S_COMM_FORMAT_STAND_I2S;
+    cfg.intr_alloc_flags = ESP_INTR_FLAG_LEVEL1;
+    cfg.dma_buf_count = 8;
+    cfg.dma_buf_len = 64;
+    cfg.use_apll = false;
+    cfg.tx_desc_auto_clear = false;
+    cfg.fixed_mclk = 0;
+    cfg.mclk_multiple = I2S_MCLK_MULTIPLE_256;
+    cfg.bits_per_chan = I2S_BITS_PER_CHAN_16BIT;
+    // Standard stereo I2S (not TDM) -- the codec is in non-TDM mode
+    // driving 2 channels on SDOUT2.
     esp_err_t err = i2s_driver_install(kRxPort, &cfg, 0, nullptr);
     if (err != ESP_OK) {
         Serial.printf("[Mic] I2S install failed: %d\n", err);
@@ -240,16 +321,45 @@ static void capture_task(void* arg) {
         return;
     }
 
+    // De-interleave scratch: i2s_read returns 2 interleaved channels
+    // (CH0 + CH1) at 16-bit each = 4 bytes per LRCK frame. We keep
+    // CH0 (which carries the on-board mic signal in TDM mode) and
+    // pack consecutive frames into a mono 16-bit stream.
+    int16_t mono[kBufBytes / 4];
+
+    // Discard a warm-up window before we start writing samples to the
+    // file. The I2S driver pre-fills its DMA buffers with zeros in
+    // i2s_zero_dma_buffer, and the codec needs a few ms to start
+    // producing real samples after MCLK comes up -- without this,
+    // the first ~100 ms of every recording is the zeroed DMA buffer
+    // being drained, which the user hears as the start of their
+    // utterance being clipped.
+    size_t warmup_bytes_remaining = sess->sample_rate / 10 * 4;  // ~100 ms
+
     bool auto_stopped = false;
     while (!sess->stop_requested) {
         size_t bytes_read = 0;
         esp_err_t err = i2s_read(kRxPort, buf, kBufBytes, &bytes_read, pdMS_TO_TICKS(100));
-        if (err == ESP_OK && bytes_read > 0) {
-            size_t w = sess->file.write(buf, bytes_read);
+        if (err == ESP_OK && bytes_read >= 4) {
+            if (warmup_bytes_remaining > 0) {
+                size_t drop = bytes_read < warmup_bytes_remaining ? bytes_read : warmup_bytes_remaining;
+                warmup_bytes_remaining -= drop;
+                if (drop == bytes_read) continue;
+                // partial warm-up consumed: keep the tail of this read
+                memmove(buf, buf + drop, bytes_read - drop);
+                bytes_read -= drop;
+            }
+            int16_t* s16 = reinterpret_cast<int16_t*>(buf);
+            size_t frames = bytes_read / 4;
+            for (size_t f = 0; f < frames; ++f) {
+                mono[f] = s16[f * 2];  // CH0
+            }
+            size_t mono_bytes = frames * 2;
+            size_t w = sess->file.write(reinterpret_cast<uint8_t*>(mono), mono_bytes);
             sess->data_bytes += (uint32_t)w;
-            if (w != bytes_read) {
+            if (w != mono_bytes) {
                 Serial.printf("[Mic] short write: wrote %u of %u\n",
-                              (unsigned)w, (unsigned)bytes_read);
+                              (unsigned)w, (unsigned)mono_bytes);
                 break;
             }
         }
@@ -387,28 +497,41 @@ int16_t* capture_buffer(uint32_t duration_ms, const RecordOpts& opts,
     if (!codec_init(opts.sample_rate, opts.gain_db)) return nullptr;
     if (!i2s_rx_install(opts.sample_rate)) return nullptr;
 
+    // i2s_read returns 2-channel interleaved data (CH0 = MIC1, CH1 =
+    // MIC2). Allocate enough space for the user-requested duration of
+    // mono PCM, plus a scratch staging buffer for the raw stereo
+    // stream we have to de-interleave from.
     size_t total_samples = (opts.sample_rate * duration_ms) / 1000;
     size_t total_bytes = total_samples * 2;
-    int16_t* buf = (int16_t*)ps_malloc(total_bytes);
-    if (!buf) {
+    int16_t* mono = (int16_t*)ps_malloc(total_bytes);
+    if (!mono) {
+        i2s_rx_uninstall();
+        return nullptr;
+    }
+    uint8_t* raw = (uint8_t*)heap_caps_malloc(1024, MALLOC_CAP_DMA);
+    if (!raw) {
+        free(mono);
         i2s_rx_uninstall();
         return nullptr;
     }
 
-    size_t written = 0;
-    while (written < total_bytes) {
+    size_t mono_written = 0;
+    while (mono_written < total_bytes) {
         size_t got = 0;
-        size_t want = total_bytes - written;
-        if (want > 1024) want = 1024;
-        esp_err_t err = i2s_read(kRxPort, (uint8_t*)buf + written, want,
-                                 &got, pdMS_TO_TICKS(200));
+        esp_err_t err = i2s_read(kRxPort, raw, 1024, &got, pdMS_TO_TICKS(200));
         if (err != ESP_OK || got == 0) break;
-        written += got;
+        int16_t* s16 = reinterpret_cast<int16_t*>(raw);
+        size_t frames = got / 4;
+        for (size_t f = 0; f < frames && mono_written < total_bytes; ++f) {
+            mono[mono_written / 2] = s16[f * 2];  // CH0
+            mono_written += 2;
+        }
     }
 
+    free(raw);
     i2s_rx_uninstall();
-    if (out_size) *out_size = written;
-    return buf;
+    if (out_size) *out_size = mono_written;
+    return mono;
 }
 
 }  // namespace mic

--- a/src/audio/mic.h
+++ b/src/audio/mic.h
@@ -1,0 +1,66 @@
+// Onboard microphone capture for T-Deck Plus.
+//
+// The T-Deck Plus routes a MEMS mic through an Everest ES7210 ADC codec.
+// The codec is I2C-controlled on the same bus as the keyboard / touch
+// controller (SDA=GPIO18, SCL=GPIO8, address 0x40) and clocks an I2S
+// stream out on a separate set of pins (MCLK=48, BCLK=47, LRCK=21,
+// DIN=14, on I2S_NUM_1) so the speaker on I2S_NUM_0 keeps working
+// untouched.
+//
+// API is intentionally narrow: start_recording() opens a WAV on the SD
+// card and primes a background task that pumps I2S RX -> file. Caller
+// gets a `MicSession*` handle back; stop_recording() finalises the WAV
+// (RIFF/data chunk sizes) and tears the task down. capture_buffer() is
+// for short clips that fit comfortably in RAM -- it returns the raw
+// little-endian PCM as a Lua string without ever touching the SD.
+//
+// Why a background task instead of pumping I2S inline: SD writes can
+// stall for tens of milliseconds when the FAT layer flushes, and we
+// don't want the Lua main loop to block on that. The task lives in
+// PSRAM-friendly heap and exits as soon as stop_recording fires.
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+namespace ezos {
+namespace mic {
+
+struct RecordOpts {
+    uint32_t sample_rate;   // Hz, e.g. 16000
+    uint8_t  bits;          // 16 only for now
+    uint8_t  gain_db;       // 0..36 mic PGA gain
+};
+
+// Opaque to callers; defined in mic.cpp.
+struct MicSession;
+
+// Probe the codec over I2C. Safe to call before recording -- returns
+// true if the ES7210 ACKs at its expected address, false otherwise
+// (e.g. unpopulated board, wiring fault).
+bool probe();
+
+// Start streaming PCM to `wav_path`. Path is a real filesystem path
+// (e.g. "/recordings/clip.wav" on the SD card mount). Returns the
+// session handle on success, nullptr if anything failed (I2C nack,
+// I2S install error, file open error). On nullptr return, no resources
+// are left held -- safe to retry.
+MicSession* start_recording(const char* wav_path, const RecordOpts& opts);
+
+// Stop streaming and finalise the WAV header. After this returns the
+// session handle is no longer valid. `out_bytes_written` (optional)
+// gets the number of PCM bytes actually committed.
+bool stop_recording(MicSession* session, uint32_t* out_bytes_written = nullptr);
+
+// True while a session is active.
+bool is_recording();
+
+// Capture `duration_ms` of mono PCM into a freshly-allocated buffer.
+// On success returns a malloc'd buffer (caller frees) and writes the
+// size in bytes into *out_size. Returns nullptr on error.
+int16_t* capture_buffer(uint32_t duration_ms, const RecordOpts& opts,
+                        size_t* out_size);
+
+}  // namespace mic
+}  // namespace ezos

--- a/src/lua/bindings/audio_bindings.cpp
+++ b/src/lua/bindings/audio_bindings.cpp
@@ -5,6 +5,7 @@
 #include "../../config.h"
 #include "../../audio/synth.h"
 #include "../../audio/mic.h"
+#include "bus_bindings.h"
 #include <Arduino.h>
 #include <driver/i2s.h>
 #include <cmath>
@@ -1358,5 +1359,26 @@ static const luaL_Reg audio_funcs[] = {
 // Register the audio module
 void registerAudioModule(lua_State* L) {
     lua_register_module(L, "audio", audio_funcs);
+
+    // The capture task self-terminates when it hits the 5-minute
+    // safety cap; it can't finalise the WAV / I2S itself without
+    // racing the Lua main loop. It posts "audio/recording_overflow"
+    // instead, and we handle the teardown here on the main loop --
+    // same code path the user-facing stop_record() takes, so both
+    // g_session (mic.cpp) and g_record_session (this file) end up
+    // cleared together. Without this, an auto-stopped session would
+    // leave is_recording() pinned at true and the WAV header
+    // un-patched until reboot.
+    MessageBus::instance().subscribeCpp("audio/recording_overflow",
+        [](lua_State*, const std::string&) {
+            if (!g_record_session) return;
+            uint32_t bytes = 0;
+            ezos::mic::stop_recording(g_record_session, &bytes);
+            g_record_session = nullptr;
+            // Post a second event so any Lua screen showing a
+            // "Recording... N s" indicator can refresh its UI.
+            MessageBus::instance().post("audio/recording_stopped", "overflow");
+        });
+
     Serial.println("[LuaRuntime] Registered ez.audio");
 }

--- a/src/lua/bindings/audio_bindings.cpp
+++ b/src/lua/bindings/audio_bindings.cpp
@@ -4,6 +4,7 @@
 #include "../lua_bindings.h"
 #include "../../config.h"
 #include "../../audio/synth.h"
+#include "../../audio/mic.h"
 #include <Arduino.h>
 #include <driver/i2s.h>
 #include <cmath>
@@ -1168,6 +1169,166 @@ LUA_FUNCTION(l_audio_unload) {
     return 0;
 }
 
+// ---- Microphone recording ----
+//
+// The recording session is process-global (see audio/mic.cpp). Only
+// one of record() / record_buffer() can be active at a time -- both
+// return false / nil if a session is already open. Stop with
+// stop_record() before starting a new one.
+
+static ezos::mic::MicSession* g_record_session = nullptr;
+
+// @lua ez.audio.mic_available() -> boolean
+// @brief Check whether the onboard ES7210 microphone is reachable
+// @description Pings the codec over I2C and returns true if it
+// acknowledges. Useful for hiding recording UI on boards that don't
+// have the microphone populated (or for diagnosing wiring faults).
+// Does not change any state; safe to call before or during a recording
+// session.
+// @return true if the codec responded
+// @example
+// if not ez.audio.mic_available() then
+//     print("No mic on this device")
+// end
+// @end
+LUA_FUNCTION(l_audio_mic_available) {
+    lua_pushboolean(L, ezos::mic::probe());
+    return 1;
+}
+
+// @lua ez.audio.record(path, opts) -> boolean
+// @brief Start streaming WAV recording to a file
+// @description Opens `path` (typically under /sd/recordings/) and
+// streams 16-bit mono PCM from the onboard MEMS microphone into a
+// WAV file. Recording continues until you call ez.audio.stop_record()
+// or the 5-minute safety cap fires. Only one recording can be active
+// at a time. Returns false if the mic isn't present, the file can't
+// be opened, or a session is already running.
+// @param path Full filesystem path to the .wav file to create (e.g. "/sd/recordings/clip.wav")
+// @param opts Table { sample_rate = 16000, gain_db = 24 } -- both optional
+// @return true if recording started
+// @example
+// ez.audio.record("/sd/recordings/note.wav", { sample_rate = 16000, gain_db = 24 })
+// ez.system.delay(2000)
+// ez.audio.stop_record()
+// @end
+LUA_FUNCTION(l_audio_record) {
+    const char* path = luaL_checkstring(L, 1);
+
+    ezos::mic::RecordOpts opts{16000, 16, 24};
+    if (lua_istable(L, 2)) {
+        lua_getfield(L, 2, "sample_rate");
+        if (lua_isnumber(L, -1)) opts.sample_rate = (uint32_t)lua_tointeger(L, -1);
+        lua_pop(L, 1);
+        lua_getfield(L, 2, "gain_db");
+        if (lua_isnumber(L, -1)) opts.gain_db = (uint8_t)lua_tointeger(L, -1);
+        lua_pop(L, 1);
+    }
+
+    if (g_record_session) {
+        Serial.println("[Audio] record(): session already active");
+        lua_pushboolean(L, false);
+        return 1;
+    }
+
+    g_record_session = ezos::mic::start_recording(path, opts);
+    lua_pushboolean(L, g_record_session != nullptr);
+    return 1;
+}
+
+// @lua ez.audio.stop_record() -> integer | nil
+// @brief Finalise the active recording
+// @description Stops the streaming task started by ez.audio.record(),
+// patches the WAV header with the final size, and closes the file.
+// Returns the number of PCM bytes captured, or nil if no recording
+// was active.
+// @return Number of PCM bytes written, or nil if not recording
+// @example
+// local bytes = ez.audio.stop_record()
+// if bytes then print(string.format("captured %d bytes", bytes)) end
+// @end
+LUA_FUNCTION(l_audio_stop_record) {
+    if (!g_record_session) {
+        lua_pushnil(L);
+        return 1;
+    }
+    uint32_t bytes = 0;
+    bool ok = ezos::mic::stop_recording(g_record_session, &bytes);
+    g_record_session = nullptr;
+    if (!ok) {
+        lua_pushnil(L);
+        return 1;
+    }
+    lua_pushinteger(L, (lua_Integer)bytes);
+    return 1;
+}
+
+// @lua ez.audio.is_recording() -> boolean
+// @brief Check whether a recording is currently active
+// @description Returns true between ez.audio.record() and
+// ez.audio.stop_record(). Useful for screens that want to show a
+// recording indicator or block other audio operations while the mic
+// is busy.
+// @return true if recording
+// @example
+// while ez.audio.is_recording() do
+//     ez.system.delay(50)
+// end
+// @end
+LUA_FUNCTION(l_audio_is_recording) {
+    lua_pushboolean(L, g_record_session != nullptr);
+    return 1;
+}
+
+// @lua ez.audio.record_buffer(duration_ms, opts) -> string | nil
+// @brief Capture a short PCM clip into a Lua string
+// @description Blocks for `duration_ms` while capturing 16-bit mono
+// PCM from the microphone, then returns the raw little-endian PCM as
+// a Lua string. Use this for short clips (a few seconds at most) that
+// fit comfortably in RAM; for longer recordings, use ez.audio.record()
+// which streams to a file. Returns nil if the mic isn't present or a
+// streaming recording is already active.
+// @param duration_ms Capture length in milliseconds
+// @param opts Optional table { sample_rate = 16000, gain_db = 24 }
+// @return Raw 16-bit LE PCM as a Lua string, or nil on error
+// @example
+// local pcm = ez.audio.record_buffer(500, { sample_rate = 16000 })
+// if pcm then print(#pcm, "bytes captured") end
+// @end
+LUA_FUNCTION(l_audio_record_buffer) {
+    int duration_ms = luaL_checkinteger(L, 1);
+    if (duration_ms <= 0 || duration_ms > 30000) {
+        lua_pushnil(L);
+        return 1;
+    }
+
+    ezos::mic::RecordOpts opts{16000, 16, 24};
+    if (lua_istable(L, 2)) {
+        lua_getfield(L, 2, "sample_rate");
+        if (lua_isnumber(L, -1)) opts.sample_rate = (uint32_t)lua_tointeger(L, -1);
+        lua_pop(L, 1);
+        lua_getfield(L, 2, "gain_db");
+        if (lua_isnumber(L, -1)) opts.gain_db = (uint8_t)lua_tointeger(L, -1);
+        lua_pop(L, 1);
+    }
+
+    if (g_record_session) {
+        lua_pushnil(L);
+        return 1;
+    }
+
+    size_t bytes = 0;
+    int16_t* buf = ezos::mic::capture_buffer((uint32_t)duration_ms, opts, &bytes);
+    if (!buf || bytes == 0) {
+        if (buf) free(buf);
+        lua_pushnil(L);
+        return 1;
+    }
+    lua_pushlstring(L, reinterpret_cast<const char*>(buf), bytes);
+    free(buf);
+    return 1;
+}
+
 // Function table for ez.audio
 static const luaL_Reg audio_funcs[] = {
     {"play",          l_audio_play},
@@ -1186,6 +1347,11 @@ static const luaL_Reg audio_funcs[] = {
     {"start",         l_audio_start},
     {"set_volume",    l_audio_set_volume},
     {"get_volume",    l_audio_get_volume},
+    {"mic_available", l_audio_mic_available},
+    {"record",        l_audio_record},
+    {"stop_record",   l_audio_stop_record},
+    {"is_recording",  l_audio_is_recording},
+    {"record_buffer", l_audio_record_buffer},
     {nullptr, nullptr}
 };
 

--- a/src/lua/bindings/audio_bindings.cpp
+++ b/src/lua/bindings/audio_bindings.cpp
@@ -679,8 +679,27 @@ LUA_FUNCTION(l_audio_play_wav) {
             srcPos += 1.0f / resampleRatio;
         }
 
-        // Adjust source position for next chunk
-        srcPos -= srcSamples;
+        // Carry over to the next chunk. If playBuf saturated before we
+        // walked through all source samples (true whenever the input
+        // rate is well below SAMPLE_RATE -- e.g. 16 kHz voice notes
+        // upsampled 2.76x to 44.1 kHz produce ~706 output samples per
+        // 256 input samples but playBuf only fits 512), rewind the
+        // file by the unread bytes so the next read starts where this
+        // chunk stopped consuming. Keep just the fractional part of
+        // srcPos for accurate sub-sample tracking. The previous code
+        // unconditionally did srcPos -= srcSamples, which on 16 kHz
+        // input drove srcPos negative and turned `src16[srcIdx]` into
+        // an out-of-bounds read of nearby heap -- the "electrical
+        // glitch" sound users heard when playing recorded voice notes.
+        int srcConsumed = (int)srcPos;
+        if (srcConsumed > srcSamples) srcConsumed = srcSamples;
+        int unusedSamples = srcSamples - srcConsumed;
+        if (unusedSamples > 0) {
+            size_t unusedBytes = (size_t)unusedSamples * bytesPerSample;
+            file.seek(file.position() - unusedBytes);
+            bytesRemaining += unusedBytes;
+        }
+        srcPos -= srcConsumed;
 
         // Write to I2S
         if (playPos > 0) {


### PR DESCRIPTION
## Summary

Closes #88. Adds capture support for the T-Deck Plus's MEMS microphone (routed through an Everest ES7210 codec on I2C 0x40), wires it up as I2S RX on `I2S_NUM_1` (separate from the existing speaker on `I2S_NUM_0`), and ships a small voice-notes app that records WAV clips to `/sd/recordings/`.

### What's in here

**Driver (`src/audio/mic.{h,cpp}`)**
- ES7210 register-level init for slave-mode I2S, 16-bit, 16 kHz, 1 channel from MIC1, MCLK = 256·fs driven by the ESP32 I2S APLL.
- `I2S_NUM_1` RX install on pins MCLK=48 / BCLK=47 / LRCK=21 / DIN=14 (the pins were already declared in `src/config.h`).
- A FreeRTOS task pumps I2S RX → WAV file on a dedicated core so SD flushes don't stall the Lua main loop. 5-minute hard cap to keep a forgotten `stop_record()` from filling the card.
- Streaming WAV writer: placeholder RIFF/data headers go down first, sizes patched on stop.

**Lua bindings (`ez.audio.*`)**
- `mic_available()` — probe the codec without touching state
- `record(path, opts)` — start streaming a `.wav` on the SD card; `opts = { sample_rate = 16000, gain_db = 24 }`
- `stop_record()` — returns bytes written; finalises the header
- `is_recording()` — true between start/stop
- `record_buffer(duration_ms, opts)` — short clip as raw PCM Lua string (for callers that don't want to touch disk)

**Voice notes screen (`lua/screens/tools/voice_notes.lua`)**
- Lists clips in `/sd/recordings/`, sorted newest-first by filename timestamp.
- Live "Recording... N s" indicator (rebuilds twice a second so the timer counts up).
- ENTER toggles record from idle, stops it while recording; **alt+R** also toggles for keyboard-only users.
- M opens per-clip Play / Delete actions.
- Listed under Apps → "Voice notes" (`icons.volume`, since there's no `mic` icon yet).

**MIC side key**
- The `KEY_MIC` plumbing through `SpecialKey::MIC` was already in the firmware but unbound. A global subscriber in `lua/boot.lua` opens the voice-notes screen when the MIC key is pressed from anywhere; the screen itself takes over the key locally (toggles record) once it's on top.

**Docs**
- New manual page `lua/docs/manual/voice-notes.md` (embedded in firmware, surfaces in the on-device Help app).
- Auto-generated API page picks up the five new bindings from the `@lua` annotations.

### Out of scope / explicit follow-ups
Carried forward from #88's "out of scope" list — none of these are touched here:
- Voice messages over MeshCore (compression + chunking)
- VAD / voice-activated recording
- Multi-channel capture
- Speech recognition

### Test plan
- [x] `pio run` — clean build, RAM 26.2%, flash 58.2%.
- [x] `pio run -t upload` — flashed to T-Deck Plus on `/dev/ttyACM0`.
- [x] `ez.audio.mic_available()` returns `true` (ES7210 ACKs on I2C 0x40).
- [x] `ez.audio.record(...)` for ~2 s → 64,512 bytes captured at 31 kB/s (= 16 kHz × 2 B). Sample rate is correct.
- [x] `ez.audio.play_wav(path)` plays the recorded clip back through the speaker — speaker path on `I2S_NUM_0` is unaffected.
- [x] `ez.audio.play_tone(880, 200)` still works after a recording.
- [x] Voice notes screen: Record button → live timer → ENTER stops → clip appears in the list with size label.
- [x] M-key context menu (Play / Delete) opens on the focused clip.
- [x] BACKSPACE / back-arrow exits to the menu.
- [ ] MIC side key — wired but not exercised on hardware yet; works through the same code path as the test bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)