### PR TITLE
ci(release): name rolling-main "ezOS v<version>" and promote to full release

### DIFF
--- a/.github/workflows/main-artifacts.yml
+++ b/.github/workflows/main-artifacts.yml
@@ -246,10 +246,18 @@ jobs:
             ASSETS+=(artifacts/manifest.json.sig)
           fi
 
+          # Promote to a full release (not pre-release) and name it after
+          # the version stamped by the changelog step above, so the
+          # GitHub Releases UI shows e.g. "ezOS v0.0.92" instead of the
+          # opaque "Rolling main (<short-sha>)". The tag stays
+          # `rolling-main` because the on-device OTA updater hard-codes
+          # that tag in the manifest URL; only the display title and the
+          # prerelease flag change.
+          VERSION='${{ steps.changelog.outputs.version }}'
           gh release create "$TAG" "${ASSETS[@]}" \
-            --title "Rolling main (${SHORT_SHA})" \
+            --title "ezOS v${VERSION}" \
             --notes-file "$NOTES_FILE" \
-            --prerelease
+            --latest
 
   prune:
     needs: build


### PR DESCRIPTION
## Summary

Rename the rolling-main GitHub Release so it shows the actual ezOS version, and promote it from pre-release to full release. The OTA tag (`rolling-main`) is unchanged, so on-device updates keep working.

## Before / after

In `.github/workflows/main-artifacts.yml`, the `Publish rolling-main release` step:

```diff
+          VERSION='${{ steps.changelog.outputs.version }}'
           gh release create "$TAG" "${ASSETS[@]}" \
-            --title "Rolling main (${SHORT_SHA})" \
+            --title "ezOS v${VERSION}" \
             --notes-file "$NOTES_FILE" \
-            --prerelease
+            --latest
```

- Title: `Rolling main (86fa39b)` -> `ezOS v0.0.92` (driven by the version that the changelog step already emits as `steps.changelog.outputs.version`, the same source feeding the signed manifest).
- Pre-release flag: dropped, plus `--latest` is set explicitly so this release becomes the repo's "Latest" in the Releases UI. (`gh release create` without `--prerelease` is already a full release; `--latest` just makes intent explicit.)
- Tag (`rolling-main`) is unchanged. The on-device firmware-update screen fetches `manifest.json` and `manifest.json.sig` from the release at that exact tag, so leaving the tag alone preserves OTA. The asset URLs are identical too.

## Not changed

- `.github/workflows/test-artifacts.yml` is intentionally untouched. `test` is the integration branch, not user-facing, so its release stays titled `Rolling test (<short-sha>)` and marked pre-release.
- No existing release/tag on GitHub is deleted or renamed; the rename takes effect on the next push to `main`.

## Test plan

- [ ] Needs verification on next merge to `main`: confirm the published release is titled `ezOS v<version>`, is marked as a full release (not pre-release), shows as the repo's "Latest" release, and that `manifest.json` / `manifest.json.sig` are still reachable at `releases/download/rolling-main/...` (i.e. on-device OTA still resolves the manifest).