### PR TITLE
chore: ignore .worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ tools/bin/
 tools/fonts/
 Inter-4.1.zip
 Nederland-schoolkaart-461-scaled.jpg
+
+# Autopilot worktrees
+.worktrees/


### PR DESCRIPTION
## Summary
- Adds `.worktrees/` to `.gitignore` so `/autopilot` can stage isolated per-issue worktrees under the repo root without polluting `git status`.

## Test plan
- [x] `cat .gitignore` shows `.worktrees/` entry
- [ ] Needs hardware QA: N/A (build-config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)