### PR TITLE
docs(claude-md): consolidate and tighten project guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,290 +1,138 @@
 # ezOS Project Guidelines
 
-## Overview
+ezOS is a complete embedded operating system for the LilyGo T-Deck Plus
+(ESP32-S3 with LoRa). C++ firmware handles hardware drivers and mesh
+networking; Lua scripts (embedded into firmware at build time) handle the
+UI and all application logic; MeshCore is the on-air protocol.
 
-ezOS is a complete embedded operating system for the LilyGo T-Deck Plus (ESP32-S3 with LoRa). It combines:
-- **C++ firmware** for hardware drivers and mesh networking
-- **Lua scripting** for the entire UI and application logic
-- **MeshCore protocol** for encrypted mesh communication
+## Building, flashing, and serial access
 
-## Serial Port Access
+```bash
+pio run            # build only
+pio run -t upload  # build + flash
+```
 
-**IMPORTANT:** Never use `stty` or interactive serial monitor commands (`pio device monitor`, `minicom`, etc.) as they block the user's interactive terminal session. The user typically has a serial monitor already open.
+Lua scripts under `lua/` are embedded into the firmware at build time, and
+`require()` resolves embedded scripts before LittleFS -- so both Lua and
+C++ changes require a full rebuild and flash.
 
-Instead, use the remote control tool for debugging:
-- `python tools/remote/ez_remote.py /dev/ttyACM0 --logs` - Get buffered log entries
-- `python tools/remote/ez_remote.py /dev/ttyACM0 --monitor` - Stream real-time logs
-- `python tools/remote/ez_remote.py /dev/ttyACM0 -e "return collectgarbage('count')"` - Query device state
+**Never use `stty`, `pio device monitor`, `minicom`, or any other
+interactive serial monitor.** The user usually has one open already, and
+the second consumer steals the port. Use the remote-control tool instead
+(see "Remote control" below).
 
-For building and flashing:
-- `pio run` - Build firmware
-- `pio run -t upload` - Build and flash
+**Port assignments**: the T-Deck is on `/dev/ttyACM0`. `/dev/ttyUSB0` is
+typically the user's separate MeshCore CLI node -- never fall back to it.
+If `ttyACM0` isn't present, ask the user to plug it in.
 
-**IMPORTANT:** Do not send messages to public mesh channels (e.g. `public <msg>` via
-meshcore-cli). The public channel is shared with real users. Only use DMs to the user's
-own devices for testing.
+**Don't send to public mesh channels** (e.g. `public <msg>` via
+meshcore-cli) -- the public channel is shared with real users. Only DM
+the user's own devices for testing.
 
