### PR TITLE
feat(signal-test): scroll viewport + ezme.sh URI for SIGT DMs

### DIFF
--- a/lua/boot.lua
+++ b/lua/boot.lua
@@ -244,6 +244,10 @@ local function boot_sequence()
     -- with that contact -- the screen itself shows the new bubble.
     ez.bus.subscribe("dm/message", function(_topic, msg)
         if type(msg) ~= "table" or msg.is_self then return end
+        -- Protocol-carrier DMs (signal-test pingpong) decrypt
+        -- successfully but aren't messages the user wrote, so they
+        -- must not raise a notification toast.
+        if require("services.sharing").is_protocol_message(msg) then return end
         local key  = msg.sender_key
         local name = msg.sender_name or "Unknown"
         local body = msg.text and msg.text:sub(1, 80) or nil

--- a/lua/screens/chat/dm_conversation.lua
+++ b/lua/screens/chat/dm_conversation.lua
@@ -369,7 +369,20 @@ function DMConversation:build(state)
     local msgs = dm_svc.get_history(key)
     local content_items = {}
 
-    if #msgs == 0 then
+    -- Hide signal-test pingpong DMs from the conversation view. They
+    -- still live in history (the tester's `p` shortcut purges them on
+    -- demand) but rendering them as bubbles would bury the actual chat
+    -- under a wall of "https://ezme.sh/#sigt/..." entries.
+    local visible_msgs = {}
+    local visible_indexes = {}
+    for i, m in ipairs(msgs) do
+        if not sharing_svc.is_protocol_message(m) then
+            visible_msgs[#visible_msgs + 1] = m
+            visible_indexes[#visible_indexes + 1] = i
+        end
+    end
+
+    if #visible_msgs == 0 then
         content_items[#content_items + 1] = ui.padding({ 20, 10, 10, 10 },
             ui.text_widget("No messages yet", {
                 color = "TEXT_MUTED",
@@ -389,14 +402,17 @@ function DMConversation:build(state)
         -- context menu uses the same dispatch.)
         local self_pub = ez.mesh.get_public_key_hex()
         content_items[#content_items + 1] = { type = "spacer", h = 2, grow = 0 }
-        for i, msg in ipairs(msgs) do
+        for vi, msg in ipairs(visible_msgs) do
             local share_sender = msg.is_self and self_pub or key
+            -- Preserve the real history index for the context menu's
+            -- delete action; SIGT entries change the mapping.
+            local orig_index = visible_indexes[vi]
             content_items[#content_items + 1] = {
                 type = "chat_bubble",
                 msg = msg,
                 share = self:_share_for_message(msg, share_sender),
                 on_press = function()
-                    show_context_menu(self, key, msg, i)
+                    show_context_menu(self, key, msg, orig_index)
                 end,
             }
         end

--- a/lua/screens/tools/signal_test.lua
+++ b/lua/screens/tools/signal_test.lua
@@ -370,12 +370,12 @@ function Screen:build(state)
         start_label = "Start"
     end
 
-    -- Two rows up top, a chart in the middle, and a one-line footer with
-    -- stats + the Start/Stop toggle. Compact list_items keep the top two
-    -- rows tight so the chart has 115 px to work with on a 240 px screen.
-    local rows = {
-        ui.title_bar("Signal Test", { back = true }),
-
+    -- Title stays pinned; everything else lives inside a scroll so the
+    -- chart + stats + Start button are reachable on the 240 px screen
+    -- even with the chart taking 115 px. Trackball/UP/DOWN walks the
+    -- focus chain (peer row, mode row, button) and ezui auto-scrolls
+    -- the focused widget into view; finger drag pans via touch_input.
+    local scroll_content = ui.vbox({ gap = 0 }, {
         ui.list_item({
             compact  = true,
             title    = "Peer: " .. (state.peer_name or "<pick>"),
@@ -411,7 +411,7 @@ function Screen:build(state)
             ui.text_widget(stats, { color = "TEXT_SEC", font = "tiny_aa" })
         ),
 
-        ui.padding({ 2, 8, 4, 8 },
+        ui.padding({ 2, 8, 6, 8 },
             ui.button(start_label, {
                 on_press = function()
                     if not has_peer then
@@ -424,9 +424,12 @@ function Screen:build(state)
                 end,
             })
         ),
-    }
+    })
 
-    return ui.vbox({ gap = 0, bg = "BG" }, rows)
+    return ui.vbox({ gap = 0, bg = "BG" }, {
+        ui.title_bar("Signal Test", { back = true }),
+        ui.scroll({ grow = 1 }, scroll_content),
+    })
 end
 
 function Screen:on_enter()
@@ -470,7 +473,7 @@ function Screen:on_exit()
         self._redraw_timer = nil
     end
     -- Tear the responder down so the device stops answering SIGT pings
-    -- and stops storing [SIGT] DM replies once the tester is closed.
+    -- and stops storing SIGT DM replies once the tester is closed.
     signal_test.stop()
 end
 

--- a/lua/services/direct_messages.lua
+++ b/lua/services/direct_messages.lua
@@ -339,7 +339,11 @@ local function try_decrypt_pending(id, pending, candidate_pub_key_hex)
         retroactive = true,
     }
     store_message(candidate_pub_key_hex, msg)
-    unread[candidate_pub_key_hex] = (unread[candidate_pub_key_hex] or 0) + 1
+    -- Same protocol-message filter as the live RX path -- a SIGT ping
+    -- that decrypts retroactively shouldn't surface as an unread.
+    if not require("services.sharing").is_protocol_message(msg) then
+        unread[candidate_pub_key_hex] = (unread[candidate_pub_key_hex] or 0) + 1
+    end
 
     pending_ciphertexts[id] = nil
     pending_count = pending_count - 1
@@ -786,7 +790,15 @@ function dm.init()
                                 }
 
                                 store_message(candidate.pub_key_hex, msg)
-                                unread[candidate.pub_key_hex] = (unread[candidate.pub_key_hex] or 0) + 1
+                                -- Don't bump unread for protocol carriers
+                                -- (signal-test pingpong). The conversation
+                                -- index already filters them out of last_msg;
+                                -- bumping unread would make the message list
+                                -- show a phantom "1" badge for every ping
+                                -- during a test.
+                                if not require("services.sharing").is_protocol_message(msg) then
+                                    unread[candidate.pub_key_hex] = (unread[candidate.pub_key_hex] or 0) + 1
+                                end
                                 ez.bus.post("dm/message", msg)
 
                                 -- Receiving a DM proves the sender has our
@@ -1143,12 +1155,23 @@ function dm.get_pending_summary()
     return out
 end
 
--- Get list of conversations with last message info, sorted by recency
+-- Get list of conversations with last message info, sorted by recency.
+-- Signal-test pingpong DMs (sharing kind "sigt") are protocol traffic;
+-- they're skipped here so an active test doesn't yank the contact to
+-- the top of the chat list every ping cycle or replace the real last
+-- message with a "https://ezme.sh/#sigt/..." preview.
 function dm.get_conversations()
+    local sharing = require("services.sharing")
     local result = {}
     for key, msgs in pairs(conversations) do
-        if #msgs > 0 then
-            local last = msgs[#msgs]
+        local last
+        for i = #msgs, 1, -1 do
+            if not sharing.is_protocol_message(msgs[i]) then
+                last = msgs[i]
+                break
+            end
+        end
+        if last then
             local contact = contacts_svc.get(key)
             result[#result + 1] = {
                 pub_key_hex = key,

--- a/lua/services/direct_messages.lua
+++ b/lua/services/direct_messages.lua
@@ -194,6 +194,11 @@ local function do_save()
                 count = msg.count,
                 rssi = msg.rssi,
                 snr = msg.snr,
+                -- Preserve the protocol-carrier flag across reboots so
+                -- stamped SIGT entries stay hidden after restart; the
+                -- stamp itself only happens during an active test, so
+                -- this is just "don't lose what we already classified".
+                protocol = msg.protocol,
             }
         end
         data.conversations[key] = saved
@@ -338,6 +343,7 @@ local function try_decrypt_pending(id, pending, candidate_pub_key_hex)
         -- Marker so the UI can indicate this was a retroactive delivery.
         retroactive = true,
     }
+    classify_inbound_protocol(msg)
     store_message(candidate_pub_key_hex, msg)
     -- Same protocol-message filter as the live RX path -- a SIGT ping
     -- that decrypts retroactively shouldn't surface as an unread.
@@ -418,6 +424,21 @@ local function fold_signal(target, src)
     if src.hop_count then
         target.hops_min = math.min(target.hops_min or src.hop_count, src.hop_count)
         target.hops_max = math.max(target.hops_max or src.hop_count, src.hop_count)
+    end
+end
+
+-- Stamp `msg.protocol` if this looks like a known protocol carrier
+-- AND the originating service is currently active. The active-scope
+-- predicate is critical: it stops a peer from hand-typing a "SIGT
+-- URL" outside an active test and silently disappearing on the
+-- recipient. Today only signal_test consults this, but the helper is
+-- the natural seam for any future protocol DM (file-offer beacons,
+-- etc.) -- they'd plug into the same active-scope flow.
+local function classify_inbound_protocol(msg)
+    if msg.protocol then return end  -- already stamped (e.g. by sender)
+    local ok, sigt = pcall(require, "services.signal_test")
+    if ok and sigt.matches_protocol and sigt.matches_protocol(msg) then
+        msg.protocol = "sigt"
     end
 end
 
@@ -789,6 +810,7 @@ function dm.init()
                                     is_self = false,
                                 }
 
+                                classify_inbound_protocol(msg)
                                 store_message(candidate.pub_key_hex, msg)
                                 -- Don't bump unread for protocol carriers
                                 -- (signal-test pingpong). The conversation
@@ -960,7 +982,7 @@ function dm.init()
     ez.log("[DM] Service initialized")
 end
 
-function dm.send(pub_key_hex, text)
+function dm.send(pub_key_hex, text, opts)
     if not text or #text == 0 then return false end
     if #text > MAX_TEXT then text = text:sub(1, MAX_TEXT) end
     if not ez.mesh.is_initialized() then return false end
@@ -978,6 +1000,11 @@ function dm.send(pub_key_hex, text)
         timestamp   = ez.system.millis(),
         is_self     = true,
         status      = "pending",
+        -- `opts.protocol` stamps the outbound carrier (e.g. signal
+        -- tester pingpong). Stamping at the send seam means the chat
+        -- filters in sharing.is_protocol_message can rely on a real
+        -- intent signal instead of guessing from the text.
+        protocol    = opts and opts.protocol or nil,
     }
     local stored = store_message(pub_key_hex, msg)
     ez.bus.post("dm/message", msg)

--- a/lua/services/sharing.lua
+++ b/lua/services/sharing.lua
@@ -266,12 +266,22 @@ end
 -- True when a DM message is a protocol carrier that should not appear
 -- in user-facing chat views. Currently only signal-test pings/replies
 -- qualify; other share kinds (contact, channel invite, time) are
--- meant for the user to see as a card-style bubble. Centralised here
--- so future protocol verbs can opt out of chat rendering by name.
+-- meant for the user to see as a card-style bubble.
+--
+-- This reads a stamped `msg.protocol` flag rather than re-parsing the
+-- text every time. Stamping happens at the DM seam
+-- (services/direct_messages.lua) under a scope predicate: the
+-- signal_test service must be active (i.e. the signal-test screen is
+-- open) for the recogniser to fire. That closes the silent-send
+-- vector earlier revisions opened up -- a peer who hand-types
+-- "https://ezme.sh/#sigt/v1?..." outside of an active test now
+-- surfaces as a normal chat bubble (notification, unread badge,
+-- conversation preview) because nothing stamped the flag. Legacy
+-- "[SIGT]P/R <nonce>" history entries left over from before the URL
+-- switch likewise show up as plain bubbles; users can delete them or
+-- run the test screen's `p` shortcut to purge in bulk.
 function sharing.is_protocol_message(msg)
-    if not msg or type(msg.text) ~= "string" then return false end
-    local share = sharing.parse(msg.text)
-    return share ~= nil and share.kind == "sigt"
+    return msg ~= nil and msg.protocol == "sigt"
 end
 
 -- Decrypt a channel-invite token from a known sender. Returns the

--- a/lua/services/sharing.lua
+++ b/lua/services/sharing.lua
@@ -5,10 +5,17 @@
 -- URL formats:
 --   https://ezme.sh/#add/v1?k=<64-hex pubkey>&n=<urlencoded name>
 --   https://ezme.sh/#join/v1?t=<base64url(nonce8 || aes128_ecb(secret, blob))>
+--   https://ezme.sh/#time/v1?t=<unix_ts>
+--   https://ezme.sh/#sigt/v1?k=<P|R>&n=<nonce hex>
 --
 -- The fragment-only design means non-ezOS receivers see a normal
 -- clickable link; the ezme.sh landing page reads location.hash
 -- client-side, so no payload data ever reaches the web server.
+--
+-- The sigt verb is a protocol carrier for the signal tester, not a
+-- user-actionable share. Chat screens filter messages whose parsed
+-- share kind is "sigt" out of conversations and previews so the
+-- pingpong doesn't clutter the user's chat history.
 --
 -- Channel invites are encrypted to the recipient's identity using the
 -- same X25519 shared secret the DM service uses, so a leaked URL is
@@ -31,6 +38,7 @@ local URL_PREFIX = "https://ezme.sh/#"
 local CONTACT_VERB = "add/v1"
 local INVITE_VERB = "join/v1"
 local TIME_VERB = "time/v1"
+local SIGT_VERB = "sigt/v1"
 
 local NONCE_SIZE = 8
 local AES_BLOCK_SIZE = 16
@@ -182,6 +190,20 @@ function sharing.encode_channel_invite(recipient_pub_key_hex, channel_name, chan
     return URL_PREFIX .. INVITE_VERB .. "?t=" .. token
 end
 
+-- Encode a signal-test ping or reply. `kind` is "P" (ping) or "R"
+-- (reply); nonce is the short hex string the tester uses to correlate
+-- send to receive. The result rides through the normal DM path as
+-- regular text but is recognised by the chat screens (and filtered
+-- out of conversation views) via sharing.parse.
+function sharing.encode_sigt(kind, nonce)
+    if kind ~= "P" and kind ~= "R" then return nil, "bad kind" end
+    if not nonce or nonce == "" then return nil, "missing nonce" end
+    -- The receive side restricts nonce charset on parse; keep
+    -- emission to the same alphabet so the round-trip survives.
+    if not nonce:match("^[A-Za-z0-9]+$") then return nil, "bad nonce" end
+    return URL_PREFIX .. SIGT_VERB .. "?k=" .. kind .. "&n=" .. nonce
+end
+
 -- Encode the current unix time into a share URL.
 function sharing.encode_time()
     local ts = ez.system.get_time_unix()
@@ -227,8 +249,29 @@ function sharing.parse(text)
             kind = "time",
             timestamp = ts,
         }
+    elseif verb == SIGT_VERB then
+        local k = params.k
+        local n = params.n
+        if (k ~= "P" and k ~= "R") or not n or n == "" then return nil end
+        if not n:match("^[A-Za-z0-9]+$") then return nil end
+        return {
+            kind = "sigt",
+            sigt_kind = k,
+            nonce = n,
+        }
     end
     return nil
+end
+
+-- True when a DM message is a protocol carrier that should not appear
+-- in user-facing chat views. Currently only signal-test pings/replies
+-- qualify; other share kinds (contact, channel invite, time) are
+-- meant for the user to see as a card-style bubble. Centralised here
+-- so future protocol verbs can opt out of chat rendering by name.
+function sharing.is_protocol_message(msg)
+    if not msg or type(msg.text) ~= "string" then return false end
+    local share = sharing.parse(msg.text)
+    return share ~= nil and share.kind == "sigt"
 end
 
 -- Decrypt a channel-invite token from a known sender. Returns the

--- a/lua/services/signal_test.lua
+++ b/lua/services/signal_test.lua
@@ -35,19 +35,53 @@ local sharing = require("services.sharing")
 local M = {}
 
 local SUBTYPE = "SIGT"
+-- Legacy DM text format used before the ezme.sh URL switch. Kept so
+-- purge_dm_history can still clean up stranded entries on devices
+-- that upgraded mid-conversation, and so the inbound classifier
+-- treats them as protocol traffic during an active test instead of
+-- letting them resurface as chat bubbles.
+local LEGACY_DM_PREFIX = "[SIGT]"
+local LEGACY_PING_TAG = "P "
+local LEGACY_PONG_TAG = "R "
 
 local active    = false
 local dm_sub_id = nil
 
--- Parse a DM body as a SIGT carrier. Accepts the share URL form
--- emitted by sharing.encode_sigt and returns { kind, nonce } if it
--- matches; nil otherwise. parse_dm is also used by purge_dm_history
--- to recognise (and only recognise) protocol carriers when sweeping
--- a contact's history after a DM-mode run.
+-- Parse a DM body as a SIGT carrier. Accepts both the new ezme.sh
+-- URL form emitted by sharing.encode_sigt and the legacy text form
+-- ("[SIGT]P <nonce>" / "[SIGT]R <nonce>") so this firmware can sweep
+-- and recognise pingpong entries that landed in history before the
+-- URL change. Returns { kind, nonce } on a match or nil.
 local function parse_dm(text)
+    if type(text) ~= "string" or text == "" then return nil end
     local share = sharing.parse(text)
-    if not share or share.kind ~= "sigt" then return nil end
-    return { kind = share.sigt_kind, nonce = share.nonce }
+    if share and share.kind == "sigt" then
+        return { kind = share.sigt_kind, nonce = share.nonce }
+    end
+    if text:sub(1, #LEGACY_DM_PREFIX) == LEGACY_DM_PREFIX then
+        local tag = text:sub(#LEGACY_DM_PREFIX + 1, #LEGACY_DM_PREFIX + 2)
+        if tag == LEGACY_PING_TAG or tag == LEGACY_PONG_TAG then
+            return {
+                kind  = tag:sub(1, 1),
+                nonce = text:sub(#LEGACY_DM_PREFIX + #LEGACY_PING_TAG + 1),
+            }
+        end
+    end
+    return nil
+end
+
+-- True when this device has the signal test screen open right now.
+-- Used by direct_messages to decide whether a SIGT-shaped DM should
+-- be stamped as a protocol carrier and hidden from the chat surface,
+-- closing the silent-send vector where a peer could otherwise hand-
+-- type a SIGT URL and have it disappear from the recipient's UI. The
+-- predicate is scope-by-time-window rather than per-peer because the
+-- responder side runs purely off incoming events and has no chosen
+-- peer until the first ping arrives.
+function M.matches_protocol(msg)
+    if not active then return false end
+    if not msg or type(msg.text) ~= "string" then return false end
+    return parse_dm(msg.text) ~= nil
 end
 
 -- Both kinds post a sample so BOTH peers chart a live RSSI trace:
@@ -101,7 +135,7 @@ local function on_dm_message(_topic, msg)
     if parsed.kind == "P" then
         local dm = require("services.direct_messages")
         local url = sharing.encode_sigt("R", parsed.nonce)
-        if url then dm.send(msg.sender_key, url) end
+        if url then dm.send(msg.sender_key, url, { protocol = "sigt" }) end
     end
 end
 
@@ -149,7 +183,7 @@ end
 function M.ping_dm(pub_key_hex, nonce)
     local dm = require("services.direct_messages")
     local url = sharing.encode_sigt("P", nonce)
-    if url then dm.send(pub_key_hex, url) end
+    if url then dm.send(pub_key_hex, url, { protocol = "sigt" }) end
 end
 
 -- After a DM-mode run, the pings/replies sit in the regular DM history

--- a/lua/services/signal_test.lua
+++ b/lua/services/signal_test.lua
@@ -17,9 +17,12 @@
 --     RAW_CUSTOM is not re-flooded by stock MeshCore repeaters, so the
 --     RSSI charted in this mode reflects raw direct radio contact.
 --   DM (TXT_MSG)
---     Text: "[SIGT]P <nonce>" / "[SIGT]R <nonce>". Goes through the
+--     Text is a sharing URL: "https://ezme.sh/#sigt/v1?k=P&n=<nonce>"
+--     for pings and "...?k=R&n=<nonce>" for replies. Goes through the
 --     normal encrypted DM path, which WILL be forwarded by repeaters —
---     the chart then reflects last-hop RSSI, not end-to-end.
+--     the chart then reflects last-hop RSSI, not end-to-end. The chat
+--     screens filter these out of conversation views (the URL is a
+--     protocol carrier, not user-readable chatter).
 --
 -- The `signal_test/sample` bus event fires with:
 --   { mode, pub_key_hex, nonce, rssi, snr, t_ms, name }
@@ -27,26 +30,24 @@
 -- can treat both modes uniformly.
 
 local cp = require("services.custom_packets")
+local sharing = require("services.sharing")
 
 local M = {}
 
-local SUBTYPE     = "SIGT"
-local DM_PREFIX   = "[SIGT]"
-local DM_PING_TAG = "P "
-local DM_PONG_TAG = "R "
+local SUBTYPE = "SIGT"
 
 local active    = false
 local dm_sub_id = nil
 
+-- Parse a DM body as a SIGT carrier. Accepts the share URL form
+-- emitted by sharing.encode_sigt and returns { kind, nonce } if it
+-- matches; nil otherwise. parse_dm is also used by purge_dm_history
+-- to recognise (and only recognise) protocol carriers when sweeping
+-- a contact's history after a DM-mode run.
 local function parse_dm(text)
-    if not text or #text < (#DM_PREFIX + 3) then return nil end
-    if text:sub(1, #DM_PREFIX) ~= DM_PREFIX then return nil end
-    local tag = text:sub(#DM_PREFIX + 1, #DM_PREFIX + 2)
-    if tag ~= DM_PING_TAG and tag ~= DM_PONG_TAG then return nil end
-    return {
-        kind  = tag:sub(1, 1),
-        nonce = text:sub(#DM_PREFIX + #DM_PING_TAG + 1),
-    }
+    local share = sharing.parse(text)
+    if not share or share.kind ~= "sigt" then return nil end
+    return { kind = share.sigt_kind, nonce = share.nonce }
 end
 
 -- Both kinds post a sample so BOTH peers chart a live RSSI trace:
@@ -99,7 +100,8 @@ local function on_dm_message(_topic, msg)
 
     if parsed.kind == "P" then
         local dm = require("services.direct_messages")
-        dm.send(msg.sender_key, DM_PREFIX .. DM_PONG_TAG .. parsed.nonce)
+        local url = sharing.encode_sigt("R", parsed.nonce)
+        if url then dm.send(msg.sender_key, url) end
     end
 end
 
@@ -146,7 +148,8 @@ end
 
 function M.ping_dm(pub_key_hex, nonce)
     local dm = require("services.direct_messages")
-    dm.send(pub_key_hex, DM_PREFIX .. DM_PING_TAG .. nonce)
+    local url = sharing.encode_sigt("P", nonce)
+    if url then dm.send(pub_key_hex, url) end
 end
 
 -- After a DM-mode run, the pings/replies sit in the regular DM history


### PR DESCRIPTION
## Summary
- Wrap the signal test screen below the title bar in a `ui.scroll` container so the Start/Stop button is reachable on the 240 px screen via trackball, UP/DOWN, or finger drag instead of being clipped under the chart.
- Replace the `[SIGT]P <nonce>` / `[SIGT]R <nonce>` DM text with a new sharing verb `https://ezme.sh/#sigt/v1?k=<P|R>&n=<nonce>`, matching how contact / channel-invite / time shares already ride the DM path.
- Add `sharing.is_protocol_message` and use it to filter SIGT pingpong DMs out of `dm.get_conversations` last-message previews, the DM thread view, unread counts, and DM toast notifications, so an active DM-mode test no longer reshuffles the chat list, spams toasts, or buries real chat under protocol carriers.

## Test plan
- [x] `pio run` builds clean.
- [x] On-device: open Signal Test, press DOWN — Start button auto-scrolls into view.
- [x] `sharing.encode_sigt("P", "abc1234")` round-trips through `sharing.parse` and `sharing.is_protocol_message` returns `true`; plain text and other share kinds (time) return `false`.
- [ ] Two devices: run a DM-mode test; confirm chat list preview and unread badge ignore the pingpong, then `p` purges the SIGT entries from history as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)