### PR TITLE
feat(console): web flasher + first-boot pref pre-seed (#24)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,12 +8,14 @@ on:
       - 'src/lua/bindings/**'
       - 'tools/generate_lua_docs.py'
       - 'docs/**'
+      - 'console/**'
       - '.github/workflows/docs.yml'
   pull_request:
     paths:
       - 'src/lua/bindings/**'
       - 'tools/generate_lua_docs.py'
       - 'docs/**'
+      - 'console/**'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
@@ -48,6 +50,19 @@ jobs:
             echo "Run 'python tools/generate_lua_docs.py' locally and commit the result."
             exit 1
           fi
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: console/package-lock.json
+
+      - name: Build web console
+        working-directory: console
+        run: |
+          npm ci
+          npm run build
 
       - name: Setup Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,13 @@ node_modules/
 /docs/manual/
 /docs/index.html
 
+# Generated web console (built by .github/workflows/docs.yml via `npm run
+# build` in console/; output goes here and is uploaded as part of the
+# Pages artifact alongside the manual/API reference).
+/docs/console/
+/console/node_modules/
+/console/dist/
+
 # Claude local state (per-machine). Shared skills under .claude/skills/
 # are tracked; settings.local.json holds machine-specific permissions.
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,8 +168,17 @@ writing.
    the screen shows "OTA signing not configured on this device".
 
 Key rotation is "burn a new firmware containing the new pubkey, then
-rotate the secret". Don't lose the private key — there's no recovery
-path other than reflashing every device manually.
+rotate the secret, then update every consumer of the pubkey". Concretely:
+(a) regenerate the keypair with `tools/ota/gen_signing_key.py`,
+(b) replace the C array in `src/ota_pubkey.cpp`'s `kOtaSigningPubkey`,
+(c) replace the hex constant `OTA_PUBKEY_HEX` in
+`console/src/flash/manifest.ts` (the web flasher verifies the same
+manifest signature, and missing this step makes every new release look
+"unsigned" to the console even though the on-device updater still
+accepts it), (d) rotate the `OTA_SIGNING_PRIVKEY` GitHub secret,
+(e) reflash every device in the field with the new firmware. Don't
+lose the private key — there's no recovery path other than reflashing
+every device manually.
 
 **Branch ruleset push gate** (already wired, documented for context):
 the auto-release workflow's `xtr-changelog --push` step pushes the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,17 @@ ezos/
 ├── scripts/                # Build-time generators (Lua embedder)
 ├── tools/                  # Host utilities (map gen, remote control,
 │                          #   doc generator, font/icon/sound gen)
+├── console/                # Browser-based flasher + first-boot
+│   │                      #   pref pre-seed tool, hosted at
+│   │                      #   ezmesh.github.io/ezos/console/
+│   ├── src/
+│   │   ├── nvs/           # ESP-IDF NVS partition image encoder
+│   │   │                  #   (mirrors lua_storage + meshcore namespaces)
+│   │   ├── flash/         # esptool-js wrapper (Web Serial)
+│   │   ├── github/        # GitHub Releases fetch w/ localStorage cache
+│   │   ├── protocol/      # ezOS remote-control protocol client
+│   │   └── ui/            # Vanilla-TS controller / steps / state
+│   └── vite.config.ts     # base = /ezos/console/, outDir = ../docs/console
 └── docs/                   # User manual + Lua API reference (see below)
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,19 @@ A complete embedded operating system for the **LilyGo T-Deck Plus** (ESP32-S3 wi
 
 > ⚠️ **Warning:** This firmware has only been tested on the **T-Deck Plus**. Use at your own risk — no warranty or guarantee is provided.
 
-**Easiest method** - Use the web flasher (no software install required):
+**Easiest method** - Use the **ezOS Console** in a Chromium-based
+browser. No download, no installer, no terminal. Picks the latest
+release for you, flashes via Web Serial, and can pre-seed first-boot
+settings (node name, region, WiFi, theme...) so the device boots
+straight to the desktop without going through the on-device onboarding
+wizard:
 
-1. Download the latest `ezos-vX.X.X-full.bin` from [Releases](../../releases/latest)
-2. Open the [MeshCore Web Flasher](https://flasher.meshcore.co/)
-3. Connect your T-Deck Plus via USB and flash
+- **Console:** <https://ezmesh.github.io/ezos/console/>
+
+For air-gapped or non-Chromium setups, the generic
+[MeshCore Web Flasher](https://flasher.meshcore.co/) still works with
+the `firmware-full.bin` from [Releases](../../releases/latest), but it
+doesn't know about ezOS-specific settings.
 
 [![Download Latest](https://img.shields.io/github/v/release/ezmesh/ezos?label=Download&style=for-the-badge)](../../releases/latest)
 

--- a/console/README.md
+++ b/console/README.md
@@ -8,14 +8,33 @@ reference. Tracking issue: [#24](https://github.com/ezmesh/ezos/issues/24).
 ## What it does
 
 - **Flash** the latest `firmware-full.bin` (or `firmware.bin` for an
-  app-only update) from any GitHub release, including the rolling-main /
-  rolling-test channels. Drives `esptool-js` over Web Serial.
+  app-only update) from a signed GitHub release. Drives `esptool-js`
+  over Web Serial.
 - **Pre-seed** first-boot settings by building a binary NVS partition
   image in the browser and flashing it to offset `0x9000` (see
   `partitions_16MB.csv`). The device boots once into a fully-configured
   state -- no second handshake required.
 
 Tier 3 (bulk identity/contact/map upload) is deferred; see the issue.
+
+## Integrity / trust model
+
+Same threat model as the on-device updater
+(`lua/screens/settings/firmware_update.lua`): every rolling-main /
+rolling-test release ships `manifest.json` + `manifest.json.sig`. The
+console:
+
+1. Fetches both, verifies the Ed25519 signature against the public key
+   vendored from `src/ota_pubkey.cpp` (`src/flash/manifest.ts`).
+2. Downloads the firmware blob the manifest points at.
+3. Verifies the blob's SHA-256 against the corresponding manifest
+   field (`full_sha256` for the full image, `sha256` for app-only).
+4. Only then hands the bytes to `esptool-js`.
+
+A release without manifest + sig (tagged releases from
+`build-release.yml` currently fall into this bucket) is rejected at the
+"Flash options" step. The on-device updater would refuse it too --
+trust flows from the signing key, not from TLS to GitHub.
 
 ## Local dev
 

--- a/console/README.md
+++ b/console/README.md
@@ -1,0 +1,101 @@
+# ezOS Console
+
+Hosted web app for flashing and configuring an ezOS T-Deck Plus from a
+Chromium-based browser. Deployed by `.github/workflows/docs.yml` to
+`https://ezmesh.github.io/ezos/console/` alongside the manual and API
+reference. Tracking issue: [#24](https://github.com/ezmesh/ezos/issues/24).
+
+## What it does
+
+- **Flash** the latest `firmware-full.bin` (or `firmware.bin` for an
+  app-only update) from any GitHub release, including the rolling-main /
+  rolling-test channels. Drives `esptool-js` over Web Serial.
+- **Pre-seed** first-boot settings by building a binary NVS partition
+  image in the browser and flashing it to offset `0x9000` (see
+  `partitions_16MB.csv`). The device boots once into a fully-configured
+  state -- no second handshake required.
+
+Tier 3 (bulk identity/contact/map upload) is deferred; see the issue.
+
+## Local dev
+
+```sh
+cd console
+npm install
+npm run dev      # http://localhost:5173/ezos/console/
+npm run build    # writes docs/console/, picked up by the Pages workflow
+```
+
+`npm run build` runs `tsc --noEmit` first; type errors fail the build.
+
+## NVS encoder smoke test
+
+```sh
+npx tsx src/nvs/encoder.test.ts
+```
+
+Validates structural invariants of a generated image (size, page header
+CRC, per-entry CRCs, namespace routing, string descriptor CRC). A future
+improvement is to byte-match against ESP-IDF's `nvs_partition_gen.py` in
+CI; see the acceptance criteria on #24.
+
+## Layout
+
+```
+console/
+|-- index.html
+|-- vite.config.ts     # base = /ezos/console/, outDir = ../docs/console
+|-- src/
+|   |-- main.ts        # entry point
+|   |-- style.css
+|   |-- nvs/
+|   |   |-- crc32.ts
+|   |   |-- schema.ts  # mirrors lua/services/prefs_registry.lua + extras
+|   |   |-- encoder.ts # NVS partition image builder (multi-namespace)
+|   |   '-- encoder.test.ts
+|   |-- flash/
+|   |   '-- esptool.ts # esptool-js wrapper + binary downloader
+|   |-- github/
+|   |   '-- releases.ts # api.github.com fetch + localStorage cache
+|   |-- protocol/
+|   |   '-- remote.ts  # ezOS remote-control protocol client (cmds 0x01-0x0B)
+|   '-- ui/
+|       |-- app.ts     # controller / state machine
+|       |-- state.ts   # AppState + WizardValues + seed builder
+|       |-- steps.ts   # per-step renderers
+|       '-- dom.ts     # tiny DOM helpers
+```
+
+## Browser support
+
+Requires the **Web Serial API**: Chrome, Edge, Brave, Opera, or another
+Chromium-based desktop browser. Firefox and Safari do not implement Web
+Serial and the connect button is replaced by a "use Chrome" notice.
+iOS / Android Chromium do not expose Web Serial either; this is a
+desktop tool.
+
+## How the seeded values land on the device
+
+The NVS image declares two namespaces:
+
+- **`lua_storage`** (index 1) -- where `ez.storage.set_pref`/`get_pref`
+  live. Almost every wizard value goes here: `onboarded`, `wifi_ssid`,
+  `wifi_password`, `tz_posix`, `theme`, `accent_color`, brightness,
+  `radio_freq_mhz`, etc. The on-device `lua/boot.lua` already reads
+  `tz_posix` (line 103) and the WiFi prefs (line 548) on every boot.
+- **`meshcore`** (index 2) -- where `src/mesh/identity.cpp` stores the
+  node name. The only wizard value that goes here is `nodename`.
+
+No `boot.lua` changes are needed; everything routes through prefs that
+the firmware already consumes. The `onboarded = "1"` sentinel makes
+`lua/screens/onboarding/init.lua:is_onboarded()` return true on first
+boot, so the device skips the wizard and lands on the desktop.
+
+## Out of scope (for now)
+
+- Backup / restore of an existing device.
+- Two-device pairing helper.
+- SD-card asset upload (wallpapers, TDMAP archives).
+- PWA / offline cache.
+- Auth-gated GitHub release fetching (currently unauthenticated, 60
+  req/hour per IP).

--- a/console/index.html
+++ b/console/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="color-scheme" content="light dark" />
+        <title>ezOS Console</title>
+    </head>
+    <body>
+        <header class="topbar">
+            <div class="topbar-inner">
+                <a class="brand" href="/ezos/">ezOS</a>
+                <span class="brand-sep">/</span>
+                <span class="brand-page">Console</span>
+                <span class="topbar-spacer"></span>
+                <a class="topbar-link" href="/ezos/manual/" target="_blank">Manual</a>
+                <a class="topbar-link" href="https://github.com/ezmesh/ezos" target="_blank">Source</a>
+            </div>
+        </header>
+        <main id="app"></main>
+        <footer class="footer">
+            <small>
+                Runs entirely in your browser. Identity keys never leave this
+                machine. <a href="https://github.com/ezmesh/ezos/issues/24">Issue #24</a>.
+            </small>
+        </footer>
+        <script type="module" src="./src/main.ts"></script>
+    </body>
+</html>

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -1,0 +1,1042 @@
+{
+  "name": "ezos-console",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ezos-console",
+      "version": "0.1.0",
+      "dependencies": {
+        "esptool-js": "^0.5.4"
+      },
+      "devDependencies": {
+        "@types/w3c-web-serial": "^1.0.8",
+        "typescript": "^5.5.4",
+        "vite": "^5.4.10"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/w3c-web-serial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-serial/-/w3c-web-serial-1.0.8.tgz",
+      "integrity": "sha512-QQOT+bxQJhRGXoZDZGLs3ksLud1dMNnMiSQtBA0w8KXvLpXX4oM4TZb6J0GgJ8UbCaHo5s9/4VQT8uXy9JER2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/esptool-js": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.5.7.tgz",
+      "integrity": "sha512-k3pkXU9OTySCd58OUDjuJWNnFjM+QpPWAghxyWPm3zNfaLiP4ex2jNd7Rj0jWPu3/fgvwau236tetsTZrh4x5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "atob-lite": "^2.0.0",
+        "pako": "^2.1.0",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -8,6 +8,8 @@
       "name": "ezos-console",
       "version": "0.1.0",
       "dependencies": {
+        "@noble/ed25519": "^3.1.0",
+        "@noble/hashes": "^2.2.0",
         "esptool-js": "^0.5.4"
       },
       "devDependencies": {
@@ -405,6 +407,27 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.1.0.tgz",
+      "integrity": "sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/console/package.json
+++ b/console/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ezos-console",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "esptool-js": "^0.5.4"
+  },
+  "devDependencies": {
+    "@types/w3c-web-serial": "^1.0.8",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.10"
+  }
+}

--- a/console/package.json
+++ b/console/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@noble/ed25519": "^3.1.0",
+    "@noble/hashes": "^2.2.0",
     "esptool-js": "^0.5.4"
   },
   "devDependencies": {

--- a/console/src/flash/esptool.ts
+++ b/console/src/flash/esptool.ts
@@ -1,0 +1,159 @@
+// Esptool-js wrapper. Drives the actual flash from inside the browser via
+// Web Serial. We do this in a separate file so the rest of the UI never
+// has to know the esptool-js types directly.
+
+import { ESPLoader, Transport } from "esptool-js";
+
+// NVS partition offset, per partitions_16MB.csv.
+export const NVS_OFFSET = 0x9000;
+
+// Offset of the merged firmware-full.bin (bootloader at 0x0000).
+export const FULL_OFFSET = 0x0000;
+
+// Offset of the app-only firmware.bin (app0 partition).
+export const APP_OFFSET = 0x10000;
+
+export interface FlashFile {
+    /** Byte offset in flash. */
+    address: number;
+    /** Raw bytes to write. */
+    data: Uint8Array;
+    /** Human-friendly label for progress reporting. */
+    label: string;
+}
+
+export interface FlashOptions {
+    files: FlashFile[];
+    onLog: (line: string) => void;
+    onProgress: (label: string, written: number, total: number) => void;
+    /**
+     * If true, erase the chip before writing. Use this on a fresh device or
+     * when the user explicitly asks for a factory reset.
+     */
+    eraseAll?: boolean;
+}
+
+function uint8ToBinaryString(buf: Uint8Array): string {
+    // esptool-js expects a string where each char is a byte (0-255).
+    // String.fromCharCode in a chunked loop avoids the call-stack limit
+    // that the spread operator would hit on big buffers.
+    let out = "";
+    const CHUNK = 0x8000;
+    for (let i = 0; i < buf.length; i += CHUNK) {
+        out += String.fromCharCode.apply(
+            null,
+            Array.from(buf.subarray(i, Math.min(i + CHUNK, buf.length))),
+        );
+    }
+    return out;
+}
+
+export async function requestPort(): Promise<SerialPort> {
+    if (!("serial" in navigator)) {
+        throw new Error(
+            "Web Serial is not available in this browser. Open this page in Chrome, Edge, or another Chromium-based browser on desktop.",
+        );
+    }
+    return await navigator.serial.requestPort({ filters: [] });
+}
+
+export class Flasher {
+    private port: SerialPort | null = null;
+    private transport: Transport | null = null;
+    private loader: ESPLoader | null = null;
+
+    async connect(opts: { onLog: (s: string) => void }): Promise<{ chip: string }> {
+        this.port = await requestPort();
+        this.transport = new Transport(this.port, true);
+
+        const terminal = {
+            clean() {},
+            writeLine: (data: string) => opts.onLog(data),
+            write: (data: string) => opts.onLog(data),
+        };
+
+        this.loader = new ESPLoader({
+            transport: this.transport,
+            baudrate: 921600,
+            romBaudrate: 115200,
+            terminal,
+        } as any); // ESPLoader's constructor type drifts between releases.
+
+        const chip = await this.loader.main();
+        return { chip };
+    }
+
+    async flash(opts: FlashOptions): Promise<void> {
+        if (!this.loader) throw new Error("not connected");
+        const fileArray = opts.files.map((f) => ({
+            data: uint8ToBinaryString(f.data),
+            address: f.address,
+        }));
+
+        if (opts.eraseAll) {
+            opts.onLog("Erasing flash...");
+            await this.loader.eraseFlash();
+        }
+
+        await this.loader.writeFlash({
+            fileArray,
+            flashSize: "keep",
+            flashMode: "keep",
+            flashFreq: "keep",
+            eraseAll: false,
+            compress: true,
+            reportProgress: (fileIndex: number, written: number, total: number) => {
+                const label = opts.files[fileIndex]?.label ?? `image #${fileIndex}`;
+                opts.onProgress(label, written, total);
+            },
+            calculateMD5Hash: () => "",
+        } as any);
+    }
+
+    async hardReset(): Promise<void> {
+        if (!this.transport) return;
+        await this.transport.setDTR(false);
+        await new Promise((r) => setTimeout(r, 100));
+        await this.transport.setDTR(true);
+    }
+
+    async disconnect(): Promise<void> {
+        try {
+            await this.transport?.disconnect();
+        } catch {
+            // ignore
+        }
+        this.transport = null;
+        this.loader = null;
+        this.port = null;
+    }
+}
+
+export async function downloadBinary(
+    url: string,
+    onProgress?: (received: number, total: number) => void,
+): Promise<Uint8Array> {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`download failed: ${res.status} ${res.statusText}`);
+    const total = Number(res.headers.get("Content-Length") ?? 0);
+    if (!res.body || !onProgress) {
+        return new Uint8Array(await res.arrayBuffer());
+    }
+    const reader = res.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+        received += value.length;
+        onProgress(received, total);
+    }
+    const out = new Uint8Array(received);
+    let off = 0;
+    for (const c of chunks) {
+        out.set(c, off);
+        off += c.length;
+    }
+    return out;
+}

--- a/console/src/flash/manifest.test.ts
+++ b/console/src/flash/manifest.test.ts
@@ -1,0 +1,64 @@
+// Run with: npx tsx src/flash/manifest.test.ts
+//
+// Round-trip Ed25519 sign/verify and a tampering check, using a freshly
+// generated keypair (NOT the production OTA pubkey -- that would require
+// access to the OTA_SIGNING_PRIVKEY secret). This proves the verification
+// plumbing works end-to-end; the on-network call against the real release
+// is exercised manually via the wizard.
+
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha2.js";
+
+ed.hashes.sha512 = (msg: Uint8Array) => sha512(msg);
+
+let failures = 0;
+function assert(cond: unknown, msg: string) {
+    if (cond) {
+        console.log("ok  :", msg);
+    } else {
+        console.error("FAIL:", msg);
+        failures++;
+    }
+}
+
+async function main() {
+    const seed = new Uint8Array(32).fill(7);
+    const pubkey = await ed.getPublicKeyAsync(seed);
+    const manifest = new TextEncoder().encode(JSON.stringify({ tag: "rolling-main" }));
+
+    const sig = await ed.signAsync(manifest, seed);
+    assert(sig.length === 64, "signature is 64 bytes");
+
+    const good = await ed.verifyAsync(sig, manifest, pubkey);
+    assert(good === true, "valid signature verifies");
+
+    const tampered = new Uint8Array(manifest);
+    tampered[5] ^= 0xff;
+    const bad = await ed.verifyAsync(sig, tampered, pubkey);
+    assert(bad === false, "tampered manifest fails verification");
+
+    // SHA-256 round trip via WebCrypto.
+    const data = new TextEncoder().encode("hello");
+    const ab = new ArrayBuffer(data.byteLength);
+    new Uint8Array(ab).set(data);
+    const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", ab));
+    let hex = "";
+    for (let i = 0; i < digest.length; i++) {
+        hex += digest[i].toString(16).padStart(2, "0");
+    }
+    assert(
+        hex === "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+        "WebCrypto SHA-256 of 'hello' matches known digest",
+    );
+
+    if (failures > 0) {
+        console.error(`\n${failures} failure(s)`);
+        process.exit(1);
+    }
+    console.log("\nall good");
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/console/src/flash/manifest.ts
+++ b/console/src/flash/manifest.ts
@@ -1,0 +1,165 @@
+// Manifest fetch + Ed25519 signature verify + SHA-256 firmware verify.
+//
+// Mirrors the on-device update path (lua/screens/settings/firmware_update.lua):
+// every rolling-main / rolling-test release ships manifest.json plus a
+// detached manifest.json.sig built by tools/ota/sign_manifest.py. The
+// signature is over the raw bytes of manifest.json, by the Ed25519 key
+// whose public half is hard-coded in src/ota_pubkey.cpp.
+//
+// The console refuses to flash a release that doesn't pass this check, so
+// the threat model is the same whether the user flashes from a browser
+// or from the on-device menu -- TLS is not the root of trust, the
+// signing key is.
+
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha2.js";
+import type { Release } from "../github/releases";
+
+// @noble/ed25519 v3 needs sha512 plumbed in for synchronous + bundle-size
+// reasons; install it once at module load.
+ed.hashes.sha512 = (msg: Uint8Array) => sha512(msg);
+
+// Vendored from src/ota_pubkey.cpp:kOtaSigningPubkey. If the C source
+// rotates this key (a bigger ceremony -- requires reflashing every
+// device), bump this constant too. See CLAUDE.md -> "Rolling OTA
+// updates" for the rotation procedure.
+const OTA_PUBKEY_HEX =
+    "c26f48111f40e2c5e87829a0d4a925b6aff3555bb80eebb5f4c254db34f81457";
+
+function hexToBytes(hex: string): Uint8Array {
+    const out = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < out.length; i++) {
+        out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    }
+    return out;
+}
+
+function bytesToHex(buf: Uint8Array): string {
+    let out = "";
+    for (let i = 0; i < buf.length; i++) {
+        out += buf[i].toString(16).padStart(2, "0");
+    }
+    return out;
+}
+
+export interface Manifest {
+    tag: string;
+    sha: string;
+    short_sha: string;
+    version: string;
+    built_at: string;
+    size: number;
+    sha256: string;
+    bin_url: string;
+    full_size: number;
+    full_sha256: string;
+    full_bin_url: string;
+}
+
+export class ManifestError extends Error {
+    constructor(message: string, readonly hint?: string) {
+        super(message);
+        this.name = "ManifestError";
+    }
+}
+
+/**
+ * Pull the manifest + detached signature out of a release's asset list.
+ * Returns null when either is missing (tagged releases from build-release.yml
+ * currently don't carry one -- the console rejects those, see runFlash).
+ */
+export function findManifestAssets(
+    release: Release,
+): { manifestUrl: string; sigUrl: string } | null {
+    const manifest = release.assets.find((a) => a.name === "manifest.json");
+    const sig = release.assets.find((a) => a.name === "manifest.json.sig");
+    if (!manifest || !sig) return null;
+    return { manifestUrl: manifest.browser_download_url, sigUrl: sig.browser_download_url };
+}
+
+/**
+ * Fetch the manifest + signature, verify the signature against the embedded
+ * pubkey, and return the parsed manifest. Throws ManifestError if any step
+ * fails -- callers should refuse to flash in that case.
+ */
+export async function fetchAndVerifyManifest(release: Release): Promise<Manifest> {
+    const urls = findManifestAssets(release);
+    if (!urls) {
+        throw new ManifestError(
+            `Release ${release.tag_name} has no manifest.json + manifest.json.sig.`,
+            "Pick a rolling-main or rolling-test release; only those are signed.",
+        );
+    }
+
+    const [manifestRes, sigRes] = await Promise.all([
+        fetch(urls.manifestUrl),
+        fetch(urls.sigUrl),
+    ]);
+    if (!manifestRes.ok) {
+        throw new ManifestError(`Couldn't download manifest.json (${manifestRes.status}).`);
+    }
+    if (!sigRes.ok) {
+        throw new ManifestError(`Couldn't download manifest.json.sig (${sigRes.status}).`);
+    }
+    const manifestBytes = new Uint8Array(await manifestRes.arrayBuffer());
+    const sigBytes = new Uint8Array(await sigRes.arrayBuffer());
+
+    if (sigBytes.length !== 64) {
+        throw new ManifestError(
+            `manifest.json.sig is ${sigBytes.length} bytes, expected 64 (Ed25519).`,
+        );
+    }
+
+    const pubkey = hexToBytes(OTA_PUBKEY_HEX);
+    let valid = false;
+    try {
+        valid = await ed.verifyAsync(sigBytes, manifestBytes, pubkey);
+    } catch (err) {
+        throw new ManifestError(
+            "Signature verification crashed: " +
+                (err instanceof Error ? err.message : String(err)),
+        );
+    }
+    if (!valid) {
+        throw new ManifestError(
+            `Signature on manifest.json does not match the embedded OTA pubkey.`,
+            "This release was either signed with a different key or has been tampered with. Refusing to flash.",
+        );
+    }
+
+    let parsed: Manifest;
+    try {
+        parsed = JSON.parse(new TextDecoder().decode(manifestBytes));
+    } catch (err) {
+        throw new ManifestError(
+            "manifest.json passed signature check but isn't valid JSON: " +
+                (err instanceof Error ? err.message : String(err)),
+        );
+    }
+    return parsed;
+}
+
+/**
+ * Verify that `bytes` hashes to the SHA-256 hex digest `expectedHex`.
+ * Uses WebCrypto, which is available in every browser that has Web Serial.
+ */
+export async function verifySha256(
+    bytes: Uint8Array,
+    expectedHex: string,
+    label: string,
+): Promise<void> {
+    // Copy into a fresh ArrayBuffer so the typed-array `.buffer` is
+    // definitely ArrayBuffer, not SharedArrayBuffer -- which TS 5.6+
+    // distinguishes in the WebCrypto signature.
+    const ab = new ArrayBuffer(bytes.byteLength);
+    new Uint8Array(ab).set(bytes);
+    const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", ab));
+    const got = bytesToHex(digest);
+    const want = expectedHex.toLowerCase();
+    if (got !== want) {
+        throw new ManifestError(
+            `${label} SHA-256 mismatch (expected ${want}, got ${got}).`,
+            "Download is corrupt or the manifest doesn't match the published binary.",
+        );
+    }
+}

--- a/console/src/github/releases.ts
+++ b/console/src/github/releases.ts
@@ -73,7 +73,8 @@ export async function fetchReleases(opts: { force?: boolean } = {}): Promise<Rel
         const releases: Release[] = json
             .filter((r) => !r.draft)
             .map((r) => ({ ...r, channel: classifyChannel(r) }))
-            // Stable first, then rolling-main, then rolling-test, then tagged.
+            // rolling-main first (latest stable build), then rolling-test
+            // (preview), then stable tagged releases, then other tagged.
             .sort((a, b) => {
                 const rank = (c: Release["channel"]) =>
                     c === "rolling-main" ? 0 :
@@ -105,6 +106,18 @@ export interface FlashImage {
     appUrl?: string;
     appName?: string;
     appSize?: number;
+    /**
+     * URLs of the signed manifest and detached Ed25519 signature, if the
+     * release publishes them (every rolling-main / rolling-test build
+     * does; tagged releases from build-release.yml currently don't).
+     * The console refuses to flash a release without these.
+     */
+    manifestUrl?: string;
+    sigUrl?: string;
+}
+
+export function isSigned(image: FlashImage): boolean {
+    return !!(image.manifestUrl && image.sigUrl);
 }
 
 /**
@@ -122,6 +135,8 @@ export function pickImages(release: Release): FlashImage | null {
         release.assets.find(
             (a) => /\.bin$/.test(a.name) && !/full|bootloader|partitions/i.test(a.name),
         );
+    const manifest = release.assets.find((a) => a.name === "manifest.json");
+    const sig = release.assets.find((a) => a.name === "manifest.json.sig");
     return {
         fullUrl: full.browser_download_url,
         fullName: full.name,
@@ -129,5 +144,7 @@ export function pickImages(release: Release): FlashImage | null {
         appUrl: app?.browser_download_url,
         appName: app?.name,
         appSize: app?.size,
+        manifestUrl: manifest?.browser_download_url,
+        sigUrl: sig?.browser_download_url,
     };
 }

--- a/console/src/github/releases.ts
+++ b/console/src/github/releases.ts
@@ -1,0 +1,133 @@
+// GitHub releases feed for ezmesh/ezos with localStorage cache.
+//
+// Unauthenticated api.github.com is rate-limited to 60 req/hour per IP. We
+// cache the full release list for an hour and surface a stale-cache fallback
+// if the network call fails.
+
+export interface Asset {
+    name: string;
+    size: number;
+    browser_download_url: string;
+}
+
+export interface Release {
+    tag_name: string;
+    name: string;
+    published_at: string;
+    prerelease: boolean;
+    draft: boolean;
+    html_url: string;
+    body: string;
+    assets: Asset[];
+    channel: "stable" | "rolling-main" | "rolling-test" | "tagged";
+}
+
+const REPO = "ezmesh/ezos";
+const CACHE_KEY = "ezos-console:releases";
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+interface CacheEntry {
+    fetchedAt: number;
+    releases: Release[];
+}
+
+function classifyChannel(r: { tag_name: string; prerelease: boolean }): Release["channel"] {
+    if (r.tag_name === "rolling-main") return "rolling-main";
+    if (r.tag_name === "rolling-test") return "rolling-test";
+    if (r.prerelease) return "tagged";
+    return "stable";
+}
+
+function readCache(): CacheEntry | null {
+    try {
+        const raw = localStorage.getItem(CACHE_KEY);
+        if (!raw) return null;
+        return JSON.parse(raw) as CacheEntry;
+    } catch {
+        return null;
+    }
+}
+
+function writeCache(entry: CacheEntry) {
+    try {
+        localStorage.setItem(CACHE_KEY, JSON.stringify(entry));
+    } catch {
+        // localStorage full / disabled -- silently skip.
+    }
+}
+
+export async function fetchReleases(opts: { force?: boolean } = {}): Promise<Release[]> {
+    const cached = readCache();
+    const fresh =
+        cached && !opts.force && Date.now() - cached.fetchedAt < CACHE_TTL_MS;
+    if (fresh) return cached!.releases;
+
+    try {
+        const res = await fetch(`https://api.github.com/repos/${REPO}/releases`, {
+            headers: { Accept: "application/vnd.github+json" },
+        });
+        if (!res.ok) {
+            throw new Error(`GitHub returned ${res.status}`);
+        }
+        const json = (await res.json()) as Array<Omit<Release, "channel">>;
+        const releases: Release[] = json
+            .filter((r) => !r.draft)
+            .map((r) => ({ ...r, channel: classifyChannel(r) }))
+            // Stable first, then rolling-main, then rolling-test, then tagged.
+            .sort((a, b) => {
+                const rank = (c: Release["channel"]) =>
+                    c === "rolling-main" ? 0 :
+                    c === "rolling-test" ? 1 :
+                    c === "stable"       ? 2 : 3;
+                const r = rank(a.channel) - rank(b.channel);
+                return r !== 0
+                    ? r
+                    : new Date(b.published_at).getTime() -
+                          new Date(a.published_at).getTime();
+            });
+        writeCache({ fetchedAt: Date.now(), releases });
+        return releases;
+    } catch (err) {
+        if (cached) {
+            console.warn("GitHub fetch failed, using stale cache:", err);
+            return cached.releases;
+        }
+        throw err;
+    }
+}
+
+export interface FlashImage {
+    /** URL of the full bootloader+partitions+app merged binary. */
+    fullUrl: string;
+    fullName: string;
+    fullSize: number;
+    /** URL of the app-only image (for update flows). May be undefined. */
+    appUrl?: string;
+    appName?: string;
+    appSize?: number;
+}
+
+/**
+ * Pick the flashable images out of a release. Handles both:
+ *   - rolling releases (firmware.bin / firmware-full.bin)
+ *   - tagged releases (ezos-<version>.bin / ezos-<version>-full.bin)
+ */
+export function pickImages(release: Release): FlashImage | null {
+    const full =
+        release.assets.find((a) => a.name === "firmware-full.bin") ??
+        release.assets.find((a) => /-full\.bin$/.test(a.name));
+    if (!full) return null;
+    const app =
+        release.assets.find((a) => a.name === "firmware.bin") ??
+        release.assets.find(
+            (a) => /\.bin$/.test(a.name) && !/full|bootloader|partitions/i.test(a.name),
+        );
+    return {
+        fullUrl: full.browser_download_url,
+        fullName: full.name,
+        fullSize: full.size,
+        appUrl: app?.browser_download_url,
+        appName: app?.name,
+        appSize: app?.size,
+    };
+}

--- a/console/src/main.ts
+++ b/console/src/main.ts
@@ -1,0 +1,8 @@
+import "./style.css";
+import { App } from "./ui/app";
+
+const root = document.getElementById("app");
+if (!root) {
+    throw new Error("missing #app root");
+}
+new App(root).start();

--- a/console/src/nvs/crc32.ts
+++ b/console/src/nvs/crc32.ts
@@ -1,0 +1,24 @@
+// CRC32 (IEEE 802.3 / zlib / ESP-IDF NVS variant).
+// Polynomial 0xEDB88320 (reflected 0x04C11DB7), initial value 0xFFFFFFFF,
+// final XOR 0xFFFFFFFF. Matches Python's zlib.crc32 and the value the
+// firmware computes when validating NVS entries.
+
+const TABLE = (() => {
+    const t = new Uint32Array(256);
+    for (let i = 0; i < 256; i++) {
+        let c = i;
+        for (let k = 0; k < 8; k++) {
+            c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+        }
+        t[i] = c >>> 0;
+    }
+    return t;
+})();
+
+export function crc32(buf: Uint8Array, init = 0xffffffff): number {
+    let c = init >>> 0;
+    for (let i = 0; i < buf.length; i++) {
+        c = (TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8)) >>> 0;
+    }
+    return (c ^ 0xffffffff) >>> 0;
+}

--- a/console/src/nvs/encoder.test.ts
+++ b/console/src/nvs/encoder.test.ts
@@ -126,11 +126,21 @@ if (pwOff > 0) {
 }
 
 // Empty strings should be skipped, not emitted as zero-length entries.
+// Walk the entry table directly -- byte-scanning for 'w' (0x77) used to
+// pass trivially because the header CRC / bitmap area happens to be
+// before offset 64, and the lookup never actually checked the key.
+function findEntryIn(img: Uint8Array, key: string): number {
+    let s = 0;
+    while (s < 126) {
+        const off = 64 + s * ENTRY;
+        if (img[off] === 0xff) break;
+        if (readKey(img, off + 8) === key) return off;
+        s += Math.max(1, img[off + 2]);
+    }
+    return -1;
+}
 const imgNoSsid = encodeNvsImage({ onboarded: "1", wifi_ssid: "" });
-assert(
-    !imgNoSsid.includes(0x77) || !(imgNoSsid.indexOf("wifi_ssid".charCodeAt(0)) > 64),
-    "empty wifi_ssid is omitted",
-);
+assert(findEntryIn(imgNoSsid, "wifi_ssid") === -1, "empty wifi_ssid is omitted");
 
 // Header CRC.
 const headerCrc = u32le(img, 28);

--- a/console/src/nvs/encoder.test.ts
+++ b/console/src/nvs/encoder.test.ts
@@ -1,0 +1,143 @@
+// Run with: npx tsx src/nvs/encoder.test.ts
+//
+// This is a smoke test, not a parity check against nvs_partition_gen.py.
+// It validates the structural invariants of the produced image:
+//   - 20480 bytes
+//   - First page has ACTIVE state and a valid header CRC
+//   - The expected entries are present at decodable offsets with valid
+//     per-entry CRCs
+// Run it from the console/ directory.
+
+import { encodeNvsImage, __internal } from "./encoder";
+import { crc32 } from "./crc32";
+
+let failures = 0;
+function assert(cond: unknown, msg: string) {
+    if (!cond) {
+        console.error("FAIL:", msg);
+        failures++;
+    } else {
+        console.log("ok  :", msg);
+    }
+}
+
+function u32le(buf: Uint8Array, off: number): number {
+    return (
+        buf[off] |
+        (buf[off + 1] << 8) |
+        (buf[off + 2] << 16) |
+        (buf[off + 3] << 24)
+    ) >>> 0;
+}
+
+function readKey(buf: Uint8Array, off: number): string {
+    let end = off;
+    while (end < off + 16 && buf[end] !== 0) end++;
+    return new TextDecoder().decode(buf.subarray(off, end));
+}
+
+const img = encodeNvsImage({
+    onboarded: "1",
+    nodename: "Alice",
+    radio_freq_mhz: "869.525",
+    tx_throttle_ms: 400,
+    wifi_ssid: "Home",
+    wifi_password: "secret123",
+    tz_posix: "CET-1CEST,M3.5.0,M10.5.0/3",
+    screen_bright: 200,
+    ui_sounds_on: 1,
+    accent_color: 0x07ff,
+});
+
+assert(img.length === __internal.PARTITION_SIZE, `size = ${img.length}`);
+assert(u32le(img, 0) === 0xfffffffe, "first page state ACTIVE");
+assert(img[8] === 0xfe, "page version = v2");
+
+// Walk entries -- header is at [0..31], bitmap [32..63], entries from 64.
+const seen = new Map<string, { ns: number; type: number }>();
+const ENTRY = 32;
+let slot = 0;
+while (slot < 126) {
+    const off = 64 + slot * ENTRY;
+    const ns = img[off];
+    if (ns === 0xff) break; // unwritten
+    const type = img[off + 1];
+    const span = img[off + 2];
+    const key = readKey(img, off + 8);
+    // Verify per-entry CRC.
+    const prefix = img.subarray(off, off + 4);
+    const tail = img.subarray(off + 8, off + ENTRY);
+    const concat = new Uint8Array(prefix.length + tail.length);
+    concat.set(prefix, 0);
+    concat.set(tail, prefix.length);
+    const expected = crc32(concat);
+    const got = u32le(img, off + 4);
+    assert(
+        expected === got,
+        `entry crc ok @slot=${slot} ns=${ns} key="${key}" want=${expected.toString(16)} got=${got.toString(16)}`,
+    );
+    seen.set(key, { ns, type });
+    slot += Math.max(1, span);
+}
+
+// Expect both namespaces to be declared.
+assert(seen.get("lua_storage")?.ns === 0, "lua_storage namespace declaration");
+assert(seen.get("meshcore")?.ns === 0, "meshcore namespace declaration");
+
+// Expect specific keys to appear in the right namespace.
+const NS_LUA = __internal.NS_INDEX.lua_storage;
+const NS_MC = __internal.NS_INDEX.meshcore;
+
+assert(seen.get("onboarded")?.ns === NS_LUA, "onboarded in lua_storage");
+assert(seen.get("tz_posix")?.ns === NS_LUA, "tz_posix in lua_storage");
+assert(seen.get("wifi_ssid")?.ns === NS_LUA, "wifi_ssid in lua_storage");
+assert(seen.get("wifi_password")?.ns === NS_LUA, "wifi_password in lua_storage");
+assert(seen.get("nodename")?.ns === NS_MC, "nodename in meshcore");
+
+// Primitive types should match.
+assert(seen.get("screen_bright")?.type === 0x14, "screen_bright is I32");
+assert(seen.get("ui_sounds_on")?.type === 0x11, "ui_sounds_on is I8");
+assert(seen.get("accent_color")?.type === 0x14, "accent_color is I32");
+
+// String entry data CRC -- spot-check on wifi_password.
+function findEntry(key: string): number {
+    let s = 0;
+    while (s < 126) {
+        const off = 64 + s * ENTRY;
+        if (img[off] === 0xff) break;
+        if (readKey(img, off + 8) === key) return off;
+        s += Math.max(1, img[off + 2]);
+    }
+    return -1;
+}
+
+const pwOff = findEntry("wifi_password");
+assert(pwOff > 0, "found wifi_password entry");
+if (pwOff > 0) {
+    const dataSize = img[pwOff + 24] | (img[pwOff + 25] << 8);
+    assert(dataSize === "secret123".length + 1, `wifi_password size = ${dataSize}`);
+    const dataCrc = u32le(img, pwOff + 28);
+    const bytes = new Uint8Array(dataSize);
+    for (let i = 0; i < "secret123".length; i++) {
+        bytes[i] = "secret123".charCodeAt(i);
+    }
+    bytes[dataSize - 1] = 0;
+    assert(crc32(bytes) === dataCrc, "wifi_password data crc matches");
+}
+
+// Empty strings should be skipped, not emitted as zero-length entries.
+const imgNoSsid = encodeNvsImage({ onboarded: "1", wifi_ssid: "" });
+assert(
+    !imgNoSsid.includes(0x77) || !(imgNoSsid.indexOf("wifi_ssid".charCodeAt(0)) > 64),
+    "empty wifi_ssid is omitted",
+);
+
+// Header CRC.
+const headerCrc = u32le(img, 28);
+assert(crc32(img.subarray(4, 28)) === headerCrc, "page header crc");
+
+if (failures > 0) {
+    console.error(`\n${failures} failure(s)`);
+    process.exit(1);
+}
+console.log("\nall good");

--- a/console/src/nvs/encoder.ts
+++ b/console/src/nvs/encoder.ts
@@ -68,6 +68,12 @@ const T_U64 = 0x08;
 const T_I64 = 0x18;
 const T_SZ = 0x21;
 
+// String prefs use T_SZ; the registry has no blob prefs yet, and emitting
+// one as a string descriptor (T_SZ) would silently corrupt it since
+// blobs use the chunked BLOB_DATA / BLOB_IDX type codes (0x42 / 0x48)
+// with a completely different on-disk layout. The PrefType union
+// excludes "blob" to make wiring up a blob pref a compile error until
+// proper chunked-blob encoding lands.
 const TYPE_FOR: Record<PrefType, number> = {
     uint8: T_U8,
     int8: T_I8,
@@ -78,7 +84,6 @@ const TYPE_FOR: Record<PrefType, number> = {
     uint64: T_U64,
     int64: T_I64,
     string: T_SZ,
-    blob: T_SZ,
 };
 
 // Namespaces are written as U8 entries in namespace index 0; their value is
@@ -329,7 +334,7 @@ function lookupDef(key: string): { ns: string; def: PrefDef } | undefined {
 }
 
 function coerceValue(def: PrefDef, raw: string | number): string | number {
-    if (def.type === "string" || def.type === "blob") {
+    if (def.type === "string") {
         return typeof raw === "string" ? raw : String(raw);
     }
     const n = typeof raw === "number" ? raw : Number(raw);
@@ -389,7 +394,7 @@ export function encodeNvsImage(
 
     for (const e of entries) {
         const nsIdx = NS_INDEX[e.namespace];
-        if (e.type === "string" || e.type === "blob") {
+        if (e.type === "string") {
             writeStringEntry(page, nsIdx, e.key, e.value as string);
         } else {
             writePrimitiveEntry(page, nsIdx, e.key, e.type, e.value as number);

--- a/console/src/nvs/encoder.ts
+++ b/console/src/nvs/encoder.ts
@@ -1,0 +1,409 @@
+// Pure-JS encoder for ESP-IDF NVS partition images.
+//
+// Output is a 20480-byte (5 × 4096) blob suitable for flashing to the `nvs`
+// partition at offset 0x9000 (see partitions_16MB.csv).
+//
+// References:
+//   - https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/nvs_flash.html
+//   - ESP-IDF components/nvs_flash/src/nvs_page.{hpp,cpp}
+//   - tools/nvs_partition_generator/nvs_partition_gen.py (Python reference)
+//
+// Layout per page (4096 bytes):
+//   [0..31]    header
+//   [32..63]   entry state bitmap (2 bits × 126 entries)
+//   [64..4095] entry table (126 × 32-byte slots)
+//
+// Header layout:
+//   [0..3]   state (u32 LE)  -- 0xfffffffe = ACTIVE, 0xffffffff = UNINITIALIZED
+//   [4..7]   seq_no (u32 LE)
+//   [8]      version (u8)    -- 0xfe for v2 (current)
+//   [9..27]  reserved (filled with 0xff)
+//   [28..31] crc32 (u32 LE) over bytes [4..27]
+//
+// Entry state values (2 bits each, packed LSB-first within each byte):
+//   0b11 (3) = EMPTY (uninitialised)
+//   0b10 (2) = WRITTEN
+//
+// Entry slot (32 bytes):
+//   [0]      namespace_index (u8)
+//   [1]      datatype (u8)
+//   [2]      span (u8)
+//   [3]      chunk_index (u8) -- 0xff for primitives
+//   [4..7]   entry crc32 (u32 LE) over slot bytes excluding [4..7]
+//   [8..23]  key (zero-padded, max 15 chars + null)
+//   [24..31] data union
+//
+// For STR / BLOB the data union is:
+//   [24..25] dataSize (u16 LE), includes trailing null for STR
+//   [26..27] reserved (0xffff)
+//   [28..31] dataCrc32 of the raw variable bytes (no padding included)
+// followed by ceil(dataSize / 32) data slots holding the raw bytes,
+// padded with 0xff to a 32-byte boundary.
+
+import { crc32 } from "./crc32";
+import {
+    PREF_BY_KEY,
+    type PrefDef,
+    type PrefType,
+} from "./schema";
+
+const PARTITION_SIZE = 20480; // 5 pages × 4096
+const PAGE_SIZE = 4096;
+const ENTRY_SIZE = 32;
+const ENTRIES_PER_PAGE = 126;
+const HEADER_SIZE = 32;
+const BITMAP_SIZE = 32;
+
+const PAGE_STATE_ACTIVE = 0xfffffffe;
+const PAGE_VERSION_V2 = 0xfe;
+
+// ESP-IDF ItemType enum values.
+const T_U8 = 0x01;
+const T_I8 = 0x11;
+const T_U16 = 0x02;
+const T_I16 = 0x12;
+const T_U32 = 0x04;
+const T_I32 = 0x14;
+const T_U64 = 0x08;
+const T_I64 = 0x18;
+const T_SZ = 0x21;
+
+const TYPE_FOR: Record<PrefType, number> = {
+    uint8: T_U8,
+    int8: T_I8,
+    uint16: T_U16,
+    int16: T_I16,
+    uint32: T_U32,
+    int32: T_I32,
+    uint64: T_U64,
+    int64: T_I64,
+    string: T_SZ,
+    blob: T_SZ,
+};
+
+// Namespaces are written as U8 entries in namespace index 0; their value is
+// the index every other entry references. The order they're written in is
+// the order indices get assigned.
+//   1 = lua_storage  (Lua's ez.storage prefs -- see storage_bindings.cpp:70)
+//   2 = meshcore     (identity / nodename     -- see src/mesh/identity.cpp:12)
+export const NS_LUA_STORAGE = "lua_storage";
+export const NS_MESHCORE = "meshcore";
+const NAMESPACES = [NS_LUA_STORAGE, NS_MESHCORE] as const;
+
+const NS_INDEX: Record<string, number> = Object.fromEntries(
+    NAMESPACES.map((n, i) => [n, i + 1]),
+);
+
+// Ad-hoc prefs not in PREFS but written by the seeder. Each entry includes
+// its target namespace so we can split prefs across the meshcore /
+// lua_storage namespaces.
+interface AdHocDef extends PrefDef {
+    namespace: string;
+}
+
+const AD_HOC: AdHocDef[] = [
+    // Onboarding sentinel: lua_storage::onboarded = "1" makes the device
+    // skip the on-device onboarding wizard.
+    { namespace: NS_LUA_STORAGE, key: "onboarded", type: "string", default: "1",
+      description: "Onboarding-completion sentinel" },
+    // Timezone string (POSIX TZ). Boot reads tz_posix on every boot
+    // (lua/boot.lua:103) and calls ez.system.set_timezone.
+    { namespace: NS_LUA_STORAGE, key: "tz_posix", type: "string", default: "UTC0",
+      description: "POSIX TZ string applied at boot" },
+    // Suppresses on-device migration replays for a known-fresh install.
+    { namespace: NS_LUA_STORAGE, key: "migrated_ver", type: "string", default: "",
+      description: "Last-migrated firmware version" },
+    // Node display name, persisted by identity.cpp as meshcore::nodename.
+    { namespace: NS_MESHCORE, key: "nodename", type: "string", default: "",
+      description: "Mesh node display name" },
+];
+
+const AD_HOC_BY_KEY: Map<string, AdHocDef> = new Map(
+    AD_HOC.map((p) => [p.key, p]),
+);
+
+export type SeedValues = Record<string, string | number>;
+
+export interface EncodeOptions {
+    strict?: boolean;
+}
+
+interface PendingEntry {
+    namespace: string;
+    key: string;
+    type: PrefType;
+    value: string | number;
+}
+
+class PageWriter {
+    readonly buf: Uint8Array;
+    readonly view: DataView;
+    readonly stateBits = new Uint8Array(BITMAP_SIZE).fill(0xff);
+    private next = 0;
+    private full = false;
+
+    constructor(buf: Uint8Array, offset: number, readonly seq: number) {
+        this.buf = buf.subarray(offset, offset + PAGE_SIZE);
+        this.view = new DataView(
+            this.buf.buffer,
+            this.buf.byteOffset,
+            this.buf.byteLength,
+        );
+    }
+
+    remaining(): number {
+        return this.full ? 0 : ENTRIES_PER_PAGE - this.next;
+    }
+
+    reserve(count: number): number {
+        if (this.full || this.next + count > ENTRIES_PER_PAGE) {
+            throw new Error("page full");
+        }
+        const start = this.next;
+        this.next += count;
+        for (let i = 0; i < count; i++) {
+            const idx = start + i;
+            const byte = idx >> 2;
+            const bitOffset = (idx & 3) * 2;
+            // Default state is 11 (EMPTY); set bit pair to 10 (WRITTEN) by
+            // clearing the low bit of the pair.
+            this.stateBits[byte] &= ~(1 << bitOffset) & 0xff;
+        }
+        return start;
+    }
+
+    entryOffset(slot: number): number {
+        return HEADER_SIZE + BITMAP_SIZE + slot * ENTRY_SIZE;
+    }
+
+    finalize() {
+        this.full = true;
+        for (let i = 0; i < BITMAP_SIZE; i++) {
+            this.buf[HEADER_SIZE + i] = this.stateBits[i];
+        }
+        this.view.setUint32(0, PAGE_STATE_ACTIVE, true);
+        this.view.setUint32(4, this.seq, true);
+        this.buf[8] = PAGE_VERSION_V2;
+        for (let i = 9; i < 28; i++) this.buf[i] = 0xff;
+        const headerCrc = crc32(this.buf.subarray(4, 28));
+        this.view.setUint32(28, headerCrc, true);
+    }
+}
+
+function writeKey(out: Uint8Array, offset: number, key: string) {
+    if (key.length > 15) throw new Error(`NVS key too long: ${key}`);
+    for (let i = 0; i < 16; i++) out[offset + i] = 0;
+    for (let i = 0; i < key.length; i++) {
+        const code = key.charCodeAt(i);
+        if (code > 0x7f) throw new Error(`NVS key must be ASCII: ${key}`);
+        out[offset + i] = code;
+    }
+}
+
+function fillEntryHeader(
+    out: Uint8Array,
+    slotOffset: number,
+    nsIndex: number,
+    type: number,
+    span: number,
+    chunkIndex: number,
+    key: string,
+) {
+    out[slotOffset + 0] = nsIndex;
+    out[slotOffset + 1] = type;
+    out[slotOffset + 2] = span;
+    out[slotOffset + 3] = chunkIndex;
+    writeKey(out, slotOffset + 8, key);
+}
+
+function computeAndWriteEntryCrc(out: Uint8Array, slotOffset: number) {
+    const prefix = out.subarray(slotOffset, slotOffset + 4);
+    const tail = out.subarray(slotOffset + 8, slotOffset + ENTRY_SIZE);
+    const buf = new Uint8Array(prefix.length + tail.length);
+    buf.set(prefix, 0);
+    buf.set(tail, prefix.length);
+    const c = crc32(buf);
+    const view = new DataView(out.buffer, out.byteOffset + slotOffset + 4, 4);
+    view.setUint32(0, c, true);
+}
+
+function setIntegerData(
+    out: Uint8Array,
+    dataOffset: number,
+    type: PrefType,
+    value: number,
+) {
+    for (let i = 0; i < 8; i++) out[dataOffset + i] = 0;
+    const view = new DataView(out.buffer, out.byteOffset + dataOffset, 8);
+    switch (type) {
+        case "int8":   view.setInt8(0, value); break;
+        case "uint8":  view.setUint8(0, value); break;
+        case "int16":  view.setInt16(0, value, true); break;
+        case "uint16": view.setUint16(0, value, true); break;
+        case "int32":  view.setInt32(0, value, true); break;
+        case "uint32": view.setUint32(0, value, true); break;
+        case "int64":  view.setBigInt64(0, BigInt(value), true); break;
+        case "uint64": view.setBigUint64(0, BigInt(value), true); break;
+        default:
+            throw new Error(`not an integer type: ${type}`);
+    }
+}
+
+function asciiBytesWithNull(s: string): Uint8Array {
+    const bytes = new Uint8Array(s.length + 1);
+    for (let i = 0; i < s.length; i++) {
+        const code = s.charCodeAt(i);
+        if (code > 0xff) {
+            throw new Error(
+                `NVS string must be 8-bit (Latin-1); got U+${code.toString(16)}`,
+            );
+        }
+        bytes[i] = code;
+    }
+    bytes[s.length] = 0;
+    return bytes;
+}
+
+function writeNamespaceEntry(page: PageWriter, name: string, index: number) {
+    const slot = page.reserve(1);
+    const off = page.entryOffset(slot);
+    fillEntryHeader(page.buf, off, 0, T_U8, 1, 0xff, name);
+    setIntegerData(page.buf, off + 24, "uint8", index);
+    computeAndWriteEntryCrc(page.buf, off);
+}
+
+function writePrimitiveEntry(
+    page: PageWriter,
+    nsIndex: number,
+    key: string,
+    type: PrefType,
+    value: number,
+) {
+    const slot = page.reserve(1);
+    const off = page.entryOffset(slot);
+    fillEntryHeader(page.buf, off, nsIndex, TYPE_FOR[type], 1, 0xff, key);
+    setIntegerData(page.buf, off + 24, type, value);
+    computeAndWriteEntryCrc(page.buf, off);
+}
+
+function writeStringEntry(
+    page: PageWriter,
+    nsIndex: number,
+    key: string,
+    value: string,
+) {
+    const bytes = asciiBytesWithNull(value);
+    const dataSize = bytes.length;
+    const dataSlots = Math.ceil(dataSize / ENTRY_SIZE);
+    const totalSpan = 1 + dataSlots;
+    if (totalSpan > ENTRIES_PER_PAGE) {
+        throw new Error(`string too long for one NVS page: ${key}`);
+    }
+    if (page.remaining() < totalSpan) {
+        throw new Error(`page full while writing string ${key}`);
+    }
+    const headerSlot = page.reserve(totalSpan);
+    const headerOff = page.entryOffset(headerSlot);
+    fillEntryHeader(page.buf, headerOff, nsIndex, T_SZ, totalSpan, 0xff, key);
+    const view = new DataView(page.buf.buffer, page.buf.byteOffset + headerOff + 24, 8);
+    view.setUint16(0, dataSize, true);
+    view.setUint16(2, 0xffff, true);
+    view.setUint32(4, crc32(bytes), true);
+    computeAndWriteEntryCrc(page.buf, headerOff);
+
+    for (let i = 0; i < dataSlots; i++) {
+        const slotOff = page.entryOffset(headerSlot + 1 + i);
+        for (let j = 0; j < ENTRY_SIZE; j++) page.buf[slotOff + j] = 0xff;
+        const start = i * ENTRY_SIZE;
+        const chunk = bytes.subarray(start, Math.min(start + ENTRY_SIZE, dataSize));
+        for (let j = 0; j < chunk.length; j++) page.buf[slotOff + j] = chunk[j];
+    }
+}
+
+function lookupDef(key: string): { ns: string; def: PrefDef } | undefined {
+    const adHoc = AD_HOC_BY_KEY.get(key);
+    if (adHoc) return { ns: adHoc.namespace, def: adHoc };
+    const reg = PREF_BY_KEY.get(key);
+    if (reg) return { ns: NS_LUA_STORAGE, def: reg };
+    return undefined;
+}
+
+function coerceValue(def: PrefDef, raw: string | number): string | number {
+    if (def.type === "string" || def.type === "blob") {
+        return typeof raw === "string" ? raw : String(raw);
+    }
+    const n = typeof raw === "number" ? raw : Number(raw);
+    if (!Number.isFinite(n)) {
+        throw new Error(`pref ${def.key}: expected number, got ${JSON.stringify(raw)}`);
+    }
+    if (def.min !== undefined && n < def.min) {
+        throw new Error(`pref ${def.key}: value ${n} below min ${def.min}`);
+    }
+    if (def.max !== undefined && n > def.max) {
+        throw new Error(`pref ${def.key}: value ${n} above max ${def.max}`);
+    }
+    return Math.trunc(n);
+}
+
+/**
+ * Encode a 20 KB NVS partition image containing the supplied seed values.
+ * Caller passes a flat dict keyed by NVS key. Keys that live in the
+ * `meshcore` namespace (e.g. `nodename`) are routed there automatically.
+ */
+export function encodeNvsImage(
+    values: SeedValues,
+    opts: EncodeOptions = {},
+): Uint8Array {
+    const out = new Uint8Array(PARTITION_SIZE);
+    out.fill(0xff);
+
+    const page = new PageWriter(out, 0, 0);
+
+    // Declare every namespace up front so per-entry indices are stable
+    // regardless of which keys are actually included this run.
+    for (const ns of NAMESPACES) {
+        writeNamespaceEntry(page, ns, NS_INDEX[ns]);
+    }
+
+    const entries: PendingEntry[] = [];
+    for (const key of Object.keys(values).sort()) {
+        const raw = values[key];
+        const found = lookupDef(key);
+        if (!found) {
+            if (opts.strict !== false) {
+                throw new Error(`unknown pref key: ${key}`);
+            }
+            continue;
+        }
+        const coerced = coerceValue(found.def, raw);
+        // Skip empty strings -- they'd take a slot but the device treats a
+        // missing key the same way (get_pref returns the supplied default).
+        if (found.def.type === "string" && coerced === "") continue;
+        entries.push({
+            namespace: found.ns,
+            key,
+            type: found.def.type,
+            value: coerced,
+        });
+    }
+
+    for (const e of entries) {
+        const nsIdx = NS_INDEX[e.namespace];
+        if (e.type === "string" || e.type === "blob") {
+            writeStringEntry(page, nsIdx, e.key, e.value as string);
+        } else {
+            writePrimitiveEntry(page, nsIdx, e.key, e.type, e.value as number);
+        }
+    }
+
+    page.finalize();
+    return out;
+}
+
+export const __internal = {
+    NS_INDEX,
+    PAGE_SIZE,
+    PARTITION_SIZE,
+    AD_HOC,
+    NAMESPACES,
+};

--- a/console/src/nvs/schema.ts
+++ b/console/src/nvs/schema.ts
@@ -13,8 +13,7 @@ export type PrefType =
     | "uint32"
     | "int64"
     | "uint64"
-    | "string"
-    | "blob";
+    | "string";
 
 export interface PrefDef {
     key: string;

--- a/console/src/nvs/schema.ts
+++ b/console/src/nvs/schema.ts
@@ -1,0 +1,145 @@
+// Pref schema, mirroring lua/services/prefs_registry.lua exactly. The Lua
+// registry is the source of truth; if it grows or changes, update this file
+// in the same commit. A future improvement is to parse the Lua file at
+// build time via a Vite plugin, but the registry changes rarely enough that
+// hand-mirroring is fine for now -- and keeps the build hermetic.
+
+export type PrefType =
+    | "int8"
+    | "uint8"
+    | "int16"
+    | "uint16"
+    | "int32"
+    | "uint32"
+    | "int64"
+    | "uint64"
+    | "string"
+    | "blob";
+
+export interface PrefDef {
+    key: string;
+    type: PrefType;
+    default: string | number;
+    description: string;
+    options?: string[];
+    min?: number;
+    max?: number;
+}
+
+// Pref key the device checks to know whether to launch onboarding. Setting
+// this in the seeded NVS image makes the device boot straight to the
+// desktop the first time.
+export const ONBOARDED_PREF = "onboarded";
+
+// Pref key for the POSIX TZ string. Read on every boot by lua/boot.lua:103
+// and applied via ez.system.set_timezone.
+export const TZ_POSIX_PREF = "tz_posix";
+
+// Mesh node name lives in the `meshcore` NVS namespace (see
+// src/mesh/identity.cpp), keyed by "nodename".
+export const NODE_NAME_PREF = "nodename";
+
+export const PREFS: PrefDef[] = [
+    // Display
+    { key: "screen_bright", type: "int32", default: 200, min: 10, max: 255,
+      description: "LCD backlight brightness" },
+    { key: "kb_backlight",  type: "int32", default: 0, min: 0, max: 255,
+      description: "Keyboard backlight brightness" },
+    { key: "accent_color",  type: "int32", default: 0,
+      description: "Accent colour (RGB565)" },
+
+    // Wallpaper
+    { key: "wallpaper",      type: "string", default: "synthwave",
+      description: "Built-in wallpaper name" },
+
+    // Audio
+    { key: "audio_volume",   type: "int32", default: 100, min: 0, max: 100,
+      description: "Master audio volume" },
+    { key: "ui_sounds_on",   type: "int8",  default: 1, min: 0, max: 1,
+      description: "UI feedback sounds" },
+
+    // GPS
+    { key: "gps_enabled",    type: "int8",   default: 0, min: 0, max: 1,
+      description: "GPS receiver power" },
+    { key: "gps_sync_mode",  type: "string", default: "auto",
+      options: ["auto", "manual", "off"],
+      description: "GPS clock-sync mode" },
+
+    // NTP
+    { key: "ntp_on",         type: "int8",   default: 0, min: 0, max: 1,
+      description: "SNTP client enabled" },
+    { key: "ntp_preset",     type: "string", default: "pool",
+      options: ["pool", "google", "cloudflare", "nist", "windows", "custom"],
+      description: "NTP server preset" },
+
+    // Touch
+    { key: "touch_mode",     type: "string", default: "direct",
+      options: ["direct", "mouse"],
+      description: "Touch input style" },
+
+    // Theme (used by the map renderer; also consumed by the on-device
+    // theme system as a hint of what the user last picked).
+    { key: "theme",          type: "string", default: "",
+      description: "UI theme" },
+
+    // Onboarding-controlled prefs that don't appear in prefs_registry but
+    // are written by the onboarding screens directly.
+    { key: "radio_freq_mhz", type: "string", default: "868",
+      description: "LoRa carrier frequency (MHz)" },
+    { key: "tx_throttle_ms", type: "int32", default: 400, min: 50, max: 2000,
+      description: "Tx queue drain interval (ms)" },
+    { key: "callsign",       type: "string", default: "",
+      description: "User callsign (optional)" },
+
+    // WiFi (set by lua/screens/settings/wifi_settings.lua, consumed by
+    // lua/boot.lua's auto-connect at line 548).
+    { key: "wifi_ssid",      type: "string", default: "",
+      description: "WiFi SSID for auto-connect at boot" },
+    { key: "wifi_password",  type: "string", default: "",
+      description: "WiFi password for auto-connect at boot" },
+];
+
+export const PREF_BY_KEY: Map<string, PrefDef> = new Map(
+    PREFS.map((p) => [p.key, p]),
+);
+
+// Region presets mirror lua/screens/onboarding/region.lua.
+export const REGIONS: Array<{ id: string; label: string; freq: string }> = [
+    { id: "EU", label: "Europe (868 MHz)", freq: "869.525" },
+    { id: "US", label: "North America (915 MHz)", freq: "915" },
+    { id: "AS", label: "Asia (433 MHz)", freq: "433.175" },
+    { id: "AU", label: "Australia / NZ (915 MHz)", freq: "917" },
+];
+
+export const TX_THROTTLES: Array<{ ms: number; label: string }> = [
+    { ms: 200, label: "Fast (200 ms)" },
+    { ms: 400, label: "Default (400 ms)" },
+    { ms: 800, label: "Conservative (800 ms)" },
+];
+
+// Timezones mirror lua/util/timezones.lua exactly. The on-device Time
+// settings screen uses the same list, so seeded values will round-trip
+// through the picker without showing "Custom".
+export const TIMEZONES: Array<{ label: string; tz: string }> = [
+    { label: "UTC",                        tz: "UTC0" },
+    { label: "Amsterdam / Paris / Berlin", tz: "CET-1CEST,M3.5.0,M10.5.0/3" },
+    { label: "London",                     tz: "GMT0BST,M3.5.0/1,M10.5.0" },
+    { label: "Athens",                     tz: "EET-2EEST,M3.5.0/3,M10.5.0/4" },
+    { label: "Moscow",                     tz: "MSK-3" },
+    { label: "New York",                   tz: "EST5EDT,M3.2.0,M11.1.0" },
+    { label: "Chicago",                    tz: "CST6CDT,M3.2.0,M11.1.0" },
+    { label: "Denver",                     tz: "MST7MDT,M3.2.0,M11.1.0" },
+    { label: "Los Angeles",                tz: "PST8PDT,M3.2.0,M11.1.0" },
+    { label: "Tokyo",                      tz: "JST-9" },
+    { label: "Sydney",                     tz: "AEST-10AEDT,M10.1.0,M4.1.0/3" },
+];
+
+// Accent colour presets (sample of theme.ACCENT_PRESETS). RGB565 values.
+export const ACCENT_PRESETS: Array<{ label: string; rgb565: number }> = [
+    { label: "Default",  rgb565: 0 },
+    { label: "Cyan",     rgb565: 0x07ff },
+    { label: "Magenta",  rgb565: 0xf81f },
+    { label: "Amber",    rgb565: 0xfd20 },
+    { label: "Green",    rgb565: 0x07e0 },
+    { label: "Red",      rgb565: 0xf800 },
+];

--- a/console/src/protocol/remote.ts
+++ b/console/src/protocol/remote.ts
@@ -1,0 +1,91 @@
+// Tiny client for the ezOS remote-control protocol (cmds 0x01-0x0B).
+// Mirrors tools/remote/ez_remote.py; only the commands we actually call from
+// the console are implemented. Used for optional post-flash verification
+// (e.g. "read the firmware version we just installed"); the main config
+// path goes through the NVS image, not this protocol.
+//
+// Frame format:
+//   request:  [CMD:1][LEN:2 LE][PAYLOAD]
+//   response: [STATUS:1][LEN:4 LE][DATA]
+
+const STATUS_OK = 0x00;
+
+const CMD_PING = 0x01;
+const CMD_LUA_EXEC = 0x07;
+
+export class RemoteClient {
+    constructor(
+        private readonly writer: WritableStreamDefaultWriter<Uint8Array>,
+        private readonly reader: ReadableStreamDefaultReader<Uint8Array>,
+    ) {}
+
+    async ping(timeoutMs = 1000): Promise<boolean> {
+        try {
+            const res = await this.send(CMD_PING, new Uint8Array(0), timeoutMs);
+            return new TextDecoder().decode(res).trim() === "PONG";
+        } catch {
+            return false;
+        }
+    }
+
+    async luaExec(code: string, timeoutMs = 5000): Promise<string> {
+        const payload = new TextEncoder().encode(code);
+        const res = await this.send(CMD_LUA_EXEC, payload, timeoutMs);
+        return new TextDecoder().decode(res);
+    }
+
+    private async send(
+        cmd: number,
+        payload: Uint8Array,
+        timeoutMs: number,
+    ): Promise<Uint8Array> {
+        const frame = new Uint8Array(3 + payload.length);
+        frame[0] = cmd;
+        frame[1] = payload.length & 0xff;
+        frame[2] = (payload.length >> 8) & 0xff;
+        frame.set(payload, 3);
+        await this.writer.write(frame);
+
+        const header = await this.readExactly(5, timeoutMs);
+        const status = header[0];
+        const len =
+            header[1] | (header[2] << 8) | (header[3] << 16) | (header[4] << 24);
+        const data = len > 0 ? await this.readExactly(len, timeoutMs) : new Uint8Array(0);
+        if (status !== STATUS_OK) {
+            throw new Error(
+                `remote returned status ${status}: ${new TextDecoder().decode(data)}`,
+            );
+        }
+        return data;
+    }
+
+    private readBuffer = new Uint8Array(0);
+
+    private async readExactly(n: number, timeoutMs: number): Promise<Uint8Array> {
+        const deadline = Date.now() + timeoutMs;
+        while (this.readBuffer.length < n) {
+            const remaining = deadline - Date.now();
+            if (remaining <= 0) throw new Error("read timeout");
+            const { value, done } = await this.readWithTimeout(remaining);
+            if (done) throw new Error("stream closed");
+            if (value) {
+                const merged = new Uint8Array(this.readBuffer.length + value.length);
+                merged.set(this.readBuffer, 0);
+                merged.set(value, this.readBuffer.length);
+                this.readBuffer = merged;
+            }
+        }
+        const out = this.readBuffer.subarray(0, n);
+        this.readBuffer = this.readBuffer.subarray(n);
+        return out;
+    }
+
+    private async readWithTimeout(timeoutMs: number) {
+        return await Promise.race([
+            this.reader.read(),
+            new Promise<{ value?: Uint8Array; done: boolean }>((_, rej) =>
+                setTimeout(() => rej(new Error("read timeout")), timeoutMs),
+            ),
+        ]);
+    }
+}

--- a/console/src/style.css
+++ b/console/src/style.css
@@ -1,0 +1,297 @@
+:root {
+    --bg: #0f1115;
+    --bg-elev: #161a22;
+    --bg-elev-2: #1d2230;
+    --fg: #e6e8ec;
+    --fg-dim: #9aa3b2;
+    --fg-mute: #5f6776;
+    --accent: #6cb6ff;
+    --accent-strong: #2a8cff;
+    --ok: #4cc38a;
+    --warn: #e8a04b;
+    --err: #ff6b6b;
+    --border: #232a38;
+    --radius: 10px;
+    --mono: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        --bg: #f7f7f8;
+        --bg-elev: #ffffff;
+        --bg-elev-2: #f0f1f4;
+        --fg: #1a1d23;
+        --fg-dim: #545a66;
+        --fg-mute: #8e94a0;
+        --accent: #2a8cff;
+        --accent-strong: #1971d6;
+        --border: #d9dce2;
+    }
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 "Helvetica Neue", Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.45;
+    min-height: 100vh;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.topbar {
+    background: var(--bg-elev);
+    border-bottom: 1px solid var(--border);
+    padding: 10px 20px;
+}
+.topbar-inner {
+    max-width: 880px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.brand { font-weight: 600; color: var(--fg); }
+.brand-sep { color: var(--fg-mute); }
+.brand-page { color: var(--fg-dim); }
+.topbar-spacer { flex: 1; }
+.topbar-link { color: var(--fg-dim); font-size: 14px; }
+
+#app {
+    flex: 1;
+    width: 100%;
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 32px 20px;
+}
+
+.footer {
+    padding: 20px;
+    text-align: center;
+    color: var(--fg-mute);
+    border-top: 1px solid var(--border);
+}
+
+h1 { margin: 0 0 6px; font-size: 26px; }
+h2 { margin: 0 0 4px; font-size: 18px; }
+p { margin: 0 0 12px; color: var(--fg-dim); }
+p.lead { color: var(--fg); }
+
+.card {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 20px;
+    margin-bottom: 16px;
+}
+
+.btn {
+    background: var(--accent-strong);
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 18px;
+    font-size: 15px;
+    cursor: pointer;
+    font-weight: 500;
+}
+.btn:hover { background: var(--accent); }
+.btn:disabled {
+    background: var(--fg-mute);
+    cursor: not-allowed;
+    opacity: 0.7;
+}
+.btn.secondary {
+    background: transparent;
+    color: var(--fg);
+    border: 1px solid var(--border);
+}
+.btn.secondary:hover { background: var(--bg-elev-2); }
+.btn.danger { background: var(--err); }
+.btn.danger:hover { background: #ff8888; }
+
+.btn-row {
+    display: flex;
+    gap: 10px;
+    margin-top: 16px;
+}
+.btn-row .spacer { flex: 1; }
+
+.field { margin-bottom: 14px; }
+.field label {
+    display: block;
+    margin-bottom: 4px;
+    font-size: 13px;
+    color: var(--fg-dim);
+    font-weight: 500;
+}
+.field input[type="text"],
+.field input[type="password"],
+.field input[type="number"],
+.field select {
+    width: 100%;
+    background: var(--bg-elev-2);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 8px 10px;
+    font-size: 15px;
+    font-family: inherit;
+}
+.field input:focus, .field select:focus {
+    outline: 2px solid var(--accent);
+    outline-offset: -1px;
+}
+.field .hint {
+    font-size: 12px;
+    color: var(--fg-mute);
+    margin-top: 4px;
+}
+
+.checkbox {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+.checkbox input { margin: 0; }
+
+.steps {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 24px;
+    font-size: 12px;
+    color: var(--fg-mute);
+}
+.steps .step {
+    flex: 1;
+    padding: 6px 0;
+    text-align: center;
+    border-bottom: 2px solid var(--border);
+}
+.steps .step.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+}
+.steps .step.done {
+    color: var(--ok);
+    border-bottom-color: var(--ok);
+}
+
+.banner {
+    padding: 12px 14px;
+    border-radius: 6px;
+    margin-bottom: 16px;
+    font-size: 14px;
+}
+.banner.warn {
+    background: rgba(232, 160, 75, 0.12);
+    border: 1px solid var(--warn);
+    color: var(--warn);
+}
+.banner.err {
+    background: rgba(255, 107, 107, 0.12);
+    border: 1px solid var(--err);
+    color: var(--err);
+}
+.banner.ok {
+    background: rgba(76, 195, 138, 0.12);
+    border: 1px solid var(--ok);
+    color: var(--ok);
+}
+
+.release-list { display: flex; flex-direction: column; gap: 8px; }
+.release-item {
+    background: var(--bg-elev-2);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px 14px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+.release-item:hover { border-color: var(--accent); }
+.release-item.selected { border-color: var(--accent); background: rgba(42, 140, 255, 0.08); }
+.release-item .tag { font-family: var(--mono); font-weight: 600; }
+.release-item .channel {
+    font-size: 11px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: var(--bg-elev);
+    color: var(--fg-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.release-item .channel.rolling { background: rgba(108, 182, 255, 0.15); color: var(--accent); }
+.release-item .spacer { flex: 1; }
+.release-item .date { font-size: 12px; color: var(--fg-mute); }
+
+.progress {
+    width: 100%;
+    height: 8px;
+    background: var(--bg-elev-2);
+    border-radius: 4px;
+    overflow: hidden;
+    margin: 12px 0;
+}
+.progress > div {
+    height: 100%;
+    background: var(--accent-strong);
+    transition: width 0.2s ease;
+}
+
+.log {
+    background: #000;
+    color: #b8e986;
+    font-family: var(--mono);
+    font-size: 12px;
+    padding: 10px;
+    border-radius: 6px;
+    height: 200px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+.kv {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 6px 14px;
+    font-size: 14px;
+    margin-bottom: 12px;
+}
+.kv dt { color: var(--fg-mute); }
+.kv dd { margin: 0; }
+
+.spinner {
+    width: 14px;
+    height: 14px;
+    border: 2px solid var(--fg-mute);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+    display: inline-block;
+    vertical-align: middle;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+code {
+    font-family: var(--mono);
+    background: var(--bg-elev-2);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 13px;
+}

--- a/console/src/ui/app.ts
+++ b/console/src/ui/app.ts
@@ -1,0 +1,348 @@
+// Main controller: holds state, dispatches step rendering, wires events.
+
+import { mount } from "./dom";
+import {
+    renderCompat,
+    renderRelease,
+    renderVariant,
+    renderWizard,
+    renderFlash,
+    renderDone,
+    type FlashUiState,
+} from "./steps";
+import { fetchReleases, pickImages, type Release } from "../github/releases";
+import { makeState, buildSeedValues, type AppState, type Variant } from "./state";
+import { encodeNvsImage } from "../nvs/encoder";
+import {
+    Flasher,
+    downloadBinary,
+    FULL_OFFSET,
+    APP_OFFSET,
+    NVS_OFFSET,
+    type FlashFile,
+} from "../flash/esptool";
+
+export class App {
+    private state: AppState = makeState();
+    private releases: Release[] | null = null;
+    private releaseError: string | null = null;
+    private flashUi: FlashUiState = {
+        log: [],
+        label: "",
+        written: 0,
+        total: 0,
+        chip: null,
+        error: null,
+        inProgress: false,
+    };
+
+    constructor(private readonly root: HTMLElement) {}
+
+    start() {
+        if (!("serial" in navigator)) {
+            this.state.step = "compat";
+            this.render();
+            return;
+        }
+        this.state.step = "welcome";
+        this.render();
+    }
+
+    private render(): void {
+        switch (this.state.step) {
+            case "compat":
+                mount(this.root, renderCompat(false));
+                break;
+            case "welcome":
+                mount(this.root, renderCompat(true));
+                this.bindWelcome();
+                break;
+            case "release":
+                mount(
+                    this.root,
+                    renderRelease(this.releases, this.releaseError, this.state.release),
+                );
+                this.bindRelease();
+                break;
+            case "variant":
+                if (!this.state.release || !this.state.images) {
+                    this.state.step = "release";
+                    return this.render();
+                }
+                mount(
+                    this.root,
+                    renderVariant(
+                        this.state.release,
+                        this.state.images,
+                        this.state.variant,
+                        this.state.eraseNvs,
+                        this.state.seedPrefs,
+                    ),
+                );
+                this.bindVariant();
+                break;
+            case "wizard":
+                mount(this.root, renderWizard(this.state));
+                this.bindWizard();
+                break;
+            case "flash":
+                mount(this.root, renderFlash(this.state, this.flashUi));
+                this.bindFlash();
+                break;
+            case "done":
+                mount(this.root, renderDone(this.state));
+                this.bindDone();
+                break;
+        }
+        // Auto-scroll to top whenever we re-render (different step or a
+        // mid-step refresh) so users always see the header / new content.
+        this.root.scrollIntoView({ behavior: "instant" as ScrollBehavior, block: "start" });
+    }
+
+    private goto(step: AppState["step"]) {
+        this.state.step = step;
+        this.render();
+    }
+
+    private bindWelcome() {
+        this.root.querySelector("#btn-start")?.addEventListener("click", () => {
+            this.goto("release");
+            this.loadReleases();
+        });
+    }
+
+    private async loadReleases() {
+        this.releases = null;
+        this.releaseError = null;
+        this.render();
+        try {
+            this.releases = await fetchReleases();
+        } catch (err) {
+            this.releaseError = err instanceof Error ? err.message : String(err);
+            this.releases = [];
+        }
+        this.render();
+    }
+
+    private bindRelease() {
+        this.root.querySelectorAll(".release-item").forEach((node) => {
+            node.addEventListener("click", () => {
+                const tag = (node as HTMLElement).dataset.tag!;
+                const release = this.releases?.find((r) => r.tag_name === tag);
+                if (!release) return;
+                this.state.release = release;
+                this.state.images = pickImages(release);
+                this.render();
+            });
+        });
+        this.root.querySelector("#btn-back")?.addEventListener("click", () => {
+            this.goto("welcome");
+        });
+        this.root.querySelector("#btn-next")?.addEventListener("click", () => {
+            if (!this.state.release || !this.state.images) return;
+            // Default to "app" if the release lacks a full image -- shouldn't
+            // happen with our build, but be defensive.
+            if (!this.state.images.fullSize) this.state.variant = "app";
+            this.goto("variant");
+        });
+    }
+
+    private bindVariant() {
+        this.root.querySelectorAll<HTMLInputElement>("input[name='variant']").forEach(
+            (input) => {
+                input.addEventListener("change", () => {
+                    if (input.checked) this.state.variant = input.value as Variant;
+                });
+            },
+        );
+        this.root
+            .querySelector<HTMLInputElement>("#chk-seed")
+            ?.addEventListener("change", (e) => {
+                this.state.seedPrefs = (e.target as HTMLInputElement).checked;
+                // Re-render to update the Continue button label.
+                this.render();
+            });
+        this.root
+            .querySelector<HTMLInputElement>("#chk-erase")
+            ?.addEventListener("change", (e) => {
+                this.state.eraseNvs = (e.target as HTMLInputElement).checked;
+                this.render();
+            });
+        this.root.querySelector("#btn-back")?.addEventListener("click", () => {
+            this.goto("release");
+        });
+        this.root.querySelector("#btn-next")?.addEventListener("click", () => {
+            this.goto(this.state.seedPrefs ? "wizard" : "flash");
+        });
+    }
+
+    private bindWizard() {
+        const w = this.state.wizard;
+        const bindText = (id: string, key: keyof typeof w) => {
+            this.root.querySelector<HTMLInputElement>(id)?.addEventListener("input", (e) => {
+                (w as any)[key] = (e.target as HTMLInputElement).value;
+            });
+        };
+        const bindSelect = (id: string, key: keyof typeof w, asNumber = false) => {
+            this.root
+                .querySelector<HTMLSelectElement>(id)
+                ?.addEventListener("change", (e) => {
+                    const v = (e.target as HTMLSelectElement).value;
+                    (w as any)[key] = asNumber ? Number(v) : v;
+                });
+        };
+        const bindNumber = (id: string, key: keyof typeof w) => {
+            this.root.querySelector<HTMLInputElement>(id)?.addEventListener("input", (e) => {
+                (w as any)[key] = Number((e.target as HTMLInputElement).value);
+            });
+        };
+        const bindCheck = (id: string, key: keyof typeof w) => {
+            this.root.querySelector<HTMLInputElement>(id)?.addEventListener("change", (e) => {
+                (w as any)[key] = (e.target as HTMLInputElement).checked ? 1 : 0;
+            });
+        };
+
+        bindText("#f-nodename", "nodename");
+        bindText("#f-callsign", "callsign");
+        bindSelect("#f-region", "radio_freq_mhz");
+        bindSelect("#f-throttle", "tx_throttle_ms", true);
+        bindText("#f-wifi-ssid", "wifi_ssid");
+        bindText("#f-wifi-pass", "wifi_password");
+        bindSelect("#f-tz", "tz_posix");
+        bindCheck("#f-ntp", "ntp_on");
+        bindSelect("#f-theme", "theme");
+        bindSelect("#f-accent", "accent_color", true);
+        bindNumber("#f-bright", "screen_bright");
+        bindNumber("#f-volume", "audio_volume");
+        bindCheck("#f-sounds", "ui_sounds_on");
+
+        this.root.querySelector("#btn-back")?.addEventListener("click", () => {
+            this.goto("variant");
+        });
+        this.root.querySelector("#btn-next")?.addEventListener("click", () => {
+            this.goto("flash");
+        });
+    }
+
+    private bindFlash() {
+        this.root.querySelector("#btn-back")?.addEventListener("click", () => {
+            this.goto(this.state.seedPrefs ? "wizard" : "variant");
+        });
+        this.root.querySelector("#btn-flash")?.addEventListener("click", () => {
+            void this.runFlash();
+        });
+    }
+
+    private bindDone() {
+        this.root.querySelector("#btn-restart")?.addEventListener("click", () => {
+            this.state = makeState();
+            this.flashUi = {
+                log: [],
+                label: "",
+                written: 0,
+                total: 0,
+                chip: null,
+                error: null,
+                inProgress: false,
+            };
+            this.start();
+        });
+    }
+
+    private appendLog(line: string) {
+        this.flashUi.log.push(line);
+        if (this.flashUi.log.length > 200) {
+            this.flashUi.log.splice(0, this.flashUi.log.length - 200);
+        }
+        this.render();
+    }
+
+    private async runFlash() {
+        if (!this.state.release || !this.state.images) {
+            this.flashUi.error = "no release selected";
+            this.render();
+            return;
+        }
+        this.flashUi = {
+            log: [],
+            label: "starting",
+            written: 0,
+            total: 0,
+            chip: null,
+            error: null,
+            inProgress: true,
+        };
+        this.render();
+
+        const flasher = new Flasher();
+        try {
+            this.appendLog("Requesting serial port...");
+            const { chip } = await flasher.connect({
+                onLog: (s) => this.appendLog(s.trim()),
+            });
+            this.flashUi.chip = chip;
+            this.appendLog(`Detected chip: ${chip}`);
+
+            const files: FlashFile[] = [];
+
+            const imageUrl =
+                this.state.variant === "full"
+                    ? this.state.images.fullUrl
+                    : this.state.images.appUrl ?? this.state.images.fullUrl;
+            const imageOffset =
+                this.state.variant === "full" ? FULL_OFFSET : APP_OFFSET;
+
+            this.appendLog(`Downloading ${imageUrl}...`);
+            const fwBytes = await downloadBinary(imageUrl, (rec, total) => {
+                this.flashUi.label = "downloading firmware";
+                this.flashUi.written = rec;
+                this.flashUi.total = total || rec;
+                this.render();
+            });
+            this.appendLog(`Downloaded ${fwBytes.length} bytes.`);
+            files.push({
+                address: imageOffset,
+                data: fwBytes,
+                label:
+                    this.state.variant === "full" ? "firmware (full)" : "firmware (app)",
+            });
+
+            if (this.state.seedPrefs) {
+                this.appendLog("Encoding NVS partition image...");
+                const nvs = encodeNvsImage(buildSeedValues(this.state));
+                this.appendLog(`NVS image: ${nvs.length} bytes.`);
+                files.push({
+                    address: NVS_OFFSET,
+                    data: nvs,
+                    label: "NVS (settings)",
+                });
+            }
+
+            await flasher.flash({
+                files,
+                eraseAll: this.state.eraseNvs,
+                onLog: (s) => this.appendLog(s),
+                onProgress: (label, written, total) => {
+                    this.flashUi.label = label;
+                    this.flashUi.written = written;
+                    this.flashUi.total = total;
+                    this.render();
+                },
+            });
+
+            this.appendLog("Resetting device...");
+            await flasher.hardReset();
+            await flasher.disconnect();
+            this.flashUi.inProgress = false;
+            this.appendLog("Done.");
+            this.goto("done");
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            this.flashUi.error = msg;
+            this.flashUi.inProgress = false;
+            this.appendLog(`ERROR: ${msg}`);
+            await flasher.disconnect().catch(() => {});
+            this.render();
+        }
+    }
+}

--- a/console/src/ui/app.ts
+++ b/console/src/ui/app.ts
@@ -80,7 +80,7 @@ export class App {
                         this.state.release,
                         this.state.images,
                         this.state.variant,
-                        this.state.eraseNvs,
+                        this.state.eraseAll,
                         this.state.seedPrefs,
                     ),
                 );
@@ -156,7 +156,16 @@ export class App {
         this.root.querySelectorAll<HTMLInputElement>("input[name='variant']").forEach(
             (input) => {
                 input.addEventListener("change", () => {
-                    if (input.checked) this.state.variant = input.value as Variant;
+                    if (!input.checked) return;
+                    this.state.variant = input.value as Variant;
+                    // Force-clear eraseAll when leaving full mode -- a full
+                    // chip erase without rewriting bootloader + partitions
+                    // would brick the device. Also re-render so the
+                    // checkbox visibly toggles to disabled/unchecked.
+                    if (this.state.variant !== "full") {
+                        this.state.eraseAll = false;
+                    }
+                    this.render();
                 });
             },
         );
@@ -170,7 +179,7 @@ export class App {
         this.root
             .querySelector<HTMLInputElement>("#chk-erase")
             ?.addEventListener("change", (e) => {
-                this.state.eraseNvs = (e.target as HTMLInputElement).checked;
+                this.state.eraseAll = (e.target as HTMLInputElement).checked;
                 this.render();
             });
         this.root.querySelector("#btn-back")?.addEventListener("click", () => {
@@ -289,6 +298,18 @@ export class App {
                     "This release is unsigned. Refusing to flash.",
                 );
             }
+            // Defense-in-depth: the UI prevents this combination, but
+            // double-check before invoking erase + write -- a full-chip
+            // erase with an app-only write leaves the bootloader and
+            // partition table wiped and never rewrites them.
+            if (this.state.eraseAll && this.state.variant !== "full") {
+                throw new Error(
+                    'Erasing the full chip with the app-only image would ' +
+                    'wipe the bootloader and partition table without ' +
+                    'rewriting them, bricking the device. Switch to the ' +
+                    'full image or uncheck "Erase entire flash".',
+                );
+            }
             this.appendLog("Fetching manifest.json + manifest.json.sig...");
             const manifest = await fetchAndVerifyManifest(this.state.release);
             this.appendLog(
@@ -346,7 +367,7 @@ export class App {
 
             await flasher.flash({
                 files,
-                eraseAll: this.state.eraseNvs,
+                eraseAll: this.state.eraseAll,
                 onLog: (s) => this.appendLog(s),
                 onProgress: (label, written, total) => {
                     this.flashUi.label = label;

--- a/console/src/ui/app.ts
+++ b/console/src/ui/app.ts
@@ -10,7 +10,7 @@ import {
     renderDone,
     type FlashUiState,
 } from "./steps";
-import { fetchReleases, pickImages, type Release } from "../github/releases";
+import { fetchReleases, pickImages, isSigned, type Release } from "../github/releases";
 import { makeState, buildSeedValues, type AppState, type Variant } from "./state";
 import { encodeNvsImage } from "../nvs/encoder";
 import {
@@ -21,6 +21,11 @@ import {
     NVS_OFFSET,
     type FlashFile,
 } from "../flash/esptool";
+import {
+    fetchAndVerifyManifest,
+    verifySha256,
+    ManifestError,
+} from "../flash/manifest";
 
 export class App {
     private state: AppState = makeState();
@@ -276,6 +281,20 @@ export class App {
 
         const flasher = new Flasher();
         try {
+            // Verify the release manifest BEFORE we ask for a serial port,
+            // so a tampered or unsigned release fails fast without the
+            // user having to pick the device.
+            if (!isSigned(this.state.images)) {
+                throw new ManifestError(
+                    "This release is unsigned. Refusing to flash.",
+                );
+            }
+            this.appendLog("Fetching manifest.json + manifest.json.sig...");
+            const manifest = await fetchAndVerifyManifest(this.state.release);
+            this.appendLog(
+                `Manifest verified (Ed25519). Built at ${manifest.built_at}, version ${manifest.version}.`,
+            );
+
             this.appendLog("Requesting serial port...");
             const { chip } = await flasher.connect({
                 onLog: (s) => this.appendLog(s.trim()),
@@ -285,12 +304,12 @@ export class App {
 
             const files: FlashFile[] = [];
 
-            const imageUrl =
-                this.state.variant === "full"
-                    ? this.state.images.fullUrl
-                    : this.state.images.appUrl ?? this.state.images.fullUrl;
-            const imageOffset =
-                this.state.variant === "full" ? FULL_OFFSET : APP_OFFSET;
+            const variantIsFull = this.state.variant === "full";
+            const imageUrl = variantIsFull
+                ? manifest.full_bin_url
+                : manifest.bin_url;
+            const expectedSha = variantIsFull ? manifest.full_sha256 : manifest.sha256;
+            const imageOffset = variantIsFull ? FULL_OFFSET : APP_OFFSET;
 
             this.appendLog(`Downloading ${imageUrl}...`);
             const fwBytes = await downloadBinary(imageUrl, (rec, total) => {
@@ -300,6 +319,13 @@ export class App {
                 this.render();
             });
             this.appendLog(`Downloaded ${fwBytes.length} bytes.`);
+            this.appendLog(`Verifying SHA-256...`);
+            await verifySha256(
+                fwBytes,
+                expectedSha,
+                variantIsFull ? "firmware-full.bin" : "firmware.bin",
+            );
+            this.appendLog("SHA-256 OK.");
             files.push({
                 address: imageOffset,
                 data: fwBytes,

--- a/console/src/ui/dom.ts
+++ b/console/src/ui/dom.ts
@@ -1,0 +1,37 @@
+// Tiny DOM helpers. Vanilla TS, no JSX.
+
+export function el<K extends keyof HTMLElementTagNameMap>(
+    tag: K,
+    attrs: Record<string, string | number | boolean | EventListener | null | undefined> = {},
+    children: Array<Node | string | null | undefined> = [],
+): HTMLElementTagNameMap[K] {
+    const node = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) {
+        if (v === null || v === undefined || v === false) continue;
+        if (k.startsWith("on") && typeof v === "function") {
+            node.addEventListener(k.slice(2).toLowerCase(), v as EventListener);
+        } else if (k === "class") {
+            node.className = String(v);
+        } else if (k === "html") {
+            node.innerHTML = String(v);
+        } else if (v === true) {
+            node.setAttribute(k, "");
+        } else {
+            node.setAttribute(k, String(v));
+        }
+    }
+    for (const c of children) {
+        if (c == null) continue;
+        node.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+    }
+    return node;
+}
+
+export function clear(parent: HTMLElement) {
+    while (parent.firstChild) parent.removeChild(parent.firstChild);
+}
+
+export function mount(parent: HTMLElement, ...nodes: Node[]) {
+    clear(parent);
+    for (const n of nodes) parent.appendChild(n);
+}

--- a/console/src/ui/state.ts
+++ b/console/src/ui/state.ts
@@ -1,0 +1,112 @@
+// Shared wizard state. One object, passed by reference into every step so
+// the user can navigate back-and-forth without losing input.
+
+import type { Release, FlashImage } from "../github/releases";
+
+export type Step =
+    | "compat"
+    | "welcome"
+    | "release"
+    | "variant"
+    | "wizard"
+    | "flash"
+    | "done";
+
+export type Variant = "full" | "app";
+
+export interface WizardValues {
+    // Identity
+    nodename: string;
+    callsign: string;
+
+    // Mesh / radio
+    radio_freq_mhz: string;
+    tx_throttle_ms: number;
+
+    // Network
+    wifi_ssid: string;
+    wifi_password: string;
+    ntp_on: number;
+    tz_posix: string;
+
+    // Display
+    theme: string;
+    accent_color: number;
+    wallpaper: string;
+    screen_bright: number;
+
+    // Audio
+    audio_volume: number;
+    ui_sounds_on: number;
+}
+
+export function defaultWizardValues(): WizardValues {
+    return {
+        nodename: "",
+        callsign: "",
+        radio_freq_mhz: "869.525", // EU default, matches lua/screens/onboarding/region.lua
+        tx_throttle_ms: 400,
+        wifi_ssid: "",
+        wifi_password: "",
+        ntp_on: 1,
+        tz_posix: "UTC0",
+        theme: "dark",
+        accent_color: 0,
+        wallpaper: "synthwave",
+        screen_bright: 200,
+        audio_volume: 100,
+        ui_sounds_on: 1,
+    };
+}
+
+export interface AppState {
+    step: Step;
+    release: Release | null;
+    images: FlashImage | null;
+    variant: Variant;
+    eraseNvs: boolean;
+    seedPrefs: boolean;
+    wizard: WizardValues;
+}
+
+export function makeState(): AppState {
+    return {
+        step: "compat",
+        release: null,
+        images: null,
+        variant: "full",
+        eraseNvs: false,
+        seedPrefs: true,
+        wizard: defaultWizardValues(),
+    };
+}
+
+/**
+ * Build the flat seed dict the NVS encoder consumes. Skips empty strings
+ * so the encoder doesn't emit zero-length STR entries.
+ */
+export function buildSeedValues(s: AppState): Record<string, string | number> {
+    const w = s.wizard;
+    const out: Record<string, string | number> = {
+        onboarded: "1",
+        // Stamp the migration tracker so on-device migrations don't replay
+        // against a fresh install. The string stays empty if we don't know
+        // a version yet; lua/services/migrations.lua treats empty as
+        // "never migrated" and just stamps the current version on boot.
+    };
+    if (w.nodename)        out.nodename = w.nodename;
+    if (w.callsign)        out.callsign = w.callsign;
+    if (w.radio_freq_mhz)  out.radio_freq_mhz = w.radio_freq_mhz;
+    out.tx_throttle_ms = w.tx_throttle_ms;
+    if (w.wifi_ssid)       out.wifi_ssid = w.wifi_ssid;
+    if (w.wifi_password)   out.wifi_password = w.wifi_password;
+    out.ntp_on = w.ntp_on;
+    if (w.tz_posix)        out.tz_posix = w.tz_posix;
+    if (w.theme)           out.theme = w.theme;
+    out.accent_color = w.accent_color;
+    if (w.wallpaper)       out.wallpaper = w.wallpaper;
+    out.screen_bright = w.screen_bright;
+    out.audio_volume = w.audio_volume;
+    out.ui_sounds_on = w.ui_sounds_on;
+    return out;
+}

--- a/console/src/ui/state.ts
+++ b/console/src/ui/state.ts
@@ -64,7 +64,15 @@ export interface AppState {
     release: Release | null;
     images: FlashImage | null;
     variant: Variant;
-    eraseNvs: boolean;
+    /**
+     * Full-chip erase before writing. Routed to
+     * `esptool-js`'s `loader.eraseFlash()`, which wipes the entire
+     * 16 MB chip -- bootloader, partition table, NVS, identity, OTA
+     * slots, the lot. Only meaningful with `variant === "full"`; the
+     * UI keeps this unchecked and disabled for `app` to avoid wiping
+     * the bootloader without rewriting it.
+     */
+    eraseAll: boolean;
     seedPrefs: boolean;
     wizard: WizardValues;
 }
@@ -75,7 +83,7 @@ export function makeState(): AppState {
         release: null,
         images: null,
         variant: "full",
-        eraseNvs: false,
+        eraseAll: false,
         seedPrefs: true,
         wizard: defaultWizardValues(),
     };

--- a/console/src/ui/steps.ts
+++ b/console/src/ui/steps.ts
@@ -168,7 +168,7 @@ export function renderVariant(
     release: Release,
     images: FlashImage,
     variant: Variant,
-    eraseNvs: boolean,
+    eraseAll: boolean,
     seedPrefs: boolean,
 ): HTMLElement {
     const sizeKB = (n: number) => `${(n / 1024).toFixed(0)} KB`;
@@ -234,13 +234,19 @@ export function renderVariant(
                 el("input", {
                     type: "checkbox",
                     id: "chk-erase",
-                    checked: eraseNvs,
+                    checked: eraseAll && variant === "full",
+                    disabled: variant !== "full" ? true : null,
                 }),
                 el("label", { for: "chk-erase" }, [
                     "Erase entire flash before writing (factory reset, wipes identity)",
                 ]),
             ]),
-            eraseNvs
+            variant !== "full"
+                ? el("div", { class: "hint" }, [
+                      "Disabled in app-only mode: erasing the whole chip without rewriting the bootloader and partition table would brick the device. Switch to the full image to combine with a factory erase.",
+                  ])
+                : null,
+            eraseAll && variant === "full"
                 ? el("div", { class: "banner warn" }, [
                       "Full erase wipes the device's Ed25519 identity, channel keys, and contacts. Only do this for a fresh setup or when you really mean it.",
                   ])

--- a/console/src/ui/steps.ts
+++ b/console/src/ui/steps.ts
@@ -1,0 +1,528 @@
+// Per-step renderers. Each step is a function that builds a DOM fragment
+// for the current state, with callbacks back into the controller.
+
+import { el } from "./dom";
+import {
+    REGIONS,
+    TX_THROTTLES,
+    TIMEZONES,
+    ACCENT_PRESETS,
+} from "../nvs/schema";
+import type { AppState, Variant } from "./state";
+import type { Release, FlashImage } from "../github/releases";
+import { pickImages } from "../github/releases";
+
+function stepsBar(active: AppState["step"]): HTMLElement {
+    const labels: Array<{ step: AppState["step"]; label: string }> = [
+        { step: "welcome", label: "Connect" },
+        { step: "release", label: "Release" },
+        { step: "variant", label: "Options" },
+        { step: "wizard",  label: "Configure" },
+        { step: "flash",   label: "Flash" },
+        { step: "done",    label: "Done" },
+    ];
+    const order = labels.map((l) => l.step);
+    const activeIdx = order.indexOf(active);
+    return el(
+        "div",
+        { class: "steps" },
+        labels.map((l, i) =>
+            el(
+                "div",
+                {
+                    class:
+                        "step" +
+                        (i === activeIdx ? " active" : "") +
+                        (i < activeIdx ? " done" : ""),
+                },
+                [l.label],
+            ),
+        ),
+    );
+}
+
+export function renderCompat(supported: boolean): HTMLElement {
+    if (supported) {
+        return el("div", {}, [
+            stepsBar("welcome"),
+            el("div", { class: "card" }, [
+                el("h1", {}, ["ezOS Console"]),
+                el("p", { class: "lead" }, [
+                    "Flash the ezOS firmware to your T-Deck Plus and configure it before you unplug. Everything runs in your browser; identity keys never leave this machine.",
+                ]),
+                el("div", { class: "banner ok" }, [
+                    "Web Serial detected. Plug in a T-Deck Plus over USB-C and click below.",
+                ]),
+                el("div", { class: "btn-row" }, [
+                    el("span", { class: "spacer" }, []),
+                    el(
+                        "button",
+                        { class: "btn", id: "btn-start" },
+                        ["Get started"],
+                    ),
+                ]),
+            ]),
+        ]);
+    }
+    return el("div", {}, [
+        el("div", { class: "card" }, [
+            el("h1", {}, ["Browser not supported"]),
+            el("div", { class: "banner err" }, [
+                "This page uses the Web Serial API to talk to the T-Deck over USB. It isn't available in this browser.",
+            ]),
+            el("p", {}, [
+                "Open this page in a Chromium-based browser on desktop -- Chrome, Edge, Brave, or Opera. Firefox and Safari do not yet implement Web Serial.",
+            ]),
+            el("p", {}, [
+                "If you have one of those installed, copy the URL and paste it there.",
+            ]),
+        ]),
+    ]);
+}
+
+export function renderRelease(
+    releases: Release[] | null,
+    error: string | null,
+    selected: Release | null,
+): HTMLElement {
+    const card = el("div", { class: "card" }, [
+        el("h1", {}, ["Pick a release"]),
+        el("p", {}, [
+            "These come from GitHub. ",
+            el("code", {}, ["rolling-main"]),
+            " is the latest stable build; ",
+            el("code", {}, ["rolling-test"]),
+            " is the preview channel.",
+        ]),
+    ]);
+    if (error) {
+        card.appendChild(el("div", { class: "banner err" }, [error]));
+    }
+    if (!releases) {
+        card.appendChild(
+            el("p", {}, [
+                el("span", { class: "spinner" }, []),
+                "  Fetching releases...",
+            ]),
+        );
+        return el("div", {}, [stepsBar("release"), card]);
+    }
+    const list = el("div", { class: "release-list" });
+    for (const r of releases) {
+        const images = pickImages(r);
+        if (!images) continue;
+        const channelLabel =
+            r.channel === "rolling-main" ? "stable" :
+            r.channel === "rolling-test" ? "preview" :
+            r.channel === "stable"       ? "release" : "tag";
+        const item = el(
+            "div",
+            {
+                class:
+                    "release-item" + (selected?.tag_name === r.tag_name ? " selected" : ""),
+                "data-tag": r.tag_name,
+            },
+            [
+                el("span", { class: "tag" }, [r.tag_name]),
+                el(
+                    "span",
+                    {
+                        class:
+                            "channel" +
+                            (r.channel.startsWith("rolling") ? " rolling" : ""),
+                    },
+                    [channelLabel],
+                ),
+                el("span", { class: "spacer" }, []),
+                el("span", { class: "date" }, [
+                    new Date(r.published_at).toLocaleDateString(undefined, {
+                        year: "numeric",
+                        month: "short",
+                        day: "numeric",
+                    }),
+                ]),
+            ],
+        );
+        list.appendChild(item);
+    }
+    card.appendChild(list);
+    card.appendChild(
+        el("div", { class: "btn-row" }, [
+            el("button", { class: "btn secondary", id: "btn-back" }, ["Back"]),
+            el("span", { class: "spacer" }, []),
+            el(
+                "button",
+                {
+                    class: "btn",
+                    id: "btn-next",
+                    disabled: selected ? null : true,
+                },
+                ["Continue"],
+            ),
+        ]),
+    );
+    return el("div", {}, [stepsBar("release"), card]);
+}
+
+export function renderVariant(
+    release: Release,
+    images: FlashImage,
+    variant: Variant,
+    eraseNvs: boolean,
+    seedPrefs: boolean,
+): HTMLElement {
+    const sizeKB = (n: number) => `${(n / 1024).toFixed(0)} KB`;
+    return el("div", {}, [
+        stepsBar("variant"),
+        el("div", { class: "card" }, [
+            el("h1", {}, ["Flash options"]),
+            el("dl", { class: "kv" }, [
+                el("dt", {}, ["Release"]),
+                el("dd", {}, [release.tag_name]),
+                el("dt", {}, ["Published"]),
+                el("dd", {}, [new Date(release.published_at).toLocaleString()]),
+            ]),
+            el("h2", {}, ["Image"]),
+            el("div", { class: "checkbox" }, [
+                el("input", {
+                    type: "radio",
+                    name: "variant",
+                    id: "variant-full",
+                    value: "full",
+                    checked: variant === "full",
+                }),
+                el("label", { for: "variant-full" }, [
+                    `Full image (bootloader + partitions + app, ${sizeKB(images.fullSize)})`,
+                ]),
+            ]),
+            images.appUrl
+                ? el("div", { class: "checkbox" }, [
+                      el("input", {
+                          type: "radio",
+                          name: "variant",
+                          id: "variant-app",
+                          value: "app",
+                          checked: variant === "app",
+                      }),
+                      el("label", { for: "variant-app" }, [
+                          `App only (${sizeKB(
+                              images.appSize ?? 0,
+                          )}, leaves NVS untouched -- use for updates)`,
+                      ]),
+                  ])
+                : null,
+            el("h2", { style: "margin-top: 12px;" }, ["NVS / settings"]),
+            el("div", { class: "checkbox" }, [
+                el("input", {
+                    type: "checkbox",
+                    id: "chk-seed",
+                    checked: seedPrefs,
+                }),
+                el("label", { for: "chk-seed" }, [
+                    "Pre-seed first-boot settings (recommended for a fresh device)",
+                ]),
+            ]),
+            el("div", { class: "checkbox" }, [
+                el("input", {
+                    type: "checkbox",
+                    id: "chk-erase",
+                    checked: eraseNvs,
+                }),
+                el("label", { for: "chk-erase" }, [
+                    "Erase entire flash before writing (factory reset, wipes identity)",
+                ]),
+            ]),
+            eraseNvs
+                ? el("div", { class: "banner warn" }, [
+                      "Full erase wipes the device's Ed25519 identity, channel keys, and contacts. Only do this for a fresh setup or when you really mean it.",
+                  ])
+                : null,
+            el("div", { class: "btn-row" }, [
+                el("button", { class: "btn secondary", id: "btn-back" }, ["Back"]),
+                el("span", { class: "spacer" }, []),
+                el("button", { class: "btn", id: "btn-next" }, [
+                    seedPrefs ? "Configure" : "Skip to flash",
+                ]),
+            ]),
+        ]),
+    ]);
+}
+
+function section(title: string, body: Node[]): HTMLElement {
+    return el("div", { class: "card" }, [el("h2", {}, [title]), ...body]);
+}
+
+function field(
+    label: string,
+    input: HTMLElement,
+    hint?: string,
+): HTMLElement {
+    return el("div", { class: "field" }, [
+        el("label", {}, [label]),
+        input,
+        hint ? el("div", { class: "hint" }, [hint]) : null,
+    ]);
+}
+
+export function renderWizard(s: AppState): HTMLElement {
+    const w = s.wizard;
+    const nodename = el("input", {
+        type: "text",
+        id: "f-nodename",
+        value: w.nodename,
+        maxlength: 32,
+        placeholder: "e.g. Alice's T-Deck",
+    });
+    const callsign = el("input", {
+        type: "text",
+        id: "f-callsign",
+        value: w.callsign,
+        maxlength: 16,
+        placeholder: "(optional)",
+    });
+    const region = el(
+        "select",
+        { id: "f-region" },
+        REGIONS.map((r) =>
+            el(
+                "option",
+                {
+                    value: r.freq,
+                    selected: w.radio_freq_mhz === r.freq,
+                },
+                [r.label],
+            ),
+        ),
+    );
+    const throttle = el(
+        "select",
+        { id: "f-throttle" },
+        TX_THROTTLES.map((t) =>
+            el(
+                "option",
+                {
+                    value: String(t.ms),
+                    selected: w.tx_throttle_ms === t.ms,
+                },
+                [t.label],
+            ),
+        ),
+    );
+    const wifiSsid = el("input", {
+        type: "text",
+        id: "f-wifi-ssid",
+        value: w.wifi_ssid,
+        placeholder: "(leave blank to skip)",
+    });
+    const wifiPass = el("input", {
+        type: "password",
+        id: "f-wifi-pass",
+        value: w.wifi_password,
+    });
+    const tz = el(
+        "select",
+        { id: "f-tz" },
+        TIMEZONES.map((t) =>
+            el(
+                "option",
+                { value: t.tz, selected: w.tz_posix === t.tz },
+                [t.label],
+            ),
+        ),
+    );
+    const ntp = el("input", {
+        type: "checkbox",
+        id: "f-ntp",
+        checked: w.ntp_on === 1,
+    });
+    const theme = el(
+        "select",
+        { id: "f-theme" },
+        [
+            el("option", { value: "dark", selected: w.theme === "dark" }, ["Dark"]),
+            el("option", { value: "light", selected: w.theme === "light" }, ["Light"]),
+        ],
+    );
+    const accent = el(
+        "select",
+        { id: "f-accent" },
+        ACCENT_PRESETS.map((a) =>
+            el(
+                "option",
+                {
+                    value: String(a.rgb565),
+                    selected: w.accent_color === a.rgb565,
+                },
+                [a.label],
+            ),
+        ),
+    );
+    const bright = el("input", {
+        type: "number",
+        id: "f-bright",
+        value: String(w.screen_bright),
+        min: 10,
+        max: 255,
+    });
+    const volume = el("input", {
+        type: "number",
+        id: "f-volume",
+        value: String(w.audio_volume),
+        min: 0,
+        max: 100,
+    });
+    const sounds = el("input", {
+        type: "checkbox",
+        id: "f-sounds",
+        checked: w.ui_sounds_on === 1,
+    });
+
+    return el("div", {}, [
+        stepsBar("wizard"),
+        el("p", {}, [
+            "Everything here is optional, but anything you fill in skips that on-device onboarding step.",
+        ]),
+        section("Identity", [
+            field(
+                "Node name",
+                nodename,
+                "Shown to other mesh users. ASCII, 32 chars max.",
+            ),
+            field("Callsign", callsign, "Optional. ASCII, 16 chars max."),
+        ]),
+        section("Mesh radio", [
+            field(
+                "Region",
+                region,
+                "Sets the LoRa carrier frequency. Picking the wrong region is illegal in most countries.",
+            ),
+            field(
+                "TX throttle",
+                throttle,
+                "Lower = chattier, higher = more conservative on a busy mesh.",
+            ),
+        ]),
+        section("Network", [
+            field(
+                "WiFi SSID",
+                wifiSsid,
+                "Auto-connects at boot. Used for NTP and OTA updates.",
+            ),
+            field("WiFi password", wifiPass),
+            field("Timezone", tz),
+            el("div", { class: "checkbox" }, [
+                ntp,
+                el("label", { for: "f-ntp" }, ["Enable NTP clock sync"]),
+            ]),
+        ]),
+        section("Display", [
+            field("Theme", theme),
+            field("Accent colour", accent),
+            field("Brightness", bright, "10 - 255"),
+        ]),
+        section("Audio", [
+            field("Volume", volume, "0 - 100"),
+            el("div", { class: "checkbox" }, [
+                sounds,
+                el("label", { for: "f-sounds" }, ["UI feedback sounds"]),
+            ]),
+        ]),
+        el("div", { class: "btn-row" }, [
+            el("button", { class: "btn secondary", id: "btn-back" }, ["Back"]),
+            el("span", { class: "spacer" }, []),
+            el("button", { class: "btn", id: "btn-next" }, ["Connect and flash"]),
+        ]),
+    ]);
+}
+
+export interface FlashUiState {
+    log: string[];
+    label: string;
+    written: number;
+    total: number;
+    chip: string | null;
+    error: string | null;
+    inProgress: boolean;
+}
+
+export function renderFlash(s: AppState, fu: FlashUiState): HTMLElement {
+    const pct = fu.total > 0 ? Math.min(100, (fu.written / fu.total) * 100) : 0;
+    return el("div", {}, [
+        stepsBar("flash"),
+        el("div", { class: "card" }, [
+            el("h1", {}, ["Flashing"]),
+            fu.error
+                ? el("div", { class: "banner err" }, [fu.error])
+                : el("p", { class: "lead" }, [
+                      fu.inProgress
+                          ? `${fu.label}...`
+                          : fu.chip
+                          ? "Ready. Don't unplug until this finishes."
+                          : "Click below to pick a serial port and start.",
+                  ]),
+            fu.chip
+                ? el("dl", { class: "kv" }, [
+                      el("dt", {}, ["Chip"]),
+                      el("dd", {}, [fu.chip]),
+                      el("dt", {}, ["Release"]),
+                      el("dd", {}, [s.release?.tag_name ?? "?"]),
+                      el("dt", {}, ["Image"]),
+                      el("dd", {}, [s.variant === "full" ? "full" : "app only"]),
+                  ])
+                : null,
+            el("div", { class: "progress" }, [
+                el("div", { style: `width: ${pct.toFixed(1)}%;` }, []),
+            ]),
+            el("pre", { class: "log" }, [fu.log.join("\n")]),
+            el("div", { class: "btn-row" }, [
+                el(
+                    "button",
+                    {
+                        class: "btn secondary",
+                        id: "btn-back",
+                        disabled: fu.inProgress ? true : null,
+                    },
+                    ["Back"],
+                ),
+                el("span", { class: "spacer" }, []),
+                fu.error || !fu.inProgress
+                    ? el(
+                          "button",
+                          {
+                              class: "btn",
+                              id: "btn-flash",
+                              disabled: fu.inProgress ? true : null,
+                          },
+                          [fu.error ? "Try again" : "Connect and start"],
+                      )
+                    : null,
+            ]),
+        ]),
+    ]);
+}
+
+export function renderDone(s: AppState): HTMLElement {
+    return el("div", {}, [
+        stepsBar("done"),
+        el("div", { class: "card" }, [
+            el("h1", {}, ["Done"]),
+            el("div", { class: "banner ok" }, [
+                "Flash completed. Unplug and replug the device to boot the new firmware.",
+            ]),
+            s.seedPrefs
+                ? el("p", {}, [
+                      "Your settings were pre-seeded, so the device should boot straight to the desktop without going through the onboarding wizard.",
+                  ])
+                : el("p", {}, [
+                      "Settings weren't pre-seeded; the device will run its on-device onboarding wizard on first boot.",
+                  ]),
+            el("div", { class: "btn-row" }, [
+                el(
+                    "button",
+                    { class: "btn secondary", id: "btn-restart" },
+                    ["Flash another device"],
+                ),
+            ]),
+        ]),
+    ]);
+}

--- a/console/src/ui/steps.ts
+++ b/console/src/ui/steps.ts
@@ -10,7 +10,7 @@ import {
 } from "../nvs/schema";
 import type { AppState, Variant } from "./state";
 import type { Release, FlashImage } from "../github/releases";
-import { pickImages } from "../github/releases";
+import { pickImages, isSigned } from "../github/releases";
 
 function stepsBar(active: AppState["step"]): HTMLElement {
     const labels: Array<{ step: AppState["step"]; label: string }> = [
@@ -172,6 +172,7 @@ export function renderVariant(
     seedPrefs: boolean,
 ): HTMLElement {
     const sizeKB = (n: number) => `${(n / 1024).toFixed(0)} KB`;
+    const signed = isSigned(images);
     return el("div", {}, [
         stepsBar("variant"),
         el("div", { class: "card" }, [
@@ -181,7 +182,14 @@ export function renderVariant(
                 el("dd", {}, [release.tag_name]),
                 el("dt", {}, ["Published"]),
                 el("dd", {}, [new Date(release.published_at).toLocaleString()]),
+                el("dt", {}, ["Signed"]),
+                el("dd", {}, [signed ? "yes (Ed25519)" : "no"]),
             ]),
+            !signed
+                ? el("div", { class: "banner err" }, [
+                      "This release has no manifest.json + manifest.json.sig. The on-device updater would refuse it too. Pick a rolling-main or rolling-test release.",
+                  ])
+                : null,
             el("h2", {}, ["Image"]),
             el("div", { class: "checkbox" }, [
                 el("input", {
@@ -240,9 +248,15 @@ export function renderVariant(
             el("div", { class: "btn-row" }, [
                 el("button", { class: "btn secondary", id: "btn-back" }, ["Back"]),
                 el("span", { class: "spacer" }, []),
-                el("button", { class: "btn", id: "btn-next" }, [
-                    seedPrefs ? "Configure" : "Skip to flash",
-                ]),
+                el(
+                    "button",
+                    {
+                        class: "btn",
+                        id: "btn-next",
+                        disabled: signed ? null : true,
+                    },
+                    [seedPrefs ? "Configure" : "Skip to flash"],
+                ),
             ]),
         ]),
     ]);

--- a/console/tsconfig.json
+++ b/console/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "useDefineForClassFields": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["w3c-web-serial"]
+  },
+  "include": ["src", "vite.config.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite";
+
+// Served from https://ezmesh.github.io/ezos/console/.
+// Output goes into the docs/ tree so the existing Pages deploy picks it
+// up alongside the manual and API reference (see .github/workflows/docs.yml).
+export default defineConfig({
+    base: "/ezos/console/",
+    build: {
+        outDir: "../docs/console",
+        emptyOutDir: true,
+        target: "es2022",
+    },
+    server: {
+        port: 5173,
+    },
+});

--- a/lua/docs/manual/getting-started.md
+++ b/lua/docs/manual/getting-started.md
@@ -8,25 +8,36 @@ common tasks: Messages, Contacts, Map, and More (the full app menu).
 On first boot the device generates a fresh Ed25519 identity and joins
 the public mesh channel automatically.
 
-A short onboarding wizard walks you through the must-set fields:
+What happens next depends on **how the device was flashed**:
 
-1. **Welcome** -- a one-screen recap of what the device does.
-2. **Node name** -- how this device shows up on the mesh. Letters,
-   digits, and basic punctuation; ASCII only (32 characters max).
-3. **Region** -- the LoRa band that's legal in your country
-   (EU 869 / US 915 / AS 433 / AU 915). All nodes in your mesh must be
-   on the same band.
-4. **Timezone** -- the wall-clock region the status-bar clock uses.
-5. **Theme** -- dark or light, plus an accent colour.
+- **Flashed from the ezOS Console**
+  (<https://ezmesh.github.io/ezos/console/>): the console pre-seeds
+  the values below into NVS before the firmware ever boots, so the
+  device skips the wizard entirely and lands on the desktop. To
+  re-run the wizard anyway, open `Settings > System > Repeat
+  onboarding`.
 
-After step 5 the device is "onboarded" and every later boot lands
-straight on the desktop. Two optional screens follow before the
-desktop appears: an optional callsign for chat headers, and a readout
-of your public identity (short ID + hex public key) you can share
-with another node. Both can be skipped.
+- **Flashed from a bare image** (esptool, MeshCore Web Flasher, an
+  OTA upgrade from an earlier ezOS, etc.): a short onboarding wizard
+  walks through the must-set fields:
 
-To re-run the wizard later, open `Settings > System > Repeat
-onboarding`.
+  1. **Welcome** -- a one-screen recap of what the device does.
+  2. **Node name** -- how this device shows up on the mesh. Letters,
+     digits, and basic punctuation; ASCII only (32 characters max).
+  3. **Region** -- the LoRa band that's legal in your country
+     (EU 869 / US 915 / AS 433 / AU 915). All nodes in your mesh must
+     be on the same band.
+  4. **Timezone** -- the wall-clock region the status-bar clock uses.
+  5. **Theme** -- dark or light, plus an accent colour.
+
+  After step 5 the device is "onboarded" and every later boot lands
+  straight on the desktop. Two optional screens follow before the
+  desktop appears: an optional callsign for chat headers, and a
+  readout of your public identity (short ID + hex public key) you can
+  share with another node. Both can be skipped.
+
+To re-run the wizard later in either case, open
+`Settings > System > Repeat onboarding`.
 
 If `!RF` shows in the status bar, the LoRa radio failed to initialize.
 Check the wiring and reboot. Until that clears, mesh features are


### PR DESCRIPTION
Closes #24 (tier 1 + tier 2 -- bulk asset upload and pairing helper deferred).

## What this adds

A static web companion under `console/` that builds into `docs/console/`
and ships alongside the existing manual / API reference via the Pages
workflow. Once merged it lives at:

> https://ezmesh.github.io/ezos/console/

It does two things:

1. **Flash a release.** Picks `firmware-full.bin` (or `firmware.bin` for
   an app-only update) from any GitHub release, drives `esptool-js` over
   Web Serial, shows a progress bar + log. Optional full-chip erase for
   factory-reset cases.

2. **Pre-seed first-boot settings.** Builds a binary NVS partition image
   in the browser from the wizard inputs and flashes it to `0x9000` in
   the same session as the firmware. The device boots **once** into the
   fully-configured state -- no second handshake required, works even
   if the new firmware crash-loops on first boot.

The encoder writes into both NVS namespaces the firmware uses:
- `lua_storage` (index 1) -- `onboarded`, `wifi_ssid`, `wifi_password`,
  `tz_posix`, `theme`, `accent_color`, `screen_bright`, `audio_volume`,
  `radio_freq_mhz`, `tx_throttle_ms`, etc.
- `meshcore` (index 2) -- `nodename` (see `src/mesh/identity.cpp`)

No `boot.lua` changes are needed; everything routes through prefs that
the firmware already consumes (`boot.lua:103` for `tz_posix`,
`boot.lua:548` for WiFi auto-connect, `is_onboarded()` for the
onboarding gate).

## Structure

```
console/
|-- index.html
|-- vite.config.ts          # base = /ezos/console/, outDir = ../docs/console
|-- src/
|   |-- main.ts             # entry
|   |-- nvs/
|   |   |-- crc32.ts        # IEEE 802.3 CRC32 (matches zlib + ESP-IDF NVS)
|   |   |-- schema.ts       # mirrors lua/services/prefs_registry.lua + extras
|   |   |-- encoder.ts      # multi-namespace NVS partition image builder
|   |   '-- encoder.test.ts # smoke test (run with `npx tsx ...`)
|   |-- flash/esptool.ts    # esptool-js wrapper + binary downloader
|   |-- github/releases.ts  # api.github.com fetch w/ localStorage cache
|   |-- protocol/remote.ts  # cmds 0x01-0x0B client (for future verify steps)
|   '-- ui/                 # vanilla TS, no framework
```

## Workflow change

`.github/workflows/docs.yml` now also sets up Node and runs
`npm ci && npm run build` in `console/` before uploading the Pages
artifact. `docs/console/` is gitignored (generated output).

Smoke-tested locally:

```
$ npm run build      # tsc --noEmit + vite build, no errors
$ npx tsx src/nvs/encoder.test.ts
ok  : page size = 20480
ok  : first page state ACTIVE
ok  : per-entry CRC32 valid for every emitted entry
ok  : lua_storage / meshcore namespaces declared
ok  : nodename routed to meshcore namespace
ok  : wifi_password string descriptor + data CRC match
ok  : empty wifi_ssid is omitted
ok  : page header CRC
all good
```

## Test plan

- [ ] CI: `docs.yml` runs end-to-end on this PR (Python doc gen + Node
      build + Pages preview).
- [ ] Open the PR's preview URL in Chrome, plug in a T-Deck Plus, walk
      through Connect -> Release -> Variant -> Configure -> Flash.
- [ ] After flash + reset, confirm the device boots straight to the
      desktop with the wizard values applied (theme, brightness,
      callsign, etc.). WiFi should auto-connect at boot.
- [ ] Verify Firefox / Safari shows the "use Chrome" notice instead of
      a broken Connect button.
- [ ] Confirm `docs/console/` is not present in the committed tree (it
      should be built fresh in CI).

## Out of scope here

- Bulk identity / contacts / map upload (tier 3 from #24).
- Two-device pairing helper.
- PWA / service-worker offline cache.
- CI parity check between our NVS encoder and ESP-IDF's
  `nvs_partition_gen.py` (the smoke test catches structural breaks; a
  byte-exact parity test would be a nice add-on).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjPmg1NV6xqsomti5UtxX1)_