### PR TITLE
chore(ci): allow merge commits + drop required_linear_history

### DIFF
--- a/scripts/branch-protection.sh
+++ b/scripts/branch-protection.sh
@@ -35,6 +35,18 @@
 #   Classic protection on these branches is removed in the same step
 #   to avoid two competing layers of policy.
 #
+# Why no `required_linear_history`:
+#   We used to require linear history on both branches, which only
+#   works as long as `test` is a strict superset of `main`. The moment
+#   anything lands directly on `main` (hotfix, CI bootstrap commit),
+#   the next `test -> main` promote PR can't merge cleanly within
+#   that constraint -- the only conflict-resolution path is rebase +
+#   force-push, which fights the rest of the policy. The trade is
+#   "merge bubbles in `git log`" vs. "force-pushes whenever main
+#   drifts"; for this repo the former is cheaper. `merge` is in
+#   `allowed_merge_methods` so the promote PR's conflict-resolution
+#   merge commits can land via the normal PR button.
+#
 # Run once. Re-running is idempotent: it snapshots existing
 # ezos-branch-* rulesets, creates fresh ones, drops classic
 # protection, then prunes the snapshotted IDs (create-then-delete,
@@ -94,7 +106,6 @@ create_ruleset() {
   "rules": [
     { "type": "deletion" },
     { "type": "non_fast_forward" },
-    { "type": "required_linear_history" },
     {
       "type": "pull_request",
       "parameters": {
@@ -103,7 +114,7 @@ create_ruleset() {
         "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_review_thread_resolution": false,
-        "allowed_merge_methods": ["squash", "rebase"]
+        "allowed_merge_methods": ["squash", "rebase", "merge"]
       }
     }
   ]


### PR DESCRIPTION
## Summary

Aligns \`scripts/branch-protection.sh\` with the ruleset change that just landed via the GitHub API to clear PR #87's conflict.

The repo's two rulesets (\`ezos-branch-test\`, \`ezos-branch-main\`) now:
- Drop the \`required_linear_history\` rule.
- Add \`merge\` to \`allowed_merge_methods\` (alongside \`squash\`, \`rebase\`).

## Why

The promote-PR workflow (\`test\` → \`main\`) only stays mergeable while \`test\` is a strict superset of \`main\`. The moment a hotfix or CI bootstrap commit lands directly on \`main\` (which had happened — #65 and the pr-checks bootstrap), \`test\` ends up "behind" on those commits and the next promote PR conflicts. Under the strict rules, the only conflict-resolution path was rebase-and-force-push, which fights the \`non_fast_forward\` rule and required bypassing the ruleset each time main drifts. For this repo the trade-off "merge bubbles in \`git log\`" vs. "force-pushes when main drifts" comes out the other way — merge commits are the cheaper option.

The bypass-actor (DeployKey) wiring and the rest of the rules stay intact.

## Test plan

- [x] PR #94 merged into \`test\` as a real merge commit using the relaxed rules.
- [x] PR #87 (\`test\` → \`main\`) flipped from \`DIRTY\` to \`CLEAN\` after #94 landed.
- [ ] Re-run \`scripts/branch-protection.sh\` and confirm it produces the same rules now in force (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)