### PR TITLE
docs(claude): scope the on-device-fonts ASCII rule to on-device surfaces only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,15 @@ re-test the chord on the device, not the remote tool.
 
 ## On-device font character set
 
+**Scope:** this section applies ONLY to strings rendered by the on-device
+bitmap fonts -- any Lua `draw_text` call, the on-device markdown viewer
+(`lua/ezui/markdown.lua`), and the firmware-embedded markdown under
+`lua/docs/`. It does NOT apply to commit messages, PR bodies / titles, issue
+text, GitHub comments, code comments, host-side tools, or anything that
+only renders on github.com or in a normal terminal. Those surfaces are
+Unicode-capable; substituting `--` for em-dashes or `->` for arrows there
+just makes the text harder to read.
+
 The built-in bitmap fonts (`src/fonts/InterAA*.h`, `Spleen*.h`) only cover
 **printable ASCII 0x20..0x7E**. Any other codepoint renders as a `[]` missing-glyph box.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,11 +77,19 @@ re-test the chord on the device, not the remote tool.
 **Scope:** this section applies ONLY to strings rendered by the on-device
 bitmap fonts -- any Lua `draw_text` call, the on-device markdown viewer
 (`lua/ezui/markdown.lua`), and the firmware-embedded markdown under
-`lua/docs/`. It does NOT apply to commit messages, PR bodies / titles, issue
-text, GitHub comments, code comments, host-side tools, or anything that
-only renders on github.com or in a normal terminal. Those surfaces are
+`lua/docs/manual/`. It does NOT apply to PR bodies / titles, issue text,
+GitHub comments, code comments, host-side tools, or anything that only
+renders on github.com or in a normal terminal. Those surfaces are
 Unicode-capable; substituting `--` for em-dashes or `->` for arrows there
 just makes the text harder to read.
+
+**Commit descriptions are a partial exception.** They appear on-device in
+the What's New screen (`lua/screens/settings/whats_new.lua`), which runs
+them through `ascii_safe()`. That helper maps the common typographic
+characters (em-dash, en-dash, ellipsis, curly quotes, bullet, middle dot)
+to ASCII -- but any other non-ASCII byte (e.g. `→`, accented letters,
+emoji) is silently **stripped**, not boxed. Prefer ASCII in commit
+subjects so on-device changelog entries don't lose characters.
 
 The built-in bitmap fonts (`src/fonts/InterAA*.h`, `Spleen*.h`) only cover
 **printable ASCII 0x20..0x7E**. Any other codepoint renders as a `[]` missing-glyph box.


### PR DESCRIPTION
## Summary

Tightens the scope of the "On-device font character set" section in `CLAUDE.md`.

The section was being read as a global style guide and applied to surfaces it was never meant to cover -- PR bodies, commit messages, GitHub comments -- where Unicode renders fine and the ASCII substitutions just make the text harder to read. PR #109's directory-tree drawing (`|--` / `'--` instead of `├──` / `└──`) is a recent example.

The fix is a one-paragraph scope note at the top of the section that says the rule applies only to strings rendered by the on-device bitmap fonts (any Lua `draw_text` call, the on-device markdown viewer, and the firmware-embedded markdown under `lua/docs/`) -- and explicitly NOT to anything that renders on github.com or a normal terminal.

No code or behaviour change.

## Test plan

- [ ] Skim the diff and confirm the scope note reads correctly and doesn't contradict the rest of the section (the existing "Applies equally to docs" paragraph still scopes itself to the on-device markdown viewer, which is consistent with the new note).
- [ ] Confirm no other repo docs reference the old framing in a way that's now misleading.

https://claude.ai/code/session_01DReZfXN8JvERcDeRv8w2Ay

---
_Generated by [Claude Code](https://claude.ai/code/session_01DReZfXN8JvERcDeRv8w2Ay)_