### PR TITLE
ci(release): stop releasing on test; regenerate changelog at build time

### DIFF
--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -22,27 +22,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      # Use the deploy key for the checkout so that `git push` later in
-      # the changelog step also goes over SSH using the same key. Branch
-      # rulesets exempt deploy-key pushes, which is the only way the
-      # auto-release commit can land on a protected branch on a free
-      # org plan (no GitHub App / bypass actor available in the picker).
-      - name: Set up deploy key
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.RELEASE_PUSH_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ssh-key: ${{ secrets.RELEASE_PUSH_KEY }}
-          persist-credentials: true
-          # xtr-changelog reads the latest `v*` tag locally to pick
-          # `previousVersion`; without this the action fetches
-          # depth=1 with no tags and falls back to package.json
-          # (which doesn't move), so every release re-stamps the
-          # same patch number. fetch-depth: 0 also gives the tool
-          # the full commit list it needs to build the changelog.
+          # The test workflow regenerates lua/docs/changelog.json into
+          # the workspace at build time but never pushes back to the
+          # branch (releases land only on main), so no deploy key is
+          # needed here. fetch-depth + fetch-tags are still required:
+          # xtr-changelog walks git log from the latest local `v*` tag
+          # to derive entries since the last release. With a shallow
+          # checkout it falls back to package.json#version and re-stamps
+          # the same patch number, and the embedded changelog loses
+          # entries.
           fetch-depth: 0
           fetch-tags: true
 
@@ -74,40 +65,32 @@ jobs:
       - name: Fetch PlatformIO dependencies
         run: pio pkg install -e t-deck-plus
 
-      - name: Configure git for release commit
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Generate changelog, sync version, and push back
+      - name: Regenerate embedded changelog and stamp synthetic version
         id: changelog
         run: |
           npm ci
-          # Push the release commit + tag back to the branch so the
-          # next run sees the freshly-created `vX.Y.Z` tag (which is
-          # how xtr-changelog picks `previousVersion` -- it greps
-          # local tags, hence the `fetch-tags: true` on checkout).
-          # Without the tag fetch, every run falls back to
-          # package.json#version and re-stamps the same patch number.
-          #
-          # [skip ci] in the commit message keeps the resulting push
-          # from re-triggering this workflow on top of the paths-ignore
-          # filter above (defense in depth).
-          #
-          # No retry on push race: if origin advances during the run,
-          # xtr-changelog --push fails non-FF and the workflow errors
-          # out. The next push (manual or otherwise) will produce a
-          # fresh release. xtr-changelog's --push isn't atomic, so a
-          # rejected branch push may still leave a tag on origin; if
-          # that happens, delete the orphan tag manually
-          # (`git push origin :refs/tags/vX.Y.Z`). Tracked upstream as
-          # https://github.com/xtr-dev/changelog/issues/1.
-          npx xtr-changelog release \
-            --execute --commit --tag --push \
-            --message '[skip ci] chore(release): {version}'
+          # Anchor the test-channel version to the last main release
+          # BEFORE running xtr-changelog -- `release --execute` rewrites
+          # versions.json[0] with an unreleased entry we don't want to
+          # ship as the build's version.
+          MAIN_VERSION=$(node -e "console.log(require('./changelog/versions.json').versions[0].version)")
+          SHORT_SHA="${GITHUB_SHA::7}"
+          VERSION="${MAIN_VERSION}+test.${SHORT_SHA}"
 
+          # `release --execute` without --commit/--tag/--push rewrites
+          # versions.json / archive.json / CHANGELOG.md / package.json
+          # in the runner workspace only. Nothing is committed back --
+          # that's the point of issue #102: those four files no longer
+          # diverge between `test` and `main`, so promotions stop
+          # conflicting on them.
+          npx xtr-changelog release --execute
+
+          # whats_new.lua reads this via ez.docs.read("@changelog.json").
+          # Regenerating per-build means the test channel shows entries
+          # not yet promoted to main.
           cp changelog/versions.json lua/docs/changelog.json
-          VERSION=$(node -e "const v=require('./changelog/versions.json'); console.log(v.versions[0].version)")
+
+          # Stamps EZOS_VERSION via embed_lua_scripts.py. Workspace-only.
           sed -i "s/^custom_version *= *.*/custom_version = ${VERSION}/" platformio.ini
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,22 +126,36 @@ pio run -t upload
 
 Pushes to `main` and `test` trigger `.github/workflows/main-artifacts.yml`
 and `.github/workflows/test-artifacts.yml` respectively. Each builds