-**Note:** `/dev/ttyUSB0` is typically the user's separate MeshCore CLI node, not the
-T-Deck. The T-Deck is usually on `/dev/ttyACM0`. If `ttyACM0` isn't present, ask the
-user to plug it in rather than falling back to `ttyUSB0`.
+## Commit messages
+
+All commits **must** use [Conventional Commits](https://www.conventionalcommits.org/):
+`type(scope): description`. Allowed types: `feat`, `fix`, `build`,
+`chore`, `ci`, `docs`, `refactor`, `perf`, `test`, `style`. A `commit-msg`
+hook rejects non-conforming messages, and `@xtr-dev/changelog` parses
+these prefixes -- skipping a prefix means the change won't appear under
+the right changelog heading.
 
 ## Keyboard layout (T-Deck Plus)
 
-The on-device QWERTY keyboard is **not** a PC keyboard. There is **no Ctrl
-key, no Esc key**, no Shift-lock, no function keys, no Tab. Designing
-shortcuts that assume Ctrl or Esc will silently break on the device, even
-if the C++ key path defines those flags for the remote-control tool. See
-`tdeck keyboard.png` in the repo root for the photographed layout.
+The on-device QWERTY keyboard is **not** a PC keyboard: **no Ctrl, no
+Esc**, no Shift-lock, no function keys, no Tab. See `tdeck keyboard.png`
+in the repo root for the photographed layout.
 
-Physical keys, top to bottom:
-- Row 1 (letters): `Q W E R T Y U I O P` + Backspace
-- Row 2 (letters): `A S D F G H J K L` + Enter
-- Row 3 (letters): `alt Z X C V B N M $`
-- Row 4 (bottom):  `0` (mic / 0) `space` (LILYGO logo'd) `sym` plus the
-  two small black side keys (microphone / speaker).
+Physical layout:
+- Row 1: `Q W E R T Y U I O P` + Backspace
+- Row 2: `A S D F G H J K L` + Enter
+- Row 3: `alt Z X C V B N M $`
+- Row 4: `0` (mic / 0), `space` (LILYGO logo'd), `sym`, plus two small
+  black side keys (microphone / speaker).
 
-Available modifiers: **`alt`** and **`shift`**. The keyboard has **two
-physical shift keys** (matrix positions `SHIFT1` and `SHIFT2` in
-`src/hardware/keyboard_matrix.h`); either one sets `key.shift` on the
-key event. `sym` is a third modifier used for the punctuation layer.
-Numbers and most punctuation are entered via `alt+letter` combinations,
-NOT via a number row.
+Modifiers: **`alt`** and **`shift`** (two physical shift keys, both at
+matrix positions `SHIFT1`/`SHIFT2` in `src/hardware/keyboard_matrix.h`,
+either sets `key.shift`). `sym` is a third modifier for the punctuation
+layer. Numbers and most punctuation are `alt+letter`, **not** a number
+row.
 
-Implications for UI / shortcut design:
+Shortcut rules:
 - **Never use `key.ctrl` for an on-device shortcut.** The remote tool can
-  send it, but a user in the field cannot. Use `key.alt` for primary
-  shortcuts (Save, Open, New, etc.), or expose actions through the M-key
-  (Alt+M) context menu instead.
-- **Never rely on `ESCAPE` as the only exit path.** There is no Esc key
-  either; on-device, the dedicated back-arrow icon (top-right of the
-  letter block) sends `BACKSPACE`. Screens should always treat
-  `key.special == "BACKSPACE"` as the back/cancel signal. `ESCAPE` is
-  still useful as a synonym for the remote tool, but it must never be
-  the sole binding for a user-reachable action.
-- Hint text shown on the device should refer to "Back" or the back-arrow
-  glyph, not "ESC". Saying "Press ESC to quit" is misleading on-device.
-- Two-handed combos are awkward; the device is held in both hands and
-  thumbed. Single-tap actions and Alt+letter combos are fine. Alt+Shift
-  combos are reachable -- both physical shift keys can be thumbed by
-  whichever hand isn't on `alt` -- but reserve them for system-level
-  global chords (e.g. the input-lock toggle), not per-screen actions.
-- Don't bind to keys that the user might want to type as text in the same
-  screen (e.g. the editor must not steal `s` for Save without `alt`).
-- The trackball acts like arrow keys; design any keyboard shortcut to
-  also work without taking a hand off the keys.
+  send it; a user in the field cannot. Use `key.alt` for primary
+  shortcuts (Save, Open, New) or expose actions via the M-key (Alt+M)
+  context menu.
+- **Never rely on `ESCAPE` as the only exit.** The dedicated back-arrow
+  icon sends `BACKSPACE`; screens must always treat
+  `key.special == "BACKSPACE"` as back/cancel. `ESCAPE` is fine as a
+  remote-tool synonym, never as the sole binding.
+- Hint text should say "Back" or use the back-arrow glyph, never "ESC".
+- The device is held two-handed and thumbed. Single-tap and Alt+letter
+  combos are fine. Alt+Shift combos are reachable but reserved for
+  system-level global chords (e.g. the input-lock toggle), not per-screen
+  actions.
+- Don't steal keys the user might want to type as text (e.g. editor
+  must not bind bare `s` for Save).
+- The trackball acts like arrow keys; design shortcuts to also work
+  without taking a hand off the keys.
 
-When porting code or docs that mention Ctrl, replace it with Alt and
-re-test the chord on the device, not the remote tool.
+When porting code/docs that mention Ctrl, replace with Alt and re-test
+the chord on the device, not the remote tool.
 
 ## On-device font character set
 
-The built-in bitmap fonts (`src/fonts/InterAA*.h`, `Spleen*.h`) only cover
-**printable ASCII 0x20..0x7E**. Any other codepoint renders as a `[]` missing-glyph box.
+Built-in bitmap fonts (`src/fonts/InterAA*.h`, `Spleen*.h`) only cover
+**printable ASCII 0x20..0x7E**. Any other codepoint renders as a `[]`
+missing-glyph box.
 
-This commonly bites when:
-- Using em-dashes (`—`, U+2014), en-dashes (`–`, U+2013), `·` (U+00B7 middle dot), `•` (U+2022 bullet), `…` (U+2026 ellipsis), curly quotes (`"`, `"`, `'`, `'`), or arrows (`→`, `←`) as separators or decoration
-- Pulling display strings from external APIs (GPS names, channel names, contact names) without sanitizing
-- Copying UI conventions from web/desktop apps
+Common offenders: em-dash (`U+2014`), en-dash (`U+2013`), middle dot
+(`U+00B7`), bullet (`U+2022`), ellipsis (`U+2026`), curly quotes, arrows
+(`U+2192`/`U+2190`). External-API strings (GPS names, channel names,
+contact names) are a frequent source -- sanitize before display.
 
-Safe substitutes:
-- Em/en-dash: `--` or ` - `
-- Separator: `|` or multiple spaces
-- Ellipsis: `...`
-- Bullet: `-` or `*`
-- Arrows: `->` or `<-`
-- Quotes: straight `"` and `'`
+Safe substitutes: `--` or ` - ` (dashes), `|` (separator), `...`
+(ellipsis), `-`/`*` (bullet), `->`/`<-` (arrows), straight `"`/`'`
+(quotes).
 
-**Applies equally to docs.** Markdown under `lua/docs/manual/` is embedded into firmware and rendered by the on-device markdown viewer (`lua/ezui/markdown.lua`), which uses the same fonts as everything else — non-ASCII characters render as `[]` boxes there too. Keep the source ASCII; the auto-generated `docs/manual/` and `docs/api/` trees served on GitHub Pages are tolerant either way, but the source the renderer reads must not be.
+**Applies equally to docs.** Markdown under `lua/docs/manual/` is
+embedded and rendered by `lua/ezui/markdown.lua` with the same fonts --
+non-ASCII renders as `[]` there too. The auto-generated `docs/manual/`
+and `docs/api/` trees served on GitHub Pages are tolerant either way,
+but the source the renderer reads must not be.
 
-If a new glyph is genuinely needed, extend the bitmap font (run the font generator with
-a wider range); otherwise stick to ASCII in any string that reaches `draw_text`.
+If a glyph is genuinely needed, extend the bitmap font (font generator
+with wider range); otherwise stay ASCII in any string reaching
+`draw_text`.
 
-## Commit Messages
-
-All commits **must** use [Conventional Commits](https://www.conventionalcommits.org/) format:
-
-```
-type(scope): description
-```
-
-Allowed types: `feat`, `fix`, `build`, `chore`, `ci`, `docs`, `refactor`, `perf`, `test`, `style`.
-
-Scope is optional but encouraged (e.g. `feat(chat):`, `fix(desktop):`).
-
-A `commit-msg` git hook enforces this — commits with non-conforming
-messages are rejected. The `@xtr-dev/changelog` tool parses these
-prefixes to generate the changelog, so skipping the prefix means the
-change won't appear under the right heading.
-
-## Building and Flashing
-
-```bash
-# Build only
-pio run
-
-# Build and flash
-pio run -t upload
-```
-
-## Rolling OTA updates
-
-Pushes to `main` and `test` trigger `.github/workflows/main-artifacts.yml`
-and `.github/workflows/test-artifacts.yml` respectively. Each builds
-the firmware, generates a `manifest.json` describing the build (SHA,
-version, sha256, size, asset URL, plus the `full_*` variants for the
-bootloader+partitions+app blob), signs it with an Ed25519 key from the
-`OTA_SIGNING_PRIVKEY` GitHub Actions secret, runs `xtr-changelog
-release --commit --tag --push` to advance `versions.json` and tag the
-release, and republishes the `rolling-main` / `rolling-test` GitHub
-Release with the binaries + manifest + detached signature. Older
-builds are kept as run artefacts (prune step caps at 3) for short-
-term debugging.
-
-Pushes that touch ONLY generated files don't retrigger the workflow
-(would otherwise loop on the workflow's own release commit):
-`paths-ignore` excludes `changelog/versions.json`,
-`changelog/archive.json`, `lua/docs/changelog.json`, `CHANGELOG.md`,
-and `platformio.ini`. The release commit is also prefixed with
-`[skip ci]` as defense in depth.
-
-The on-device update screen (`lua/screens/settings/firmware_update.lua`)
-lets the user pick `main` or `test` channel, fetches `manifest.json`
-and `manifest.json.sig` from that release, calls
-`ez.crypto.ed25519_verify` against the embedded `kOtaSigningPubkey`
-(`src/ota_pubkey.cpp`), and only on a valid signature passes the
-`full_bin_url` + `full_sha256` into `ez.ota.apply_full_url`, which
-streams the firmware straight into the inactive OTA partition (writing
-bootloader / partition table only when they differ from current
-flash) and switches the boot slot via direct otadata write. Trust
-flows from the signature, not from TLS — the streamer uses
-`setInsecure()` and re-checks SHA-256 against the manifest while
-writing.
-
-**Setup ceremony** (do this once per project, not per release):
-
-1. `pip install pynacl && python tools/ota/gen_signing_key.py`
-2. Paste the printed private key into the GitHub repo secret
-   `OTA_SIGNING_PRIVKEY` (Settings → Secrets and variables → Actions).
-3. Paste the printed C-array form into `src/ota_pubkey.cpp`'s
-   `kOtaSigningPubkey` (replacing the all-zero placeholder).
-4. Build + flash. Devices flashed *before* this step won't accept
-   rolling-main updates — `ez.ota.signing_pubkey()` returns nil and
-   the screen shows "OTA signing not configured on this device".
-
-Key rotation is "burn a new firmware containing the new pubkey, then
-rotate the secret". Don't lose the private key — there's no recovery
-path other than reflashing every device manually.
-
-**Branch ruleset push gate** (already wired, documented for context):
-the auto-release workflow's `xtr-changelog --push` step pushes the
-`[skip ci]` release commit + tag straight back to `main` / `test`.
-Both branches are protected by repo rulesets (see
-`scripts/branch-protection.sh`), and the rulesets' `pull_request`
-rule blocks direct pushes from any actor not on the bypass list --
-including the workflow's `GITHUB_TOKEN`, regardless of `permissions:`
-scope. The "GitHub Actions" identity does not appear in the bypass
-picker on the free org plan, so we can't put it on the bypass list.
-
-Workaround in use: a write-enabled **deploy key** (`auto-release-push`,
-private half stored in repo secret `RELEASE_PUSH_KEY`) **plus a
-DeployKey bypass actor on each ruleset**. Both `*-artifacts.yml`
-workflows load the key into ssh-agent via `webfactory/ssh-agent`
-and check the repo out over SSH so the subsequent `git push` from
-xtr-changelog flows through the same key, and the bypass actor
-on `ezos-branch-main` / `ezos-branch-test` lets that push land
-despite the `pull_request` rule. **Deploy keys do NOT bypass
-rulesets implicitly** -- the bypass actor must be present, of
-type `DeployKey` (which covers any deploy key on the repo, so the
-API stores it with `actor_id: null`).
-
-If OTA releases ever stop publishing, check the failing workflow
-run's "Generate changelog, sync version, and push back" step. A
-GH013 / "Changes must be made through a pull request" error means
-the push reached GitHub but the `pull_request` rule fired anyway.
-The two common causes:
-
-1. The DeployKey bypass entry is missing from the ruleset's
-   `bypass_actors`. Re-run `scripts/branch-protection.sh` (which
-   includes it now), or add it manually:
-   ```sh
-   gh api repos/ezmesh/ezos/rulesets        # find the ruleset id
-   gh api -X PUT repos/ezmesh/ezos/rulesets/<id> -f \
-       'bypass_actors[][actor_type]=DeployKey' \
-       -f 'bypass_actors[][bypass_mode]=always' ...
-   ```
-   (Pass the full ruleset payload; the PUT replaces it.)
-2. The SSH push genuinely fell back to HTTPS+GITHUB_TOKEN because
-   the deploy key is missing or the secret was rotated. Regenerate
-   the keypair with `ssh-keygen -t ed25519`, register the public
-   half via `POST /repos/ezmesh/ezos/keys` with `read_only: false`,
-   and re-upload the private half to `RELEASE_PUSH_KEY`. The
-   `webfactory/ssh-agent` step's log lines (`Identity added: ...`,
-   key fingerprint) confirm whether auth got off the ground.
-
-## Project Structure
+## Project structure
 
 ```
 ezos/
 ├── src/                    # C++ firmware
 │   ├── main.cpp           # Boot sequence, main loop
 │   ├── hardware/          # Display, keyboard, radio, GPS drivers
-│   ├── mesh/              # MeshCore implementation (identity, routing, crypto)
-│   ├── lua/               # Lua runtime and bindings
-│   │   └── bindings/      # C++ wrappers for Lua APIs (@lua-annotated)
-│   └── remote/            # USB remote control protocol
-├── lua/                    # Lua scripts (embedded into firmware)
-│   ├── boot.lua           # Entry point (services init, apply settings)
-│   ├── core/              # Module infrastructure (modules.lua)
+│   ├── mesh/              # MeshCore (identity, routing, crypto)
+│   ├── lua/bindings/      # C++ wrappers for Lua APIs (@lua-annotated)
+│   └── remote/            # USB remote-control protocol
+├── lua/                    # Lua, embedded into firmware
+│   ├── boot.lua           # Entry point (service init, apply settings)
+│   ├── core/              # Module infrastructure
 │   ├── engine/            # Long-lived helpers (audio_engine, highscores)
-│   ├── ezui/              # Declarative UI framework
-│   │   ├── init.lua       # Public API, main loop
-│   │   ├── screen.lua     # Screen stack manager
-│   │   ├── node.lua       # Node tree system
-│   │   ├── layout.lua     # Layout nodes (vbox, hbox, scroll, etc.)
-│   │   ├── widgets.lua    # Widget constructors (button, list_item, etc.)
-│   │   ├── widgets/       # Composite widgets (map_view, etc.)
-│   │   ├── focus.lua      # Focus/navigation manager
-│   │   ├── text.lua       # Text measurement and wrapping
-│   │   ├── theme.lua      # Palettes, map palette, fonts, dimensions
-│   │   ├── icons.lua      # PNG icon definitions
-│   │   ├── markdown.lua   # On-device markdown renderer
-│   │   ├── dialog.lua     # Modal dialogs
-│   │   ├── persist.lua    # Per-screen state persistence
-│   │   ├── shadows.lua    # Drop-shadow primitives
-│   │   ├── touch_input.lua# Touch / trackball input plumbing
-│   │   ├── transient.lua  # Transient overlays (toasts, etc.)
-│   │   └── async.lua      # Async file I/O helpers
-│   ├── screens/           # Screen definitions (about, apps, chat,
-│   │                      #   desktop, dev, dialog, games, menu,
-│   │                      #   onboarding, pickers, settings, test_mode,
-│   │                      #   tools)
-│   ├── services/          # Background services (apps, channels,
-│   │                      #   contacts, custom_packets, direct_messages,
-│   │                      #   file_transfer, gps, input_lock,
-│   │                      #   log_persist, map_archive, migrations,
-│   │                      #   notifications, ntp, prefs_registry,
-│   │                      #   sharing, signal_test, ui_sounds)
-│   └── util/              # Shared helpers (timezones, etc.)
+│   ├── ezui/              # Declarative UI framework (see below)
+│   ├── screens/           # Screen definitions
+│   ├── services/          # Background services
+│   └── util/              # Shared helpers
 ├── scripts/                # Build-time generators (Lua embedder)
-├── tools/                  # Host utilities (map gen, remote control,
-│                          #   doc generator, font/icon/sound gen)
-└── docs/                   # User manual + Lua API reference (see below)
+├── tools/                  # Host utilities (maps, remote, doc gen, ...)
+└── docs/                   # User manual + Lua API reference
 ```
 
-## UI System Architecture (ezui)
+## UI system (ezui)
 
-### Chat bubble actions
+### Declarative screen model
 
-**All actions on chat bubble content (share cards, time shares, invites)
-must be behind a context menu.** Tapping a bubble opens the context menu;
-destructive or state-changing actions (sync clock, add contact, join
-channel) live as menu items inside it. Never fire an action directly
-from `on_press` on a chat bubble -- the touch target is large and
-accidental taps are common on the T-Deck's small screen.
-
-### Declarative Screen Model
-Screens define a `build(state)` method that returns a node tree. State changes via
-`set_state()` trigger an automatic rebuild and redraw.
+Screens define `build(state)` returning a node tree. `set_state()`
+triggers automatic rebuild + redraw.
 
 ```lua
 local MyScreen = { title = "My Screen" }
@@ -296,342 +144,207 @@ function MyScreen:build(state)
     })
 end
 
-function MyScreen:on_enter()      -- Called when screen becomes active
-function MyScreen:on_leave()      -- Called when screen is paused (another pushed on top)
-function MyScreen:on_exit()       -- Called when screen is popped off the stack
-function MyScreen:handle_key(key) -- Process input not handled by focused nodes
+function MyScreen:on_enter()      -- screen becomes active
+function MyScreen:on_leave()      -- screen paused (another pushed on top)
+function MyScreen:on_exit()       -- screen popped off the stack
+function MyScreen:handle_key(key) -- input not handled by focused nodes
 ```
 
-### Main Loop
+### Main loop
 
-The C++ `loop()` calls `_G.main_loop()` which is set by `ui.start()`:
-1. Update mesh network (every 50ms via `ez.mesh.update()`)
-2. Screen manager update (input + render at ~30 FPS)
-3. Incremental garbage collection (every 2 seconds)
+C++ `loop()` calls `_G.main_loop()` (set by `ui.start()`):
+1. Update mesh network (every 50ms via `ez.mesh.update()`).
+2. Screen manager update (input + render at ~30 FPS).
+3. Incremental GC (every 2s).
 
-Timers and bus messages are processed by C++ `LuaRuntime::update()` before the Lua main loop runs.
+Timers and bus messages are processed by C++ `LuaRuntime::update()`
+before the Lua main loop runs.
+
+### Module loading
+
+```lua
+load_module(path)        -- async load from LittleFS (yields in coroutine)
+require("module.name")   -- standard require; embedded first, then LittleFS
+spawn(fn)                -- run function in coroutine
+```
+
+### Settings persistence
+
+`ez.storage.set_pref(key, value)` / `ez.storage.get_pref(key, default)`.
+Restored in `lua/boot.lua` at startup. NVS keys have a **15-char limit**.
+
+### Chat bubble actions
+
+**All actions on chat bubble content (share cards, time shares, invites)
+must be behind a context menu.** Tap opens the menu; destructive or
+state-changing actions (sync clock, add contact, join channel) are menu
+items inside it. Never fire from `on_press` on a chat bubble -- the
+touch target is large and accidental taps are common on the small
+screen.
 
 ### Services
 
-Services are initialized in order in `lua/boot.lua`:
-1. **log_persist** — Runs first so subsequent service init lines are captured to the persisted log
-2. **contacts** — Contact list CRUD with persistence
-3. **channels** — Channel management, GRP_TXT decryption
-4. **direct_messages** — Encrypted DMs via TXT_MSG packets
-5. **sharing** — Share-card construction and dispatch
-6. **custom_packets** — Custom (non-MeshCore) packet handlers
-7. **file_transfer** — Mesh-based file send/receive
-8. **ui_sounds** — UI sound effects via the audio engine
-9. **notifications** — Toast queue + bus subscribers for OTA, DMs,
-   file transfer, low battery, SD connect/disconnect, and panic /
-   brownout recovery. See "Notifications service" below for the
-   public API and per-source mute pref namespace.
-10. **apps** — Registered file-type → screen handlers (used by the file manager)
-11. **gps** — `gps_svc.start_sync_loop()` is always called; the loop itself
-    respects the user's "never / at boot / hourly" pref and is a no-op when
-    GPS is disabled
+Services init in order in `lua/boot.lua`:
 
-After services start, `migrations.run()` runs version migrations and an
-`ntp` sync is kicked. Other modules under `lua/services/` (e.g.
-`input_lock`, `map_archive`, `prefs_registry`, `signal_test`) are
-loaded on demand by the screens / framework code that needs them.
+1. **log_persist** -- runs first so subsequent init lines are captured
+2. **contacts** -- CRUD + persistence
+3. **channels** -- channel management, GRP_TXT decryption
+4. **direct_messages** -- encrypted DMs via TXT_MSG packets
+5. **sharing** -- share-card construction and dispatch
+6. **custom_packets** -- non-MeshCore packet handlers
+7. **file_transfer** -- mesh-based file send/receive
+8. **ui_sounds** -- UI SFX via the audio engine
+9. **notifications** -- toast queue + bus subscribers (OTA, DMs, file
+   transfer, low battery, SD connect/disconnect, panic/brownout recovery)
+10. **apps** -- file-type → screen handler registry (used by file manager)
+11. **gps** -- `start_sync_loop()` always called; loop respects the
+    "never / at boot / hourly" pref and no-ops when GPS is disabled
+
+After services start: `migrations.run()` runs version migrations, then
+`ntp` kicks a sync. Other modules under `lua/services/` (`input_lock`,
+`map_archive`, `prefs_registry`, `signal_test`) load on demand.
 
 ### Notifications service
 
-`services/notifications` is an in-memory toast queue. The bus topic
-`notifications/changed` fires on every change; `ezui/screen.lua`
-subscribes once and renders the most recent entry as a toast.
+In-memory toast queue. Bus topic `notifications/changed` fires on every
+change; `ezui/screen.lua` subscribes once and renders the most recent as
+a toast.
 
 Public API:
+- `notifications.post(opts)` -- `{ title, body?, source?, sticky?,
+  action? = { label, on_press }, read? }`. Returns id, or nil if
+  suppressed (muted source / missing title). `title`/`body` are
+  sanitized to printable ASCII before storage (peer-originated, and the
+  fonts can't render anything else).
+- `notifications.post_unless_focused(opts, predicate)` -- posts only
+  when `predicate(top_screen_inst)` is false. Use for events that lead
+  to a screen the user may already be on (DM → DM conversation).
+- `notifications.dismiss(id)` / `dismiss_source(s)` / `list()` /
+  `unread_count()` / `mark_all_read()`.
 
-- `notifications.post(opts)` — `{ title, body?, source?, sticky?,
-  action? = { label, on_press }, read? }`. Returns the new id, or
-  nil if suppressed (muted source, missing title). `title` and
-  `body` are sanitized to printable ASCII before being stored — the
-  on-device fonts can't render anything else (see "On-device font
-  character set" above), and titles/bodies often come from
-  peer-originated mesh data.
-- `notifications.post_unless_focused(opts, predicate)` — posts only
-  when `predicate(top_screen_inst)` returns false. Use for events
-  that lead to a screen the user might already be looking at (the
-  DM message → DM conversation flow is the canonical example).
-- `notifications.dismiss(id)` / `notifications.dismiss_source(s)` /
-  `notifications.list()` / `notifications.unread_count()` /
-  `notifications.mark_all_read()`.
-
-Per-source mute pref: every `post()` consults `notify_<source>` in
-NVS (default `"1"` = on). Setting `notify_dm = "0"`, for instance,
-silences every DM toast without touching the wiring. The namespace
-is meant for a future Settings panel; pref keys must stay under
-NVS's 15-character limit, so source tags should be short
-(`dm`, `file`, `battery`, `sd`, `ota`, `channel`, `system`).
+Per-source mute pref: every `post()` consults `notify_<source>` in NVS
+(default `"1"` = on). Setting `notify_dm = "0"` silences every DM toast
+without touching wiring. Source tags must stay short to fit NVS's
+15-char limit (`dm`, `file`, `battery`, `sd`, `ota`, `channel`,
+`system`).
 
 ### Input lock service
 
-`services/input_lock` is a tiny in-memory gate consulted by the
-keyboard and touch chokepoints. While locked, `screen.handle_input`
-swallows every key except the unlock chord, the touch bridge
-swallows every `touch/*` event, and a bottom banner is drawn on top
-of every screen. Boot always starts unlocked -- state is in-memory
-only by design, so a regression in the chord path can't soft-brick
-the device across reboots.
+`services/input_lock` is a tiny in-memory gate consulted by the keyboard
+and touch chokepoints. While locked, `screen.handle_input` swallows
+every key except the unlock chord, the touch bridge swallows every
+`touch/*`, and a bottom banner is drawn on top of every screen. Boot
+always starts unlocked -- in-memory only by design, so a chord-path
+regression can't soft-brick the device across reboots.
 
-Public API:
+API: `input_lock.is_locked()`, `set(new_locked)` (coerces to bool,
+deduplicates no-ops), `toggle()`.
 
-- `input_lock.is_locked() -> bool` -- current state.
-- `input_lock.set(new_locked)` -- coerces to bool, deduplicates
-  no-ops (won't fire the bus event when state doesn't change).
-- `input_lock.toggle()` -- flip; thin wrapper over `set`.
+Bus: `input_lock/changed`, payload `{ locked = bool }`. Fires on every
+real transition so other services can react (dim backlight, suppress
+sounds) without polling.
 
-Bus topic: `input_lock/changed`, payload `{ locked = bool }`. Fired
-on every real transition so other services can react (dim backlight,
-suppress sounds, etc.) without polling.
+Chord: **Shift+Alt+L** locks, **Shift+Alt+U** unlocks. Recognised inside
+`screen.handle_input` before everything else (including `notify_input` /
+screensaver dismissal), so unlock works even when the screensaver is up.
+The matrix path uppercases letters when shift is held; the remote-inject
+path forwards as-is -- the handler accepts both cases.
 
-Chord: **Shift+Alt+L** locks, **Shift+Alt+U** unlocks. Recognised
-inside `screen.handle_input` before everything else (including
-`notify_input` / screensaver dismissal), so the unlock chord works
-even when the screensaver is up. The matrix path uppercases letters
-when shift is held; the remote-control inject path forwards them
-as-is, so the handler accepts both cases.
-
-Touch subscribers: per "Touch input and the screensaver wake gate"
-below, the lock gate is opt-in for direct `touch/*` subscribers via
-`touch_input.is_locked()`, the same way `is_wake_event` is opt-in.
-
-### Module Loading
-
-```lua
-load_module(path)           -- Async load from LittleFS (yields in coroutine)
-require("module.name")      -- Standard Lua require (loads embedded scripts first)
-spawn(fn)                   -- Run function in coroutine
-```
+Touch subscribers: the lock gate is **opt-in** for direct `touch/*`
+subscribers via `touch_input.is_locked()`, same as `is_wake_event`. See
+next section.
 
 ### Touch input and the screensaver wake gate
 
 `lua/ezui/touch_input.lua` is the global touch-to-widget bridge. It
-subscribes once at boot to `touch/down` / `touch/move` / `touch/up`
-and turns single-finger taps into focus-chain activations on the
-widget under the finger. Most screens get touch for free.
+subscribes once at boot to `touch/down|move|up` and turns single-finger
+taps into focus-chain activations on the widget under the finger -- most
+screens get touch for free.
 
-Three developer-facing APIs gate raw `touch/*` events and must be
-consulted by anyone writing new touch code:
+Three developer APIs gate raw `touch/*` events:
 
-- **`screen.notify_input()`** (`lua/ezui/screen.lua`) -- bumps
-  `last_input_time` and, if the screensaver overlay is currently
-  drawn, dismisses it. Returns `true` when the screensaver was just
-  dismissed so the caller can swallow the originating event. The
-  keyboard read loop calls this; you usually don't, but it's the
-  single chokepoint if you ever need to synthesise a wake.
+- **`screen.notify_input()`** -- bumps `last_input_time` and dismisses
+  the screensaver overlay if drawn. Returns `true` when the screensaver
+  was just dismissed so the caller can swallow the originating event.
+  The keyboard read loop calls this; you usually don't.
 
-- **`touch_input.is_wake_event()`** -- predicate that returns true
-  for ~250 ms after a touch dismissed the screensaver. The bridge
-  sets the timestamp from inside its own `screensaver_swallow()`
-  guard. Call this **at the top of every `touch/*` bus subscriber a
-  screen registers**:
+- **`touch_input.is_wake_event()`** -- true for ~250ms after a touch
+  dismissed the screensaver. The bridge sets the timestamp inside its
+  own `screensaver_swallow()` guard.
 
-  ```lua
-  ez.bus.subscribe("touch/down", function(_, data)
-      local ti = require("ezui.touch_input")
-      if ti.is_locked() or ti.is_wake_event() then return end
-      -- ... real handler
-  end)
-  ```
+- **`touch_input.is_locked()`** -- true while the global input lock is
+  engaged (Shift+Alt+L).
 
-  Without this guard, a tap that wakes the device from the
-  screensaver also fires the screen's handler -- a wake-tap on the
-  desktop would launch an icon, a wake-tap in Paint would seed a
-  stroke, etc. The bus broadcasts to every subscriber, so the
-  bridge can't suppress them on its own; each direct subscriber
-  has to opt in.
+**Call both at the top of every direct `touch/*` subscriber:**
 
-- **`touch_input.is_locked()`** -- predicate that returns true while
-  the global input lock is engaged (Shift+Alt+L; see
-  `lua/services/input_lock.lua`). Same opt-in contract as
-  `is_wake_event`: the bus broadcasts to every subscriber, so a
-  screen with a direct `touch/*` subscription has to consult this
-  itself or a pocket touch will still drive the screen's handler
-  while the device is "locked". Always pair the two checks at the
-  top of the handler, as shown above.
+```lua
+ez.bus.subscribe("touch/down", function(_, data)
+    local ti = require("ezui.touch_input")
+    if ti.is_locked() or ti.is_wake_event() then return end
+    -- ... real handler
+end)
+```
 
-`touch/tap` and `touch/long_press` subscribers (games, custom
-views) are **not** affected by either gate -- those are synthesised
-inside the bridge's own `on_up`, which already returns early on a
-wake event AND while locked, so they're covered transitively.
-Raw `touch/down|move|up` subscribers don't get that for free.
+Without these guards: a wake-tap on the desktop would launch an icon,
+a wake-tap in Paint would seed a stroke, a pocket touch with the device
+"locked" would still drive the screen's handler. The bus broadcasts to
+every subscriber, so the bridge can't suppress them on its own -- each
+direct subscriber has to opt in.
 
-### Settings
+`touch/tap` and `touch/long_press` subscribers (games, custom views)
+are **not** affected -- those are synthesised inside the bridge's
+`on_up`, which already returns early on wake events AND while locked.
 
-Settings are stored via `ez.storage.set_pref(key, value)` and restored in
-`lua/boot.lua` at startup.
+## Theming
 
-## Map Tools (`tools/maps/`)
+`lua/ezui/theme.lua` is the single source of truth for colors and fonts.
 
-Convert OpenStreetMap vector tiles to optimized TDMAP format for offline viewing.
+- Built-in palettes: `dark` (default) and `light`. Switch via
+  `theme.set("dark"|"light")`, persisted under the `theme` pref,
+  restored at boot.
+- Accent color is independent of dark/light. Stored under `accent_color`,
+  picked from `theme.ACCENT_PRESETS`. Settings → Display → Accent colour.
+- **Map palette**: `theme.map_palette()` returns the 8-color tile
+  palette + label inks/halo for the active theme. The map renderer reads
+  this every frame, so a theme switch repaints tiles without invalidating
+  the cache. See `lua/ezui/widgets/map_view.lua`.
+- User entry: Settings → Display → Theme → Dark mode toggle. The Map
+  screen also accepts `T` as a legacy shortcut.
 
-### Files
+Use `theme.color("NAME")` rather than raw RGB565 literals so values flow
+through both palettes.
 
-| File | Purpose |
-|------|---------|
-| `pmtiles_to_tdmap.py` | Main converter — PMTiles to TDMAP |
-| `config.py` | Tile sources, regions, semantic-index → grayscale lookup used by the rasterizer |
-| `process.py` | Grayscale conversion, dithering, RLE/zlib tile compression |
-| `archive.py` | TDMAP format writer/reader/inspector |
-| `land_mask.py` | Natural Earth land polygon downloader |
-| `viewer.html` | Browser-based TDMAP viewer |
+## Remote control (`tools/remote/`)
 
-### Usage
+Primary tool for automated testing and debugging.
 
 ```bash
-cd tools/maps
-pip install -r requirements.txt
-python pmtiles_to_tdmap.py input.pmtiles -o output.tdmap
-python pmtiles_to_tdmap.py input.pmtiles --bounds 4.0,52.0,5.5,52.5 --zoom 10,14 -o region.tdmap
+cd tools/remote && pip install pyserial pillow
 ```
 
-Copy generated `.tdmap` files to `/sd/maps/` on the device. The Map app
-opens a loader screen (`screens/tools/map_loader.lua`) that lists every
-archive there; "Set as default" via the M-key actions menu skips the
-picker on subsequent opens.
+| Flag | Use |
+|------|-----|
+| (none) | Test connection |
+| `-s out.png` | Screenshot (24-bit BMP, BGR bottom-up) |
+| `-k <key>` | Send key (e.g. `enter`, `a`, `up`); add `--ctrl`, `--shift`, `--alt` |
+| `--info` | Current screen title and dimensions |
+| `--text` | Text rendered in next frame (positions + colors) |
+| `--primitives` | Draw calls in next frame (rects, lines, bitmaps) |
+| `--logs` | Buffered log entries |
+| `--monitor` | Real-time log stream |
+| `-e "<lua>"` | Execute Lua, returns JSON |
+| `-f script.lua` | Execute Lua file |
 
-### TDMAP Format (v6)
+### Picking a capture mode
 
-Optimized archive format for ESP32. The writer emits v6 and the reader
-accepts v6 only — pre-v6 archives are rejected at open time with a
-"regenerate with the current writer" message.
+**Prefer `--text` over screenshots when verifying UI content** -- faster,
+smaller, programmatically searchable. Use `--primitives` for rendering
+issues (e.g. map tiles); reserve screenshots for visual layout, colors,
+graphics, or doc/bug-report material.
 
-- **Header** (33 bytes): Magic, version, compression type, tile/label counts, offsets, zoom range. `palette_count` is always 0; the byte is kept for header-shape stability.
-- **Metadata block**: 4-byte length + TLV tags (region name, bounds, build timestamp, tool version, source hash). Always present (length may be 0) so readers don't need a version-conditional branch to locate the index.
-- **Tile Index**: Sorted by (zoom, x, y) for binary search.
-- **Tile Data**: zlib-compressed 3-bit indexed pixels.
-- **Labels**: Geographic coordinates (lat_e6, lon_e6), zoom ranges, label types.
-
-Semantic feature indices (0-7): Land, Water, Park, Building, RoadMinor, RoadMajor, Highway, Railway.
-
-Tile colors are **not** stored in the archive. The on-device renderer
-maps indices to RGB565 via `ezui.theme.map_palette()`, which returns a
-per-theme palette plus matching label inks — so a single archive serves
-both light and dark themes.
-
-### Resume Support
-
-Checkpoints saved every 500 tiles. Interrupted conversions resume automatically:
-```bash
-# If interrupted, just run again:
-python pmtiles_to_tdmap.py input.pmtiles -o output.tdmap
-```
-
-## Remote Control (`tools/remote/`)
-
-Control T-Deck over USB serial from host computer. This is the primary tool for automated testing and debugging.
-
-### Setup
-
-```bash
-cd tools/remote
-pip install pyserial pillow
-```
-
-### Commands
-
-```bash
-# Test connection
-python ez_remote.py /dev/ttyACM0
-
-# Screenshots
-python ez_remote.py /dev/ttyACM0 -s screenshot.png
-
-# Send keys
-python ez_remote.py /dev/ttyACM0 -k enter
-python ez_remote.py /dev/ttyACM0 -k a
-python ez_remote.py /dev/ttyACM0 -k up
-python ez_remote.py /dev/ttyACM0 -k c --ctrl
-
-# Screen info
-python ez_remote.py /dev/ttyACM0 --info
-
-# Capture rendered text (for UI verification)
-python ez_remote.py /dev/ttyACM0 --text
-
-# Capture draw primitives (for debugging rendering)
-python ez_remote.py /dev/ttyACM0 --primitives
-
-# Get buffered logs
-python ez_remote.py /dev/ttyACM0 --logs
-
-# Monitor serial output (real-time logs)
-python ez_remote.py /dev/ttyACM0 --monitor
-
-# Execute Lua code
-python ez_remote.py /dev/ttyACM0 -e "1+1"
-python ez_remote.py /dev/ttyACM0 -e "return collectgarbage('count')"
-python ez_remote.py /dev/ttyACM0 -e "ez.system.get_time()"
-python ez_remote.py /dev/ttyACM0 -f script.lua
-```
-
-### Capture Modes
-
-**Text Capture (`--text`)**: Returns all text rendered in a frame with positions and colors. Useful for verifying UI content.
-
-**Primitive Capture (`--primitives`)**: Returns all draw calls (rects, lines, circles, triangles, bitmaps) with coordinates. Useful for debugging rendering issues like map tiles.
-
-Example primitive output for map tiles:
-```json
-[
-  {"type": "draw_bitmap", "x": 32, "y": 48, "w": 64, "h": 64, "transparent_color": 0},
-  {"type": "fill_rect", "x": 0, "y": 0, "w": 320, "h": 24, "color": 0}
-]
-```
-
-### Protocol
-
-- Baudrate: 921600
-- Request: `[CMD:1][LEN:2][PAYLOAD:LEN]`
-- Response: `[STATUS:1][LEN:4 little-endian][DATA:LEN]` (4-byte length to fit screenshot BMPs, ~225 KiB at 320x240; file reads are capped at PAYLOAD_CAP = 16 KiB)
-
-Commands:
-- `0x01` PING - Test connection
-- `0x02` SCREENSHOT - Capture framebuffer as a 24-bit BMP (BGR, bottom-up)
-- `0x03` KEY_CHAR - Send character with modifiers
-- `0x04` KEY_SPECIAL - Send special key (arrows, enter, etc.)
-- `0x05` SCREEN_INFO - Get current screen title and dimensions
-- `0x06` WAIT_FRAME_TEXT - Capture text from next rendered frame
-- `0x07` LUA_EXEC - Execute Lua code and return result
-- `0x08` WAIT_FRAME_PRIMITIVES - Capture draw primitives from next frame
-- `0x09` WRITE_FILE - Write file: `[path_len:2][path][data]`
-- `0x0A` READ_FILE - Read file:  `[path_len:2][path][offset:4][length:4]`
-- `0x0B` WRITE_AT  - Patch file: `[path_len:2][path][offset:4][data]`
-
-## Development Workflow
-
-### Building and Testing
-
-1. **Build firmware**: `pio run`
-2. **Flash to device**: `pio run -t upload`
-3. **Verify with remote control**:
-   - Take screenshot: `python tools/remote/ez_remote.py /dev/ttyACM0 -s test.png`
-   - Check logs: `python tools/remote/ez_remote.py /dev/ttyACM0 --logs`
-   - Run tests via Lua: `python tools/remote/ez_remote.py /dev/ttyACM0 -e "your_test_code"`
-
-### Debugging UI Issues
-
-**IMPORTANT:** Prefer using `--text` over screenshots when verifying UI content. Text capture is faster, uses less bandwidth, and can be easily compared or searched programmatically.
-
-1. Navigate to the problematic screen (use `ui.push_screen()` via `-e` flag)
-2. **Prefer:** Capture text to verify content: `--text`
-3. **If needed:** Capture primitives to debug rendering: `--primitives`
-4. **Last resort:** Take screenshot for visual verification: `-s screenshot.png`
-5. Check logs for errors: `--logs`
-
-Screenshots are best for:
-- Verifying visual layout, colors, and graphics
-- Debugging rendering issues not captured by text/primitives
-- Creating documentation or bug reports
-
-**Wallpaper convention for documentation screenshots.** When the
-shot includes the Desktop (so the wallpaper is visible behind the
-icon dock), ALWAYS set the wallpaper to `green-coastline` first so
-re-shoots stay visually consistent with what's already in
-`docs/screenshots/`:
+**Wallpaper convention for Desktop screenshots** included in
+`docs/screenshots/`: set `wallpaper` to `green-coastline` first so
+re-shoots stay visually consistent.
 
 ```bash
 python tools/remote/ez_remote.py /dev/ttyACM0 \
@@ -639,157 +352,237 @@ python tools/remote/ez_remote.py /dev/ttyACM0 \
 # then navigate back to Desktop and take the shot
 ```
 
-Shots that don't show the wallpaper (Map viewer, Chat, Settings
-sub-pages, etc.) don't care -- this rule only matters for the
-Desktop screen itself.
+Non-Desktop shots (Map, Chat, Settings sub-pages, ...) don't care.
 
-### Debugging with Lua Execution
-
-The `-e` flag executes Lua code on the device and returns JSON results:
+### Lua execution examples
 
 ```bash
-# Check system state
-python ez_remote.py /dev/ttyACM0 -e "ez.system.get_time()"
 python ez_remote.py /dev/ttyACM0 -e "return collectgarbage('count')"
-python ez_remote.py /dev/ttyACM0 -e "return ez.system.millis()"
-
-# Query settings
 python ez_remote.py /dev/ttyACM0 -e "ez.storage.get_pref('brightness', 200)"
-
-# Access services
-python ez_remote.py /dev/ttyACM0 -e "local ch = require('services.channels'); return #ch.get_history('#Public')"
-python ez_remote.py /dev/ttyACM0 -e "local dm = require('services.direct_messages'); return dm.get_total_unread()"
+python ez_remote.py /dev/ttyACM0 -e \
+    "local ch = require('services.channels'); return #ch.get_history('#Public')"
 ```
 
-### Navigating Screens
-
-Push screens using the ezui API:
+### Navigating screens
 
 ```bash
-# Push a screen loaded from LittleFS
-python ez_remote.py /dev/ttyACM0 -e "local ui = require('ezui'); ui.push_screen('\$screens/chat/messages.lua')"
+# Push from LittleFS path
+-e "local ui = require('ezui'); ui.push_screen('\$screens/chat/messages.lua')"
 
-# Push a screen from a require()'d module
-python ez_remote.py /dev/ttyACM0 -e "local ui = require('ezui'); local s = require('ezui.screen'); local def = require('screens.chat.contacts'); s.push(s.create(def, {}))"
+# Push from require()'d module
+-e "local ui = require('ezui'); local s = require('ezui.screen'); \
+    local def = require('screens.chat.contacts'); s.push(s.create(def, {}))"
 
-# Pop current screen (go back)
-python ez_remote.py /dev/ttyACM0 -e "require('ezui.screen').pop()"
+# Pop
+-e "require('ezui.screen').pop()"
 ```
 
-### Testing Changes
+### Protocol
 
-Lua scripts in `lua/` are embedded into the firmware at build time. `require()` loads
-embedded scripts before LittleFS, so you must rebuild and flash for changes to take effect:
+- Baudrate: 921600.
+- Request: `[CMD:1][LEN:2][PAYLOAD:LEN]`.
+- Response: `[STATUS:1][LEN:4 LE][DATA:LEN]` -- 4-byte length to fit
+  screenshot BMPs (~225 KiB at 320x240); file reads capped at
+  `PAYLOAD_CAP = 16 KiB`.
+
+| Cmd | Name | Payload |
+|-----|------|---------|
+| `0x01` | PING | -- |
+| `0x02` | SCREENSHOT | -- |
+| `0x03` | KEY_CHAR | char + modifiers |
+| `0x04` | KEY_SPECIAL | special key id |
+| `0x05` | SCREEN_INFO | -- |
+| `0x06` | WAIT_FRAME_TEXT | -- |
+| `0x07` | LUA_EXEC | lua source |
+| `0x08` | WAIT_FRAME_PRIMITIVES | -- |
+| `0x09` | WRITE_FILE | `[path_len:2][path][data]` |
+| `0x0A` | READ_FILE | `[path_len:2][path][offset:4][length:4]` |
+| `0x0B` | WRITE_AT | `[path_len:2][path][offset:4][data]` |
+
+## Map tools (`tools/maps/`)
+
+Convert OpenStreetMap vector tiles to optimized TDMAP format for offline
+viewing.
+
+| File | Purpose |
+|------|---------|
+| `pmtiles_to_tdmap.py` | PMTiles → TDMAP converter |
+| `config.py` | Tile sources, regions, semantic-index → grayscale lookup |
+| `process.py` | Grayscale conversion, dithering, RLE/zlib tile compression |
+| `archive.py` | TDMAP format writer/reader/inspector |
+| `land_mask.py` | Natural Earth land polygon downloader |
+| `viewer.html` | Browser-based TDMAP viewer |
 
 ```bash
-pio run -t upload
+cd tools/maps
+pip install -r requirements.txt
+python pmtiles_to_tdmap.py input.pmtiles -o output.tdmap
+python pmtiles_to_tdmap.py input.pmtiles --bounds 4.0,52.0,5.5,52.5 \
+    --zoom 10,14 -o region.tdmap
 ```
 
-Both Lua and C++ changes require a full rebuild and flash.
+Copy `.tdmap` files to `/sd/maps/`. The Map app's loader
+(`screens/tools/map_loader.lua`) lists every archive there; "Set as
+default" via the M-key actions menu skips the picker on subsequent
+opens.
 
-### Verifying Fixes
+Checkpoints save every 500 tiles; interrupted conversions resume on
+re-run.
 
-After making a fix:
-1. Build and flash: `pio run -t upload`
-2. Navigate to relevant screen via remote key injection
-3. Verify with appropriate capture mode (text/primitives/screenshot)
-4. Check logs for any errors
+### TDMAP format (v6)
 
-## Key Components
+Writer emits v6 only; reader rejects pre-v6 with a "regenerate" message.
 
-### Identity System (Ed25519)
-- Keypairs stored in NVS (`privkey`, `pubkey`)
-- Node ID derived from SHA-256 hash of public key (first 6 bytes)
-- Sign/verify methods for message authentication
+- **Header** (33 bytes): magic, version, compression type, tile/label
+  counts, offsets, zoom range. `palette_count` is always 0; the byte is
+  kept for header-shape stability.
+- **Metadata block**: 4-byte length + TLV tags (region name, bounds,
+  build timestamp, tool version, source hash). Always present (length
+  may be 0) so readers don't need a version-conditional branch to
+  locate the index.
+- **Tile index**: sorted by `(zoom, x, y)` for binary search.
+- **Tile data**: zlib-compressed 3-bit indexed pixels.
+- **Labels**: geographic coords (`lat_e6`, `lon_e6`), zoom ranges,
+  label types.
 
-### Channel System
-- Default channel: `#Public` (joined automatically on startup)
-- Encrypted channels: AES-128-ECB with password-derived keys
-- GRP_TXT plaintext format: `[timestamp:4 LE][type:1][sendername: text]`
-- Room server relays wrap an additional `[timestamp:4][type:1][sender: text]` inside the text
+Semantic feature indices (0-7): Land, Water, Park, Building, RoadMinor,
+RoadMajor, Highway, Railway. Tile colors are **not** stored in the
+archive -- the on-device renderer maps indices to RGB565 via
+`ezui.theme.map_palette()`, so a single archive serves both themes.
 
-### Direct Messages (TXT_MSG)
-- ECDH shared secret (X25519) → first 16 bytes as AES key, full 32 bytes as HMAC key
-- Over-the-air payload: `[dest_hash:1][src_hash:1][MAC:2][ciphertext:N]`
-- MAC: HMAC-SHA256 truncated to 2 bytes, keyed with full 32-byte shared secret
-- Ciphertext: AES-128-ECB, zero-padded to 16-byte boundary
-- Inner plaintext: `[timestamp:4 LE][flags:1][text:N]`
-- Receiver filters by dest_hash, then tries contacts/nodes matching src_hash
+## Rolling OTA updates
 
-### Radio Status
-- `!RF` indicator means radio failed to initialize
-- Check LoRa module wiring if this appears
+Pushes to `main` / `test` trigger `.github/workflows/main-artifacts.yml`
+/ `test-artifacts.yml`. Each builds firmware, generates `manifest.json`
+(SHA, version, sha256, size, asset URL, plus `full_*` variants for the
+bootloader+partitions+app blob), signs it with the Ed25519 key from the
+`OTA_SIGNING_PRIVKEY` secret, runs `xtr-changelog release --commit --tag
+--push` to advance `versions.json` and tag the release, and republishes
+the `rolling-main` / `rolling-test` GitHub Release. Older builds are
+kept as run artefacts (prune caps at 3).
 
-## Theming
+`paths-ignore` excludes generated files (`changelog/versions.json`,
+`changelog/archive.json`, `lua/docs/changelog.json`, `CHANGELOG.md`,
+`platformio.ini`) so the workflow's own release commit doesn't retrigger
+itself. The release commit is also `[skip ci]`-prefixed as defense in
+depth.
 
-`lua/ezui/theme.lua` is the single source of truth for colors and fonts.
+On-device update (`lua/screens/settings/firmware_update.lua`): user
+picks `main` / `test`, screen fetches `manifest.json` and
+`manifest.json.sig`, calls `ez.crypto.ed25519_verify` against the
+embedded `kOtaSigningPubkey` (`src/ota_pubkey.cpp`), and only on valid
+signature passes `full_bin_url` + `full_sha256` into
+`ez.ota.apply_full_url`. The streamer writes the firmware straight into
+the inactive OTA partition (bootloader/partitions only if they differ
+from current flash) and switches the boot slot via direct otadata write.
+Trust flows from the signature, not TLS -- `setInsecure()` is used and
+SHA-256 is re-checked against the manifest while writing.
 
-- Built-in palettes: `dark` (default) and `light`. Selected via
-  `theme.set("dark"|"light")`, persisted under the `theme` pref, and
-  restored at boot.
-- Accent color is independent of the dark/light choice. Stored under
-  `accent_color`, picked from `theme.ACCENT_PRESETS`. Settings → Display
-  → Accent colour.
-- **Map palette**: `theme.map_palette()` returns the 8-color tile palette
-  + label inks/halo for the active theme. The map renderer reads this
-  every frame, so a theme switch repaints tiles without invalidating the
-  cache. See `lua/ezui/widgets/map_view.lua`.
-- User entry points: Settings → Display → Theme → Dark mode toggle. The
-  Map screen also accepts `T` as a legacy shortcut.
+**Setup ceremony** (once per project):
 
-When adding new theme tokens, use `theme.color("NAME")` rather than raw
-RGB565 literals so the value can flow through both palettes.
+1. `pip install pynacl && python tools/ota/gen_signing_key.py`
+2. Paste private key into repo secret `OTA_SIGNING_PRIVKEY`.
+3. Paste C-array form into `kOtaSigningPubkey` in
+   `src/ota_pubkey.cpp` (replacing the all-zero placeholder).
+4. Build + flash. Devices flashed before this won't accept rolling-main
+   updates -- `ez.ota.signing_pubkey()` returns nil and the screen shows
+   "OTA signing not configured on this device".
 
-## C++ Binding Safety Rules
+Key rotation: burn a new firmware containing the new pubkey, then
+rotate the secret. **Don't lose the private key** -- recovery means
+reflashing every device manually.
 
-### Dangling lua_State* Pointer Bug
+### Branch ruleset push gate
 
-**CRITICAL:** Never store a `lua_State* L` parameter in a static/global variable when
-the function may be called from a Lua coroutine. The coroutine's state becomes invalid
-after it is garbage collected, causing crashes when the stored pointer is later used.
+The workflow's `xtr-changelog --push` step pushes `[skip ci]` release
+commits + tags back to `main` / `test`. Both branches are protected by
+repo rulesets (`scripts/branch-protection.sh`); the `pull_request` rule
+blocks direct pushes from any actor not on the bypass list, including
+the workflow's `GITHUB_TOKEN`. The "GitHub Actions" identity does not
+appear in the bypass picker on the free org plan.
 
-This bug has occurred multiple times:
-- Packet callbacks in `mesh_bindings.cpp` — used to capture the registering coroutine's state and crashed once that coroutine was GC'd; fixed by switching to `LUA_STATE` at the call sites (see e.g. `mesh_bindings.cpp:166`).
-- `timerLuaState` in `system_bindings.cpp` — stored boot coroutine's state, crashed on 30-second timer; now resolved via `LUA_STATE` (see comment at `system_bindings.cpp:103`).
+**Workaround**: a write-enabled deploy key `auto-release-push` (private
+half in repo secret `RELEASE_PUSH_KEY`) **plus a `DeployKey` bypass
+actor on each ruleset**. The `*-artifacts.yml` workflows load the key
+via `webfactory/ssh-agent` and check out over SSH so the push flows
+through the same key. **Deploy keys do NOT bypass rulesets
+implicitly** -- the `DeployKey` bypass actor must be present (it
+covers any deploy key on the repo; the API stores it with
+`actor_id: null`).
 
-**Fix pattern:** Use the `LUA_STATE` macro (`LuaRuntime::instance().getState()`) which
-always returns the main Lua state. Include `lua_runtime.h` for access.
+If OTA releases stop publishing, check the "Generate changelog, sync
+version, and push back" step. `GH013 / Changes must be made through a
+pull request` means the push reached GitHub but the `pull_request` rule
+fired. Two common causes:
+
+1. The `DeployKey` bypass entry is missing from the ruleset's
+   `bypass_actors`. Re-run `scripts/branch-protection.sh`, or add it
+   manually:
+   ```sh
+   gh api repos/ezmesh/ezos/rulesets        # find the ruleset id
+   gh api -X PUT repos/ezmesh/ezos/rulesets/<id> -f \
+       'bypass_actors[][actor_type]=DeployKey' \
+       -f 'bypass_actors[][bypass_mode]=always' ...
+   ```
+   (The PUT replaces the full payload.)
+2. SSH push fell back to HTTPS+`GITHUB_TOKEN` because the deploy key
+   is missing or the secret was rotated. Regenerate with
+   `ssh-keygen -t ed25519`, register the public half via
+   `POST /repos/ezmesh/ezos/keys` with `read_only: false`, re-upload
+   the private half to `RELEASE_PUSH_KEY`. The `webfactory/ssh-agent`
+   step's log (`Identity added: ...`, fingerprint) confirms whether
+   auth got off the ground.
+
+## C++ binding safety: dangling `lua_State*`
+
+**CRITICAL:** Never store a `lua_State* L` parameter in a
+static/global variable when the function may be called from a Lua
+coroutine. The coroutine's state becomes invalid after it is GC'd,
+crashing later use of the stored pointer.
+
+Has bitten this codebase twice:
+- Packet callbacks in `mesh_bindings.cpp` -- captured the registering
+  coroutine's state, crashed once GC'd. Fixed by switching to
+  `LUA_STATE` at call sites (`mesh_bindings.cpp:166`).
+- `timerLuaState` in `system_bindings.cpp` -- stored boot coroutine's
+  state, crashed on 30-second timer. Now uses `LUA_STATE`
+  (`system_bindings.cpp:103`).
+
+**Fix pattern**: use the `LUA_STATE` macro
+(`LuaRuntime::instance().getState()`), which always returns the main
+Lua state. Include `lua_runtime.h`.
 
 ```cpp
 // BAD: L may be a coroutine state that gets GC'd
 static lua_State* savedState = nullptr;
-LUA_FUNCTION(my_func) {
-    savedState = L;  // Dangling after coroutine GC!
-}
+LUA_FUNCTION(my_func) { savedState = L; }
 
-// GOOD: Always use main state
+// GOOD: always use main state
 void myCallback() {
-    lua_State* L = LUA_STATE;  // Always valid
+    lua_State* L = LUA_STATE;
     if (L) { lua_pcall(L, ...); }
 }
 ```
 
-When writing new C++ bindings that register callbacks, audit every `lua_State*` that
-outlives the current function call. If it's stored for later use, it must come from
-`LUA_STATE`, not from the `L` parameter.
+When writing bindings that register callbacks, audit every `lua_State*`
+that outlives the current function call. If stored, it must come from
+`LUA_STATE`, not the `L` parameter.
 
 ## Documentation
 
-Two doc surfaces live under `docs/`:
+Two doc surfaces under `docs/`:
 
-- `docs/manual/` — User-facing manual (Markdown + generated HTML).
-  Hand-written prose covering what the device does, how to use each
-  app, and where to find settings.
-- `docs/api/` — Lua API reference, **generated from C++ binding
+- `docs/manual/` -- user-facing manual (hand-written prose + generated
+  HTML). Covers what the device does, how to use each app, where to find
+  settings.
+- `docs/api/` -- Lua API reference, **generated from C++ binding
   annotations** by `tools/generate_lua_docs.py`. Do not hand-edit;
-  changes are overwritten on the next regen.
+  overwritten on next regen.
 
-### Annotation conventions (C++ bindings)
+### Annotation conventions
 
-Every Lua binding under `src/lua/bindings/` is documented inline with
-structured comments. The generator parses these into `docs/api/`. See
-the docstring at the top of `tools/generate_lua_docs.py` for the full
-grammar; the common cases:
+Every binding under `src/lua/bindings/` is documented inline. The
+generator's docstring has the full grammar; common cases:
 
 ```cpp
 // @module ez.display
@@ -812,131 +605,141 @@ grammar; the common cases:
 // @payload { key: string, special: bool, ctrl: bool, shift: bool }
 ```
 
-Bus topics (`@bus`), parameters (`@param`), return values (`@return`),
-and code samples (`@example`) all flow into the published API page.
+`@bus`, `@param`, `@return`, and `@example` all flow into the published
+API page.
 
-### Regenerating docs
+### Regenerating
 
 ```bash
 python tools/generate_lua_docs.py
 ```
 
-The script writes both Markdown and HTML to `docs/api/` and `docs/manual/`.
-There is **no** "watch" mode; run it manually after touching annotations.
+Writes Markdown + HTML to `docs/api/` and `docs/manual/`. No watch
+mode; run manually after touching annotations.
 
 ### Maintenance contract
 
-- **Adding or modifying a Lua binding**: update the C++ annotation in
-  the same diff. Don't ship undocumented surface — `@brief` at minimum.
-- **Adding or removing a Lua-only API** (something that doesn't go
-  through a C++ binding, e.g. a service or ezui module): document it
-  under `docs/manual/` if it's user-visible, or in CLAUDE.md if it's
-  developer-only context.
-- **Adding a new screen / app / settings panel**: add or update the
-  matching page under `docs/manual/<area>/index.md`.
-- **Changing on-disk formats** (TDMAP, prefs, transfer protocol): keep
-  CLAUDE.md's Key Components / TDMAP / MeshCore sections honest. Bump
-  the version constant *and* the prose in the same commit.
+- **Adding/modifying a Lua binding**: update the C++ annotation in the
+  same diff. `@brief` minimum -- don't ship undocumented surface.
+- **Adding/removing a Lua-only API** (service or ezui module, no C++
+  binding): document under `docs/manual/` if user-visible, in CLAUDE.md
+  if developer-only.
+- **New screen / app / settings panel**: add or update the matching
+  page under `docs/manual/<area>/index.md`.
+- **On-disk format changes** (TDMAP, prefs, transfer protocol): keep
+  the Key Components / TDMAP / MeshCore sections honest. Bump version
+  constants *and* prose in the same commit.
 - **CLAUDE.md itself is a living doc**: when a section becomes wrong
-  (renamed module, deleted screen, format bump), fix the section in the
-  same change set rather than letting drift accumulate.
+  (renamed module, deleted screen, format bump), fix it in the same
+  change set rather than letting drift accumulate.
 
 The on-device docs reader (`lua/screens/tools/help.lua`) browses two
-stores: firmware-embedded markdown under `lua/docs/` (hand-authored
-prose, exposed via the `ez.docs.list` / `ez.docs.read` bindings) and
-SD-side markdown under `/sd/docs/manual/` and `/sd/docs/api/` (the
-bulkier auto-generated reference content). Both render through
-`lua/ezui/markdown.lua`, the same renderer used by the About screen.
+stores: firmware-embedded markdown under `lua/docs/` (hand-authored,
+exposed via `ez.docs.list` / `ez.docs.read`) and SD-side markdown under
+`/sd/docs/manual/` and `/sd/docs/api/` (bulkier auto-generated
+reference). Both render through `lua/ezui/markdown.lua`.
 
 Source-of-truth split:
-- `lua/docs/manual/` — hand-authored, embedded in firmware. Edit
-  directly; the embedder picks it up on the next `pio run`.
-- `docs/manual/` and `docs/api/` — auto-generated by
-  `tools/generate_lua_docs.py` from C++ binding annotations and Lua
-  registries. Do not hand-edit; deployed to GitHub Pages and meant to
-  be copied to SD for on-device reference reading.
+- `lua/docs/manual/` -- hand-authored, embedded in firmware. Edit
+  directly; the embedder picks up on next `pio run`.
+- `docs/manual/` and `docs/api/` -- auto-generated. Do not hand-edit;
+  deployed to GitHub Pages and meant to be copied to SD for on-device
+  reference reading.
 
-## MeshCore Protocol Reference
+## Key components
 
-Reference implementation: https://github.com/ripplebiz/MeshCore
+### Identity (Ed25519)
+- Keypairs in NVS (`privkey`, `pubkey`).
+- Node ID = first 6 bytes of SHA-256(pubkey).
+- Sign/verify for message authentication.
 
-### Cryptographic Constants
-- `PUB_KEY_SIZE`: 32 bytes (Ed25519 public key)
-- `PRV_KEY_SIZE`: 64 bytes (Ed25519 private key)
-- `SIGNATURE_SIZE`: 64 bytes (Ed25519 signature)
-- `SEED_SIZE`: 32 bytes
+### Channels
+- Default `#Public`, joined automatically at startup.
+- Encrypted channels: AES-128-ECB with password-derived keys.
+- GRP_TXT plaintext: `[timestamp:4 LE][type:1][sendername: text]`.
+- Room server relays wrap an additional
+  `[timestamp:4][type:1][sender: text]` inside the text.
 
-### Cipher Constants
-- `CIPHER_KEY_SIZE`: 16 bytes
-- `CIPHER_BLOCK_SIZE`: 16 bytes
-- `CIPHER_MAC_SIZE`: 2 bytes
+### Direct messages (TXT_MSG)
+- ECDH shared secret (X25519); first 16 bytes = AES key, full 32 = HMAC
+  key.
+- OTA payload: `[dest_hash:1][src_hash:1][MAC:2][ciphertext:N]`.
+- MAC: HMAC-SHA256 truncated to 2 bytes, keyed with full 32-byte shared
+  secret.
+- Ciphertext: AES-128-ECB, zero-padded to 16-byte boundary.
+- Inner plaintext: `[timestamp:4 LE][flags:1][text:N]`.
+- Receiver filters by `dest_hash`, then tries contacts/nodes matching
+  `src_hash`.
 
-### Packet Constants
-- `MAX_PACKET_PAYLOAD`: 184 bytes
-- `MAX_PATH_SIZE`: 64 bytes
-- `MAX_TRANS_UNIT`: 255 bytes
-- `MAX_ADVERT_DATA_SIZE`: 32 bytes
-- `PATH_HASH_SIZE`: 1 byte
+### Radio
+- `!RF` indicator = LoRa init failed. Check module wiring.
 
-### Packet Header Format (1 byte)
-- Bits 0-1: Route type (mask 0x03)
-- Bits 2-5: Payload type (shift 2, mask 0x0F)
-- Bits 6-7: Payload version (shift 6, mask 0x03)
+## MeshCore protocol reference
 
-### Route Types
-- `ROUTE_TYPE_TRANSPORT_FLOOD` (0x00): Flood with transport codes
-- `ROUTE_TYPE_FLOOD` (0x01): Standard flood routing
-- `ROUTE_TYPE_DIRECT` (0x02): Direct with supplied path
-- `ROUTE_TYPE_TRANSPORT_DIRECT` (0x03): Direct with transport codes
+Reference: https://github.com/ripplebiz/MeshCore
 
-### ADVERT Packet Payload Format
+### Sizes
+- Identity: `PUB_KEY_SIZE`=32, `PRV_KEY_SIZE`=64, `SIGNATURE_SIZE`=64,
+  `SEED_SIZE`=32.
+- Cipher: `CIPHER_KEY_SIZE`=16, `CIPHER_BLOCK_SIZE`=16,
+  `CIPHER_MAC_SIZE`=2.
+- Packet: `MAX_PACKET_PAYLOAD`=184, `MAX_PATH_SIZE`=64,
+  `MAX_TRANS_UNIT`=255, `MAX_ADVERT_DATA_SIZE`=32, `PATH_HASH_SIZE`=1.
+
+### Packet header (1 byte)
+- Bits 0-1: route type (mask `0x03`).
+- Bits 2-5: payload type (shift 2, mask `0x0F`).
+- Bits 6-7: payload version (shift 6, mask `0x03`).
+
+Route types: `TRANSPORT_FLOOD`=0x00, `FLOOD`=0x01, `DIRECT`=0x02,
+`TRANSPORT_DIRECT`=0x03.
+
+### ADVERT payload
+
 ```
 [pub_key:32][timestamp:4][signature:64][app_data:variable]
 ```
-- Offset 0: Public key (32 bytes)
-- Offset 32: Timestamp (4 bytes, little-endian)
-- Offset 36: Ed25519 signature (64 bytes)
-- Offset 100: App data (up to 32 bytes) - contains node name, location, metadata
 
-**Signature computed over:** `[pub_key:32][timestamp:4][app_data:variable]`
+- 0: pubkey (32).
+- 32: timestamp (4 LE).
+- 36: Ed25519 signature (64).
+- 100: app data (up to 32) -- name, location, metadata.
 
-### App Data Structure (within ADVERT)
-All multi-byte integers are little-endian.
+**Signature is computed over**: `[pub_key:32][timestamp:4][app_data:variable]`.
 
-| Field | Offset | Size | Type | Description |
-|-------|--------|------|------|-------------|
-| flags | 0 | 1 | uint8 | Bit flags for presence/type |
-| latitude | 1 | 4 | int32_le | Optional: lat × 1,000,000 |
-| longitude | 5 | 4 | int32_le | Optional: lon × 1,000,000 |
-| feature1 | 9 | 2 | uint16_le | Optional: reserved |
-| feature2 | 11 | 2 | uint16_le | Optional: reserved |
-| name | variable | variable | string | UTF-8 node name |
+App data (all multi-byte ints LE):
 
-### Flags Byte
-| Bit | Value | Meaning |
-|-----|-------|---------|
-| 0-1 | 0x01 | Chat node |
-| 0-1 | 0x02 | Repeater |
-| 0-1 | 0x03 | Room server |
-| 2 | 0x04 | Sensor |
-| 4 | 0x10 | Has location (lat/lon present) |
-| 5 | 0x20 | Has feature1 |
-| 6 | 0x40 | Has feature2 |
-| 7 | 0x80 | Has name |
+| Field | Offset | Size | Type | Notes |
+|-------|--------|------|------|-------|
+| flags | 0 | 1 | uint8 | presence/type bits |
+| latitude | 1 | 4 | int32_le | optional: lat × 1e6 |
+| longitude | 5 | 4 | int32_le | optional: lon × 1e6 |
+| feature1 | 9 | 2 | uint16_le | optional, reserved |
+| feature2 | 11 | 2 | uint16_le | optional, reserved |
+| name | var | var | string | UTF-8 |
 
-### Location Encoding
-- Latitude/Longitude stored as `int32_le` = decimal degrees × 1,000,000
-- Example: 47.543968° → 47543968, -122.108616° → -122108616
-- Only present when flags bit 4 (0x10) is set
+Flags byte:
 
-### Device Roles (bits 0-1)
-- 0x01: Chat client (companion app user)
-- 0x02: Repeater (infrastructure node, often has GPS)
-- 0x03: Room server
+| Bit/value | Meaning |
+|-----------|---------|
+| 0-1 = 0x01 | chat node |
+| 0-1 = 0x02 | repeater |
+| 0-1 = 0x03 | room server |
+| 2 (0x04) | sensor |
+| 4 (0x10) | has location |
+| 5 (0x20) | has feature1 |
+| 6 (0x40) | has feature2 |
+| 7 (0x80) | has name |
 
-### Key Source Files (ripplebiz/MeshCore)
-- [src/Packet.h](https://github.com/ripplebiz/MeshCore/blob/main/src/Packet.h) - Packet structure and header format
-- [src/Mesh.cpp](https://github.com/ripplebiz/MeshCore/blob/main/src/Mesh.cpp) - Packet handling including ADVERT processing
-- [src/Identity.h](https://github.com/ripplebiz/MeshCore/blob/main/src/Identity.h) - Ed25519 identity class
-- [src/MeshCore.h](https://github.com/ripplebiz/MeshCore/blob/main/src/MeshCore.h) - Main constants and definitions
-- [src/helpers/AdvertDataHelpers.h](https://github.com/ripplebiz/MeshCore/blob/main/src/helpers/AdvertDataHelpers.h) - ADVERT appdata parsing
+Lat/lon encoded as `int32_le = decimal_degrees * 1_000_000`
+(e.g. 47.543968° → 47543968). Only present when bit 4 (`0x10`) is set.
+
+Device roles (bits 0-1): `0x01` chat client, `0x02` repeater (often
+GPS-equipped), `0x03` room server.
+
+### Key MeshCore source files
+- [`src/Packet.h`](https://github.com/ripplebiz/MeshCore/blob/main/src/Packet.h) -- packet structure + header format
+- [`src/Mesh.cpp`](https://github.com/ripplebiz/MeshCore/blob/main/src/Mesh.cpp) -- packet handling (ADVERT processing)
+- [`src/Identity.h`](https://github.com/ripplebiz/MeshCore/blob/main/src/Identity.h) -- Ed25519 identity class
+- [`src/MeshCore.h`](https://github.com/ripplebiz/MeshCore/blob/main/src/MeshCore.h) -- main constants
+- [`src/helpers/AdvertDataHelpers.h`](https://github.com/ripplebiz/MeshCore/blob/main/src/helpers/AdvertDataHelpers.h) -- ADVERT appdata parsing


### PR DESCRIPTION
## Summary
- Drops ~200 lines (~21%) by collapsing three near-duplicate build/flash blocks and the scattered debug / capture / remote-control sections into single canonical sections.
- Tightens verbose prose around OTA setup, the branch ruleset workaround, the keyboard layout intro, and the font ASCII rule -- without losing any load-bearing fact.
- Stacked on #104 so the input-lock service / touch-lock guard references stay accurate; will retarget to `test` automatically once #104 merges.

Preserved verbatim: the dangling `lua_State*` incident citations, the `DeployKey` bypass-actor workaround, the font ASCII rule, the keyboard chord rules, the touch wake-gate / input-lock guard pairing, service init order, TDMAP v6 format, and the MeshCore ADVERT structure.

## Test plan
- [ ] Skim the rendered diff on GitHub for any factual claims that changed shape (build commands, port assignments, service order, protocol tables, code samples).
- [ ] Confirm the remaining non-ASCII characters in CLAUDE.md (`→`, `°`, `×`, box-drawing) are limited to the directory tree and protocol-spec tables -- they were present before and never reach `draw_text`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)