### PR TITLE
chore(claude): add /next, /work-issue, /autopilot skills

### DIFF
--- a/.claude/skills/autopilot/SKILL.md
+++ b/.claude/skills/autopilot/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: autopilot
+description: Loop through eligible open GitHub issues, ship one PR per issue from a dedicated git worktree off `test`, and only stop on user interrupt, no eligible issues, or repeated hard failures. Use when the user says "keep shipping issues", "work the queue", "autopilot", or anything that asks Claude to make autonomous progress across the backlog.
+---
+
+# Goal
+
+Ship one PR per eligible open issue, in a loop, without per-issue confirmation. Use git worktrees so each issue gets a clean isolated branch and the user's main checkout stays untouched.
+
+The companion `/work-issue` skill is what runs *inside* the loop — re-read it for the per-issue conventions (conventional commits, `pio run` gate, PR against `test`, `Closes #N` line, on-device verification caveats).
+
+# Boundaries
+
+- **Don't ask between issues.** A clean PR-per-issue cadence is the point. Reserve `AskUserQuestion` for genuine blockers on a single issue.
+- **When blocked, skip — don't stall.** Log the reason, skip, continue. Surface the skip list at the end.
+- **Never merge.** PRs land for the user to review.
+- **Never push to `main`** (this repo uses `test` as the integration branch — `main` is release-only). Never delete a worktree the user might be inspecting.
+- **Hardware verification is the user's job in batch mode.** The agent can't reliably share `/dev/ttyACM0` with the user across many issues. Build cleanly with `pio run`; surface "needs hardware QA" in every PR's test plan.
+
+# Setup (run once at start)
+
+1. **Pre-flight in the main checkout:**
+   ```
+   git status                           # must be clean
+   git rev-parse --abbrev-ref HEAD      # must be test
+   git fetch origin test
+   git pull --ff-only
+   ```
+   If the working tree is dirty or HEAD isn't `test`, stop and tell the user.
+
+2. **Ensure `.worktrees/` is git-ignored:**
+   ```
+   grep -q '^\.worktrees/$' .gitignore || echo '.worktrees/' >> .gitignore
+   ```
+   If you added the line, commit it on `test` (`chore: ignore .worktrees/`) and push before starting the loop.
+
+3. **List candidates:**
+   ```
+   gh issue list --state open --limit 100 \
+     --json number,title,body,labels,assignees
+   ```
+   Filter out here (cheap):
+   - Has any non-bot assignee.
+   - Labels: `wontfix`, `duplicate`, `invalid`, `question`.
+   - Body is empty or a one-line headline with no scope.
+
+   The "is there already a PR?" check is **per-issue**, immediately before claiming the worktree (state changes during the run).
+
+4. **Show the user the queue.** Numbered list, titles only, with the count. No confirmation needed; visibility only.
+
+# Per-issue procedure
+
+For each candidate `<N>` (ascending by issue number unless the user named another order):
+
+0. **Re-check claimability** — right before the worktree, every time:
+   - **Open + unassigned:**
+     ```
+     gh issue view <N> --json state,assignees
+     ```
+     Skip if `state != OPEN` or `assignees` contains a non-bot user.
+   - **No claiming PR:**
+     ```
+     gh pr list --search "<N> in:body" --state all --limit 20 \
+       --json number,state,headRefName,body | \
+       jq --argjson n <N> '[.[] | select((.body // "") | test("(?i)(closes|fixes|resolves)\\s+#\($n)([^0-9]|$)"))]'
+     ```
+     Skip if non-empty.
+   - **No claiming branch:**
+     ```
+     git ls-remote --heads origin "*/issue-<N>-*"
+     ```
+     Skip if anything comes back.
+
+1. **Type prefix + slug.** Read the issue's title and body:
+   - `<type>` from the title prefix if present (`feat(...)`, `fix(...)`, `docs:`), else infer (`bug` label → `fix`; `enhancement` → `feat`; doc-shaped issue → `docs`).
+   - `<slug>` = 2-4 hyphenated words from the title.
+
+2. **Worktree off `test`:**
+   ```
+   git worktree add .worktrees/issue-<N>-<slug> -b <type>/issue-<N>-<slug> origin/test
+   ```
+   If the branch already exists locally or remotely, skip (race; someone else picked it up).
+
+3. **All subsequent commands run with cwd = `.worktrees/issue-<N>-<slug>`** (absolute path under that directory, or `cd` in compound commands).
+
+4. **Run the work-issue flow non-interactively.** Same steps as `/work-issue` but without the surface-the-plan pause:
+   - Read the issue body + comments.
+   - Plan against CLAUDE.md silently.
+   - Implement. Watch the recurring gotchas: no Ctrl/Esc keybindings, ASCII-only on default fonts, no `lua_State*` storage across calls, no `pio device monitor`, no public-channel sends.
+   - `pio run` must pass clean before commit.
+   - Conventional-commit message via heredoc (the `commit-msg` hook rejects anything else).
+   - `git push -u origin <type>/issue-<N>-<slug>`.
+   - `gh pr create --base test --title "<type>(<scope>): ..." --body "..."`. The body must contain `Closes #<N>` and a test plan with an explicit "needs hardware QA" checkbox un-checked (the loop doesn't flash).
+
+5. **On hard failure for the issue:**
+   - Don't commit junk; reset uncommitted state in the worktree.
+   - Record `#<N>: skipped — <reason>` in the skip list.
+   - Continue to the next issue.
+
+6. **Return to the main checkout** before starting the next issue. Do **not** delete the worktree — the user may want to inspect or keep iterating on a PR. Worktrees pile up under `.worktrees/`; the user removes them with `git worktree remove .worktrees/issue-<N>-<slug>` when done.
+
+# Stop conditions
+
+End the loop and print the final report when **any** of these hits:
+
+- No eligible issues left.
+- User sends an interrupt or message — abandon the in-flight issue's *uncommitted* work, leave any opened PR alone, exit cleanly.
+- **2 consecutive hard failures.** Two skips in a row signals something systemic (network, broken `test`, expired auth). Stop and tell the user.
+- PRs opened ≥ 5 in one run. Soft cap to keep the user's review-and-flash queue manageable; mention it in the report and let them re-invoke if they want more.
+
+# When to ask the user
+
+Use `AskUserQuestion` **only** if all three are true:
+
+- The issue is unworkable without a decision Claude can't make alone.
+- A skip would lose information the user would want surfaced *now*, not at the end.
+- The decision unblocks more than one issue (otherwise just skip + log).
+
+Default behavior is **skip + log**, not **ask + wait**.
+
+# Output
+
+While running, after each issue: one line — `#<N>: opened PR #<M>` or `#<N>: skipped — <reason>`.
+
+Final report (under 200 words):
+
+- **Opened** — bullet per PR with issue number, PR number, title, branch.
+- **Skipped** — bullet per issue with one-line reason.
+- **Worktrees left behind** — paths under `.worktrees/`. Remind the user: `git worktree remove .worktrees/<dir>` when each PR is dealt with.
+- **Reminder** — "Each PR needs hardware QA — `pio run -t upload` from the worktree and verify."
+- **Next** — if the loop hit a soft cap or repeated failure, name the suspected cause; if it ran the queue dry, say so.
+
+# Don't
+
+- Don't run from a dirty checkout or a branch that isn't `test`.
+- Don't merge PRs, don't force-push, don't delete worktrees.
+- Don't pause between issues asking "should I continue?". The loop is the point.
+- Don't open a PR with the `Closes #<N>` line missing.
+- Don't `--no-verify` the commit-msg hook to slip a non-conforming message through.
+- Don't claim hardware verification you didn't do — leave the QA checkbox un-checked.

--- a/.claude/skills/next/SKILL.md
+++ b/.claude/skills/next/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: next
+description: Survey open GitHub issues on the ezOS repo, recommend one concrete issue to work on next (with 2-3 runners-up), and offer to hand off to `/work-issue`. Use when the user says "what's next", "what should I work on", "pick something", or any other prioritisation question.
+---
+
+# Goal
+
+Recommend ONE concrete issue. Don't dump raw command output — synthesise. Hand the user a decision they can make in five seconds.
+
+# Signals to gather
+
+Run in parallel:
+
+1. **Open issues:**
+   ```
+   gh issue list --state open --limit 50 \
+     --json number,title,body,labels,assignees,createdAt,comments
+   ```
+
+2. **Filter out** before scoring:
+   - Has any non-bot assignee.
+   - Has a linked open PR (search PR bodies for `closes|fixes|resolves #<N>`):
+     ```
+     gh pr list --state open --search "<N> in:body" --json number,body | \
+       jq --argjson n <N> 'any(.[]; (.body // "") | test("(?i)(closes|fixes|resolves)\\s+#\($n)([^0-9]|$)"))'
+     ```
+   - Labels: `wontfix`, `duplicate`, `invalid`, `question`. Those need a decision, not implementation.
+
+3. **Recent commits** — `git log --oneline -20` — so the recommendation builds on the current thread rather than context-switching.
+
+# Prioritisation
+
+Prefer issues that:
+- Match the area the user just worked in (commits / labels overlap).
+- Are well-scoped (clear acceptance criteria in the body, ≤3 days of work).
+- Unblock other work (foundations, shared widgets, services touched by other open issues).
+- Have `good first issue` if the user is onboarding someone.
+
+Deprioritise:
+- Long-running architecture discussions (issues with >10 comments and no concrete proposal in the body).
+- Issues whose body is just a one-line headline and no specifics — they need scoping, not coding.
+- Anything mentioning hardware variants we don't have (some issues reference T-Deck *non-Plus*).
+
+# Output
+
+Under 300 words, in this shape:
+
+- **Recommendation** — one issue: number + title. One sentence on *what*, one sentence on *why now*. Cite the issue (`#42`) and any relevant commit / file path.
+- **Runners-up** — 2-3 alternates, one line each with citation.
+- **Survey** — counts only: open issues total, filtered out (assigned / has-PR / non-actionable), candidate pool size.
+
+# Next step — ask, don't tell
+
+After the report, call `AskUserQuestion` so the user picks without retyping anything:
+
+- "Work on `#<recommended>` (Recommended)" — invoke `/work-issue` with that number.
+- "Pick a runner-up" — follow up with another `AskUserQuestion` listing them, then invoke `/work-issue` on the chosen number.
+- "Run `/autopilot`" — start the batch loop instead.
+- "Not now" — stop and wait.
+
+# Don't
+
+- Don't pick an issue assigned to a human (even if PR-less).
+- Don't recommend an issue whose body reads as a discussion thread — those need scoping first.
+- Don't hide low-effort issues just because they're cosmetic; sometimes the best "next" is closing a small one to bank momentum.

--- a/.claude/skills/review-loop/SKILL.md
+++ b/.claude/skills/review-loop/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: review-loop
+description: Loop through open PRs assigned to (or authored by) the user, read the actionable review feedback on each, implement the concrete asks as new commits, and batch every ambiguous / judgment-needed item into a single set of questions at the end. Never force-pushes. Use when the user says "address my review feedback", "work my review queue", "fix my PR comments", or asks Claude to clear inbound review activity across their open PRs.
+---
+
+# Goal
+
+For each open PR the user owns (assigned or authored) with actionable review feedback, push a NEW commit that addresses it — without per-PR confirmation. One worktree per PR, mirroring `/autopilot`. The companion to `/autopilot`: that skill opens PRs, this one iterates on them.
+
+# Boundaries
+
+- **PRs the user owns.** Either `assignee == @me` or `author == @me`. Don't touch a stranger's branch.
+- **Never force-push.** Always add a NEW commit; never `--amend` pushed history; never `git push --force`/`--force-with-lease`.
+- **Never push to `main`.** This repo's release lane is `test → main` via a release commit; PRs in flight live on feature branches.
+- **Don't resolve review threads.** The reviewer marks them resolved when they re-review the new commit.
+- **Don't implement vague feedback.** "This could be cleaner" / "what do you think" / "interesting" — queue for the user, don't act.
+- **Default to skip-and-queue, not ask-and-wait.** The one exception is the after-loop batch (see "After the per-PR loop — questions for the user").
+
+# Setup (run once at start)
+
+1. **Pre-flight in the main checkout:**
+   ```
+   git status                          # must be clean
+   git fetch origin
+   ```
+   If the working tree is dirty, stop and ask the user. Don't auto-stash.
+
+2. **Ensure `.worktrees/` is git-ignored:**
+   ```
+   grep -q '^\.worktrees/$' .gitignore || echo '.worktrees/' >> .gitignore
+   ```
+   If you added the line, commit it on `test` (`chore: ignore .worktrees/`) before continuing.
+
+3. **List candidate PRs:**
+   ```
+   gh pr list --state open --limit 50 \
+     --search "assignee:@me OR author:@me" \
+     --json number,title,headRefName,baseRefName,author,assignees,reviewDecision,isDraft,mergeable,mergeStateStatus
+   ```
+   Drop drafts. Drop PRs whose `headRefName` matches a branch the user is currently checked out on locally — they're mid-iteration and would clash with worktree creation.
+
+4. **Per-candidate triage** — fetch the inputs that decide actionability:
+   ```
+   gh pr view <N> --json reviews,reviewRequests,comments,statusCheckRollup,headRefOid,mergeable,mergeStateStatus,baseRefName
+   gh api repos/{owner}/{repo}/pulls/<N>/comments      # inline review comments
+   gh api repos/{owner}/{repo}/pulls/<N>/files         # what the PR touches (to gauge feasibility)
+   ```
+   Mark a PR **actionable** if any of:
+
+   - **CHANGES_REQUESTED** review whose `commit_id` predates the PR's current `headRefOid`, body containing imperative cues ("change", "rename", "remove", "add", "fix", "use", "switch to", "drop", "split", "merge").
+   - **Inline review comment** with the same cues, not visibly addressed (thread unresolved, no commit after the comment's `created_at` touched the comment's `path`).
+   - **Failed CI** (`statusCheckRollup` entry with `conclusion == FAILURE`), only if the failure log points to a deterministic fix: build error (`pio run` failure with a concrete file:line), Lua syntax error, doc-generator failure, conventional-commit hook rejection. Skip flaky / network failures (timeout, ECONNRESET, esp32 toolchain 503).
+   - **Top-level PR comment** opening with an imperative ("please ...", "could you ...", "rename ...", "drop ...") authored after the PR's current `headRefOid` was pushed.
+   - `mergeable == "CONFLICTING"` (equivalently `mergeStateStatus == "DIRTY"`). `UNKNOWN` is not a trigger on its own; the per-PR step will probe locally.
+
+   If none hit, mark the PR **inactionable** (log `#<P>: skipped — no actionable feedback`).
+
+5. **Show the user the queue.** Numbered list of actionable PRs with `#<P>: <title>` and a one-line cue per PR. Call out conflicts explicitly when present (`2 inline asks; CI build red; conflicts vs test`). No confirmation needed; visibility only.
+
+# Per-PR procedure
+
+For each actionable PR `<P>` (ascending by PR number, cap at 5):
+
+0. **Re-check claimability.** State changes between triage and now (the user pushed a follow-up, the PR closed, a new review landed):
+   ```
+   gh pr view <P> --json state,headRefName,headRefOid,reviews,statusCheckRollup
+   ```
+   Skip if any of:
+   - `state != OPEN`.
+   - The `headRefOid` advanced since triage (the user or someone else pushed; their commit may already address the feedback).
+   - The branch has commits on `origin` that aren't on the PR's recorded head.
+
+1. **Worktree:**
+   ```
+   git fetch origin <head_ref>
+   git worktree add .worktrees/pr-<P>-<slug> -B <head_ref> origin/<head_ref>
+   ```
+   `<slug>` = 2-4 hyphenated words from the PR title. If the path already exists, skip the PR (a previous run is still being inspected).
+
+2. **All subsequent commands run with cwd = the worktree path.**
+
+3. **Reconcile with `<base_ref>` (usually `test`).** Probe the merge before the punch list, so a conflicted PR is either resolved-and-pushed or queued cleanly:
+   ```
+   git fetch origin <base_ref>
+   git merge --no-ff --no-commit origin/<base_ref>
+   ```
+   - **No conflicts (clean auto-merge):** finalize with `git commit --no-edit`, verify per step 7, push as a normal merge commit. This counts as an addressed item even if the rest of the punch list is empty.
+   - **Already up to date:** `git merge --abort` (no-op) and continue.
+   - **Conflicts surface:** capture conflicted paths from `git status --short` (`UU`/`AA`/`DD`/`AU`/`UA`/`DU`/`UD`). Try mechanical resolution per the rules below; if any rule applies and tests pass after, finalize the merge. Otherwise, `git merge --abort`, log `conflicts vs <base_ref> need user decision`, and add `{ pr, head_ref, base_ref, conflicted_paths, worktree }` to a **flagged-conflicts** list for the post-loop questions step. Do **not** half-resolve.
+
+   ## Mechanical conflict-resolution rules (ezos-specific)
+
+   **R1 — Release-generated changelog/version files only.**
+   The `Test Branch Artifacts` workflow rewrites `CHANGELOG.md`, `changelog/versions.json`, `changelog/archive.json`, `lua/docs/changelog.json`, and the `custom_version = ...` line in `platformio.ini` on every push to `test`. PRs opened before that release commit will conflict on those paths even when no real code conflict exists.
+   - **Detector:** the conflicted paths are a strict subset of:
+     `{CHANGELOG.md, changelog/versions.json, changelog/archive.json, lua/docs/changelog.json, platformio.ini}`.
+     **For `platformio.ini`, additionally verify** the conflict block only differs on the `custom_version =` line — if either side touched `lib_deps`, `build_flags`, or any other key, this rule does **not** apply (flag instead).
+   - **Recipe:**
+     1. `git checkout --theirs -- CHANGELOG.md changelog/versions.json changelog/archive.json lua/docs/changelog.json` for whichever of those are conflicted.
+     2. For `platformio.ini`: take theirs for the `custom_version` line specifically (resolve the conflict marker by deleting our side's version line and keeping their side's), keeping any other PR-side edits to the file intact. Verify the resolved file has no remaining `<<<<<<<` markers.
+     3. `git add` the resolved paths.
+
+   No other patterns auto-resolve. Edits to generated source under `src/generated/` are gitignored and shouldn't be in the PR in the first place — if they are, that's a separate bug to surface.
+
+4. **Read feedback in priority order**, building a punch list of concrete edits:
+   1. CI failures — read the failing job's log, pin to file:line.
+   2. Inline review comments — `path:line` is given; pair each ask with the file location.
+   3. CHANGES_REQUESTED review bodies — usually summarise the inline comments; cross-reference and dedup.
+   4. Top-level PR comments — only imperative ones; ignore discussion threads.
+
+5. **Skip rules** (queue for the post-loop questions step, don't half-implement):
+   - Vague feedback the punch list can't pin to a file edit.
+   - Two reviewers asking for opposite things — the user needs to pick direction.
+   - Architectural asks (add a new module, swap a framework, restructure tests) — not a review iteration; that's a fresh issue.
+   - CLAUDE.md conflicts — flag and queue.
+
+6. **Implement** the punch list. CLAUDE.md applies as always — the recurring traps on this repo:
+   - No `Ctrl` / `Esc` keybindings (the T-Deck Plus keyboard has neither). Use `alt+letter`; treat `BACKSPACE` as the back signal.
+   - ASCII-only on the default bitmap fonts. Em-dashes / curly quotes / bullets render as `[]`. Use `--`, `'`, `*`.
+   - Chat-bubble actions live behind the M-key context menu, not direct `on_press`.
+   - Never store `lua_State* L` from the function parameter across calls. Use `LUA_STATE` (`lua_runtime.h`).
+   - Lua files under `lua/` are embedded into firmware at build time. Editing them requires `pio run -t upload`, not `uploadfs`.
+   - Never send to `#Public` from tests; it's a shared real-user channel.
+
+7. **Verify.** `pio run` must pass clean. After a step-3 merge, run it even if the punch list is empty — a clean text-level merge can still break the build. Hardware verification is **not** automated by this loop (single shared device); call out any hardware-sensitive change in the optional PR-reply comment so the user remembers to flash before merging.
+
+8. **Commit.** Conventional commits enforced by `commit-msg` hook. Subject names what the review asked for — not "address feedback":
+   ```
+   fix(chat): rename render_bubble to draw_bubble per review
+   ```
+   Imperative, sentence-case, ≤72 chars. Heredoc through `git commit -m`.
+
+9. **Push** (NEVER `--force` / `--force-with-lease`):
+   ```
+   git push origin <head_ref>
+   ```
+   If the push is rejected (non-fast-forward), the branch advanced under us — abandon this PR's commit, log the skip, continue.
+
+10. **Optional reply.** Post one PR comment summarising what changed, referencing the addressed comments by `path:line`:
+    ```
+    gh pr comment <P> --body "..."
+    ```
+    Bullets per change, no rebuttal of feedback. Skip the comment if the punch list is one item — the commit message is enough. A bare merge commit doesn't need a reply.
+
+11. **Return to the main checkout** before starting the next PR. Do not delete the worktree.
+
+# After the per-PR loop — questions for the user
+
+Once every PR in the queue has been visited (or the soft cap or stop conditions hit), batch-ask the queued questions before the final report. This is the explicit exception to "don't ask between PRs" — the inner loop refused to guess, and the user is the one to pick.
+
+For each PR with queued questions:
+
+1. **Show one short paragraph of context** — `#<P> <title>`, link, summary of what's ambiguous (e.g. "Reviewer A asks to rename `foo` → `bar`; Reviewer B says keep `foo`. Picking one direction.") Don't dump diffs; the user can open the worktree if they want detail.
+
+2. **One `AskUserQuestion`** per PR, with options scoped to the queued items. Typical option shapes:
+
+   **Disagreement between reviewers:**
+   - Take A's direction *(recommended if A reviewed last / has more context)*.
+   - Take B's direction.
+   - Skip — I'll respond inline.
+
+   **Vague-but-actionable feedback ("clean this up"):**
+   - Pick a specific concrete change (e.g. "extract `foo()` into its own file").
+   - Ask the reviewer for clarification (post a PR comment).
+   - Skip.
+
+   **Conflict the mechanical rules wouldn't touch:**
+   - **Take ours** *(PR side wins)* — `git merge -X ours origin/<base_ref>`. Recommend when the PR's edits are authoritative.
+   - **Take theirs** *(base side wins)* — `git merge -X theirs origin/<base_ref>`. Recommend when `test` already did what the PR was trying to do.
+   - **Skip — I'll resolve manually.** Leaves the PR untouched.
+   - **Other** — user types a directive (path-scoped checkout, file deletion, running a known script). Carry it out only if it lives within the existing skill rules (no force-push, no `--no-verify`, no rebase).
+
+3. **Apply the answer in the PR's worktree** — same gates as the inner loop (pio run clean, conventional commit, no force-push, push rejected = abandon).
+
+4. **One ask per PR, no auto-cascading.** Even if multiple PRs share an obviously identical question shape (e.g. five branches asking the same naming question), still ask once per PR. Cross-PR consequences are the judgment the user is being asked to make.
+
+# Hard failure (per PR)
+
+- Tests / build fail in a way the punch list doesn't explain: don't commit, don't push, log the skip with the concrete failure.
+- Implementation requires architectural decisions outside the review scope: skip, queue, move on.
+- Push rejected (non-fast-forward) after a clean local commit: do not force-push; record the skip with the divergence.
+- `git merge origin/<base_ref>` reports conflicts: try R1, then `git merge --abort` and queue if no recipe matches. Tests not run; review edits not attempted (working tree state isn't trustworthy to edit on top of).
+
+# Stop conditions
+
+End the loop and print the final report when **any** of these hits:
+
+- No actionable PRs left.
+- User sends an interrupt or message — abandon in-flight *uncommitted* work, leave pushed commits alone, exit cleanly.
+- **2 consecutive hard failures.** Signals something systemic (auth expired, CI down, branch protection changed). Stop and tell the user.
+- PRs touched ≥ 5 in one run. Soft cap to keep the user's review-of-the-review-loop manageable.
+
+# When to ask the user (during the inner loop)
+
+Use `AskUserQuestion` mid-loop **only** if all three are true:
+
+- The PR is unworkable without a decision Claude can't responsibly make alone.
+- A queue-for-later would lose information the user would want surfaced *now*, not in the batch.
+- The decision unblocks more than one PR.
+
+Default behavior is **queue + log** for the post-loop batch, not **ask + wait**.
+
+# Output
+
+While running, after each PR: one line — `#<P>: pushed <sha>` (note `(merge)` when step 3 produced a commit, `(merge, -X ours|theirs)` when a post-loop strategy merge produced one) or `#<P>: skipped — <reason>` or `#<P>: queued for user — <reason>`.
+
+Final report (under 200 words):
+
+- **Pushed** — bullet per PR with number, title, the new commit's short SHA, one-line summary. Flag review-feedback commits, step-3 auto-merges, and post-loop strategy merges separately when more than one landed on a single PR.
+- **Queued questions resolved** — what the user picked for each post-loop ask.
+- **Outstanding** — PRs the user opted to handle manually, plus any "Other" directives the loop couldn't carry out. Echo conflicted paths / directive verbatim so the user can open the worktree and finish without re-deriving context.
+- **Skipped** — PRs without actionable feedback or where the loop hit a hard failure; one line each.
+- **Worktrees left behind** — paths under `.worktrees/`. Reminder: `git worktree remove .worktrees/<dir>`.
+- **Hardware QA reminder** — list the pushed PRs that touched hardware-sensitive paths (audio, radio, display, keyboard, UI). The loop didn't flash anything.
+- **Next** — if the loop hit the soft cap, name the suspected cause; if it ran the queue dry, say so.
+
+# Don't
+
+- Don't force-push, don't `--force-with-lease`, don't amend pushed history.
+- Don't push to `main`.
+- Don't resolve review threads or close other reviewers' reviews — humans mark conversations resolved.
+- Don't implement vague feedback or pick a side when reviewers disagree — queue it for the post-loop ask.
+- Don't `--no-verify` the commit hook to slip a non-conforming message past it.
+- Don't squelch failing tests / builds with `--skip` / `xfail` to keep the loop moving.
+- Don't auto-resolve conflicts outside R1. No blanket `-X ours` / `-X theirs`, no hand-edited markers in code files, no "looks additive enough" guessing — those belong in the post-loop `AskUserQuestion` batch.
+- Don't extend the mechanical rule set on the fly. New rules need to be written into this skill (detector + recipe + test gate) before they're trusted in a run.
+- Don't rebase a PR branch onto its base to "fix" conflicts. Rebase forces force-push, which the loop refuses.
+- Don't claim hardware verification you didn't do — the loop never flashes a device.

--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: work-issue
+description: Pick up a GitHub issue by number, branch off `test` with a conventional-commit prefix, implement following CLAUDE.md, build clean with `pio run`, and open a PR back to `test` that closes the issue. Use when the user says "work on issue N", "implement #N", "let's do #N", or similar.
+---
+
+# Goal
+
+Take an issue number → ship a PR that closes it. Honor every convention in CLAUDE.md.
+
+# Pre-flight
+
+In the main checkout, before touching anything:
+
+```
+git status                          # must be clean
+git fetch origin test
+git rev-parse --abbrev-ref HEAD     # ideally `test`, otherwise warn
+```
+
+If the working tree is dirty or HEAD is unrelated, stop and ask the user. Don't auto-stash.
+
+# Steps
+
+1. **Fetch the issue.**
+   ```
+   gh issue view <N> --json number,title,body,labels,state,assignees,comments
+   ```
+   Stop if:
+   - State is closed.
+   - A PR already links to it (body contains `closes|fixes|resolves #<N>` — same search as `/next`).
+   - The body is just a discussion / one-liner with no scope to implement against.
+
+2. **Plan, then surface to the user.** Under 150 words:
+   - The conventional-commit `<type>` (feat / fix / docs / refactor / chore / ...).
+   - Scope (e.g. `audio`, `chat`, `desktop`) if applicable.
+   - Files to touch — discover with grep/find, don't guess.
+   - How you'll verify it works (build only? remote-tool screenshot? Lua exec via `tools/remote/ez_remote.py`?).
+   - Skip this step only when the issue is unambiguous and ≤3 files of change.
+
+3. **Branch.**
+   ```
+   git checkout -b <type>/issue-<N>-<slug> origin/test
+   ```
+   `<slug>` = 2-4 hyphenated words from the title.
+
+4. **Implement.** CLAUDE.md is authoritative. The non-obvious gotchas:
+   - **Keyboard:** no Ctrl, no Esc. Use `alt+letter` for shortcuts; `key.special == "BACKSPACE"` is the back signal. Don't bind to letter keys the user might want to type.
+   - **Fonts:** built-in bitmap fonts are ASCII-only. Em-dashes, curly quotes, bullets, arrows render as `[]`. Use `--`, `...`, `->`, `*`.
+   - **Chat-bubble actions:** behind the M-key context menu, not direct `on_press`.
+   - **`lua_State*`:** never store the `L` argument across calls. Use `LUA_STATE` from `lua_runtime.h`.
+   - **Embedded Lua:** scripts under `lua/` are embedded into firmware at build time. Editing them requires `pio run -t upload`, not `uploadfs`.
+   - **Don't broadcast on `#Public`.** That channel is shared with real users.
+
+5. **Verify.**
+   - **Always:** `pio run` must succeed clean.
+   - **When the change affects the on-device UI / audio / radio:** flash and probe with `tools/remote/ez_remote.py`. Take a screenshot or pull `--text` for a sanity check. Use `-e "..."` to run Lua snippets on-device.
+   - **Don't use `pio device monitor` or `stty`** — they steal the serial port from the user's other tools. Use `ez_remote.py --logs` / `--monitor` instead.
+   - If hardware isn't available (no `/dev/ttyACM0`), say so explicitly in the PR body's test plan rather than claiming success.
+
+6. **Commit.** Conventional commits are enforced by a `commit-msg` hook. Format:
+   ```
+   <type>(<scope>): short description
+   ```
+   Imperative, sentence-case, ≤72 chars. Pass the message via heredoc.
+
+7. **Push and open the PR vs `test`** (not `main`):
+   ```bash
+   git push -u origin <type>/issue-<N>-<slug>
+   gh pr create --base test --title "<type>(<scope>): ..." --body "$(cat <<'EOF'
+   ## Summary
+   <one paragraph: what + why>
+
+   ## Test plan
+   - [x] `pio run` clean (RAM x%, flash y%)
+   - [ ] Flashed to T-Deck Plus and verified — <briefly, or "user to QA on hardware">
+
+   Closes #<N>
+   EOF
+   )"
+   ```
+   The `Closes #<N>` line is required for auto-close on merge. PR title must satisfy conventional-commits (the repo's pr-checks workflow rejects non-conforming titles).
+
+8. **Report the PR URL** and stop.
+
+# Stop and ask when
+
+- The plan substantially expands the issue's scope.
+- An architectural decision (new module, new service, new dep) is implied but not asked for.
+- The on-device font / keyboard rules force a UX change the issue didn't anticipate.
+- The change touches more than ~15 files.
+
+# Don't
+
+- Don't target `main`. PRs land on `test` first; promotion is a separate release commit.
+- Don't merge the PR — that's the user's call.
+- Don't `--no-verify` the commit hook. If the message is rejected, fix the message.
+- Don't write a comment in code unless the WHY is non-obvious (CLAUDE.md).
+- Don't claim hardware verification you didn't do. The PR body's test-plan checkboxes should reflect reality.

--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,10 @@ node_modules/
 /docs/manual/
 /docs/index.html
 
-# Claude session cache
-.claude/
+# Claude local state (per-machine). Shared skills under .claude/skills/
+# are tracked; settings.local.json holds machine-specific permissions.
+.claude/settings.local.json
+.claude/projects/
 
 # Raw asset source trees (only processed outputs are tracked)
 wallpapers-in/


### PR DESCRIPTION
## Summary

Four Claude Code skills for moving work from GitHub issue → PR → review-feedback iteration on this repo.

- **`/next`** — surveys open issues, filters out assigned / already-has-PR / non-actionable (`wontfix` / `duplicate` / `invalid` / `question` / empty body), recommends one with 2-3 runners-up, then asks the user whether to hand off to `/work-issue` or `/autopilot`. Scoring favours issues that overlap with the recent commit thread.
- **`/work-issue <N>`** — pre-flights a clean tree, fetches the issue, surfaces a short plan, branches `<type>/issue-N-slug` off `test`, implements with CLAUDE.md (no Ctrl/Esc keybindings, ASCII-only on default fonts, no `lua_State*` storage across calls, no `pio device monitor`, no `#Public`-channel sends), gates on `pio run` clean, and opens a PR against `test` with `Closes #N` and a test plan that's honest about whether hardware was flashed.
- **`/autopilot`** — batch loop. Worktrees under `.worktrees/`, per-issue claim re-check (state / claiming PR / claiming branch), runs the `/work-issue` flow non-interactively, skip+log on blockers, stops on 5-PR cap / 2 consecutive failures / user interrupt / queue empty. PRs go out with the hardware-QA checkbox un-checked, since one device is shared with the user and the agent can't reliably flash mid-run.
- **`/review-loop`** — companion to `/autopilot`. Loops through PRs the user owns (assigned or authored), reads CHANGES_REQUESTED reviews + inline comments + failed CI + top-level imperatives, builds a punch list per PR, pushes new commits (NEVER force-push). Anything ambiguous — vague feedback, disagreeing reviewers, non-mechanical conflicts — is queued during the inner loop and surfaced as a single `AskUserQuestion` per PR *after* the loop, so the user makes all the judgment calls in one pass. One mechanical conflict recipe covers the common ezos case where release-generated changelog/version files conflict on PRs opened before a `test` release commit.

## Conventions baked in

- PRs target **`test`**, not `main` (the repo promotes `test` → `main` via release commits).
- Branch names are `<type>/issue-<N>-<slug>` (for `/autopilot`) and `pr-<P>-<slug>` worktrees (for `/review-loop`) so the issue / PR number is traceable and the prefix satisfies the conventional-commits style.
- Commit messages go through the `commit-msg` hook; no `--no-verify` shortcuts.
- Hardware QA stays the user's responsibility — neither `/autopilot` nor `/review-loop` flashes a device. The hardware-sensitive PRs are called out explicitly in each skill's final report.

## `.gitignore` change

Narrowed from `.claude/` to just `.claude/settings.local.json` + `.claude/projects/` so the shared skill files under `.claude/skills/` are tracked while per-user state (permission allowlists, transcript cache) stays local.

## Test plan

- [x] Skills live under `.claude/skills/<name>/SKILL.md` with the expected frontmatter (`name`, `description`).
- [x] `git status` after the commit is clean except for ignored per-user state.
- [ ] Live-test `/next` against the current open backlog and confirm it recommends something sensible (user to verify in a session).
- [ ] Live-test `/review-loop` once the docs PR (#91) or mic PR (#89) has review activity to react to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)