-the firmware, generates a `manifest.json` describing the build (SHA,
-version, sha256, size, asset URL, plus the `full_*` variants for the
+firmware, generates a `manifest.json` describing the build (SHA,
+version, sha256, size, asset URL, plus `full_*` variants for the
 bootloader+partitions+app blob), signs it with an Ed25519 key from the
-`OTA_SIGNING_PRIVKEY` GitHub Actions secret, runs `xtr-changelog
-release --commit --tag --push` to advance `versions.json` and tag the
-release, and republishes the `rolling-main` / `rolling-test` GitHub
-Release with the binaries + manifest + detached signature. Older
-builds are kept as run artefacts (prune step caps at 3) for short-
-term debugging.
+`OTA_SIGNING_PRIVKEY` GitHub Actions secret, and republishes the
+`rolling-main` / `rolling-test` GitHub Release with binaries +
+manifest + detached signature. Older builds are kept as run artefacts
+(prune caps at 3) for short-term debugging.
 
-Pushes that touch ONLY generated files don't retrigger the workflow
-(would otherwise loop on the workflow's own release commit):
-`paths-ignore` excludes `changelog/versions.json`,
-`changelog/archive.json`, `lua/docs/changelog.json`, `CHANGELOG.md`,
-and `platformio.ini`. The release commit is also prefixed with
-`[skip ci]` as defense in depth.
+**Release commits land on `main` only.** Only the main workflow runs
+`xtr-changelog release --commit --tag --push` -- advancing
+`changelog/versions.json`, `changelog/archive.json`, `CHANGELOG.md`,
+and `package.json`, then pushing the `[skip ci] chore(release): vX.Y.Z`
+commit + `vX.Y.Z` tag back to `main`. The test workflow does NOT
+commit or push; it runs `xtr-changelog release --execute` to
+regenerate those files into the runner workspace only, copies the
+fresh `versions.json` into `lua/docs/changelog.json` so the on-device
+"What's new" screen reflects everything currently on `test`, and
+stamps `platformio.ini` with a synthetic
+`<main-version>+test.<short-sha>` (e.g. `0.0.94+test.a1b9073`). None
+of the four release-bookkeeping files are modified on `test` after
+the last main release, so `test -> main` promotions stop conflicting
+on them.
+
+`paths-ignore` on the main workflow excludes the generated files
+(`changelog/versions.json`, `changelog/archive.json`,
+`lua/docs/changelog.json`, `CHANGELOG.md`, `platformio.ini`) so the
+release commit doesn't re-trigger the workflow. `[skip ci]` in the
+commit message is defense in depth. The test workflow keeps the same
+`paths-ignore` purely for symmetry / future-proofing; since it never
+commits back, those entries are dormant.
 
 The on-device update screen (`lua/screens/settings/firmware_update.lua`)
 lets the user pick `main` or `test` channel, fetches `manifest.json`
@@ -171,29 +185,31 @@ Key rotation is "burn a new firmware containing the new pubkey, then
 rotate the secret". Don't lose the private key — there's no recovery
 path other than reflashing every device manually.
 
-**Branch ruleset push gate** (already wired, documented for context):
-the auto-release workflow's `xtr-changelog --push` step pushes the
-`[skip ci]` release commit + tag straight back to `main` / `test`.
-Both branches are protected by repo rulesets (see
-`scripts/branch-protection.sh`), and the rulesets' `pull_request`
+**Branch ruleset push gate** (relevant to `main` only since the test
+workflow stopped pushing): the main-artifacts workflow's
+`xtr-changelog --push` step pushes the `[skip ci]` release commit +
+tag straight back to `main`. `main` is protected by a repo ruleset
+(see `scripts/branch-protection.sh`), and the ruleset's `pull_request`
 rule blocks direct pushes from any actor not on the bypass list --
 including the workflow's `GITHUB_TOKEN`, regardless of `permissions:`
 scope. The "GitHub Actions" identity does not appear in the bypass
-picker on the free org plan, so we can't put it on the bypass list.
+picker on the free org plan.
 
 Workaround in use: a write-enabled **deploy key** (`auto-release-push`,
 private half stored in repo secret `RELEASE_PUSH_KEY`) **plus a
-DeployKey bypass actor on each ruleset**. Both `*-artifacts.yml`
-workflows load the key into ssh-agent via `webfactory/ssh-agent`
-and check the repo out over SSH so the subsequent `git push` from
-xtr-changelog flows through the same key, and the bypass actor
-on `ezos-branch-main` / `ezos-branch-test` lets that push land
-despite the `pull_request` rule. **Deploy keys do NOT bypass
-rulesets implicitly** -- the bypass actor must be present, of
-type `DeployKey` (which covers any deploy key on the repo, so the
-API stores it with `actor_id: null`).
+DeployKey bypass actor on the `ezos-branch-main` ruleset**. The
+main-artifacts workflow loads the key into ssh-agent via
+`webfactory/ssh-agent` and checks the repo out over SSH so the
+subsequent `git push` from xtr-changelog flows through the same
+key, and the bypass actor lets that push land despite the
+`pull_request` rule. **Deploy keys do NOT bypass rulesets
+implicitly** -- the bypass actor must be present, of type
+`DeployKey` (which covers any deploy key on the repo, so the API
+stores it with `actor_id: null`). The `ezos-branch-test` ruleset
+keeps its DeployKey bypass actor too, but it's currently dormant:
+the test-artifacts workflow does not load the deploy key.
 
-If OTA releases ever stop publishing, check the failing workflow
+If OTA releases ever stop publishing, check the failing main-artifacts
 run's "Generate changelog, sync version, and push back" step. A
 GH013 / "Changes must be made through a pull request" error means
 the push reached GitHub but the `pull_request` rule fired anyway.


### PR DESCRIPTION
## Summary

Drops the `xtr-changelog release --commit --tag --push` step from `test-artifacts.yml`. The workflow now runs `release --execute` (workspace-only) to regenerate `lua/docs/changelog.json` per build, and stamps `platformio.ini` with a synthetic `<main-version>+test.<short-sha>` version. Nothing on `test` modifies `CHANGELOG.md` / `changelog/versions.json` / `changelog/archive.json` / `package.json` after the last main release, so `test -> main` promotions stop conflicting on those four files.

Removes the `webfactory/ssh-agent` step and the `ssh-key:` on checkout (no push from this workflow anymore). `main-artifacts.yml` is untouched -- release commits + tags continue to land on `main` as before.

CLAUDE.md's "Rolling OTA updates" section is rewritten to describe the asymmetric model and to note that the DeployKey/RELEASE_PUSH_KEY plumbing is now main-only (the `ezos-branch-test` ruleset bypass actor is left in place but dormant).

## Acceptance checklist (from issue #102)

- [x] Push to `test` rebuilds firmware + republishes `rolling-test` release without modifying any of the four release-bookkeeping files. **Code path verified by reading the workflow; the only workspace writes are the four xtr-changelog regenerations + lua/docs/changelog.json + platformio.ini, and there is no `git add/commit/push`.**
- [x] On-device changelog screen on a test-channel build derives from `test`'s commits. **`cp changelog/versions.json lua/docs/changelog.json` happens after `xtr-changelog release --execute`, which walks git log since the last `v*` tag.**
- [x] Manifest on rolling-test shows `<main-version>+test.<short-sha>`. **`VERSION="${MAIN_VERSION}+test.${SHORT_SHA}"` flows into `steps.changelog.outputs.version` and into the manifest's `version` field via the existing wiring.**
- [ ] PR from `test -> main` (post-change) has no conflicts on the four files. **Verifiable only after this lands on `test` and a promotion PR is opened.**
- [ ] On-device OTA from rolling-test still works (signature verifies, full image flashes, version displays). **Verifiable only after the workflow runs and produces a rolling-test release; the OTA code path is unchanged.**
- [x] CLAUDE.md "Rolling OTA updates" section updated.

## Test plan

- [x] `pio run` clean (RAM 26.2%, flash 58.2%). Local build picks up `custom_version = 0.2.0` from the unmodified `platformio.ini`, since the synthetic-version stamp only runs in CI.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses the updated workflow without error.
- [ ] First post-merge push to `test` produces a `rolling-test` release with `manifest.version` matching `<main-version>+test.<short-sha>`, and `git log -1 origin/test` shows the user's merge commit, not a `[skip ci] chore(release)` commit on top.
- [ ] On a flashed test-channel build, Settings -> About / Firmware Update displays the synthetic version, and the What's new screen shows the latest test-only commit.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)