### PR TITLE
feat(display): progressive dim and panel-off on prolonged idle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,15 +393,36 @@ subscribes once at boot to `touch/down` / `touch/move` / `touch/up`
 and turns single-finger taps into focus-chain activations on the
 widget under the finger. Most screens get touch for free.
 
-Two developer-facing APIs participate in the screensaver wake-event
+Several developer-facing APIs participate in the screensaver wake-event
 flow and must be used by anyone writing new touch code:
 
 - **`screen.notify_input()`** (`lua/ezui/screen.lua`) -- bumps
-  `last_input_time` and, if the screensaver overlay is currently
-  drawn, dismisses it. Returns `true` when the screensaver was just
-  dismissed so the caller can swallow the originating event. The
-  keyboard read loop calls this; you usually don't, but it's the
-  single chokepoint if you ever need to synthesise a wake.
+  `last_input_time` and, if the idle ladder is anywhere past stage 0
+  (pre-dim, screensaver-active, or panel-off), unwinds it: restores
+  the LCD backlight, dismisses the screensaver overlay if drawn, and
+  resets the stage to 0. Returns `true` when the call cleared a
+  non-zero stage (dim, screensaver, OR panel-off) so the caller can
+  swallow the originating event -- a tap that wakes the device
+  should not also click whatever sat under the finger. The keyboard
+  read loop calls this; you usually don't, but it's the single
+  chokepoint if you ever need to synthesise a wake.
+
+- **`screen.acquire_wakelock(tag)`** / **`screen.release_wakelock(tag)`**
+  (`lua/ezui/screen.lua`) -- tag-keyed counter that pins the idle
+  ladder at stage 0 regardless of `ss_timeout`. Pass the same string
+  tag to both calls; releasing a tag that was never acquired is a
+  no-op. Multiple distinct tags can be held concurrently and the
+  ladder only resumes once the last one is released. `release_wakelock`
+  also resets `last_input_time` so a long-held wakelock (e.g. a
+  multi-minute file transfer) doesn't make the next idle tick jump
+  straight to panel-off. There is one implicit wakelock built in:
+  `_wakelocks_held()` polls `ez.audio.is_recording()`, so the
+  voice-notes / signal-test capture paths stay lit without their
+  screens having to acquire anything. Prefer wakelocks over
+  per-frame `notify_input()` pings when a background activity needs
+  the display alive for an unbounded duration -- they don't fight
+  the user's chosen `ss_timeout` for the *next* idle period after
+  release.
 
 - **`touch_input.is_wake_event()`** -- predicate that returns true
   for ~250 ms after a touch dismissed the screensaver. The bridge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,9 +425,11 @@ flow and must be used by anyone writing new touch code:
   release.
 
 - **`touch_input.is_wake_event()`** -- predicate that returns true
-  for ~250 ms after a touch dismissed the screensaver. The bridge
-  sets the timestamp from inside its own `screensaver_swallow()`
-  guard. Call this **at the top of every `touch/*` bus subscriber a
+  for ~250 ms after a touch woke the device from any non-zero idle
+  stage (pre-dim, screensaver-active, or panel-off). The bridge sets
+  the timestamp from inside its own `screensaver_swallow()` guard
+  whenever `notify_input()` reports the wake cleared a non-zero
+  stage. Call this **at the top of every `touch/*` bus subscriber a
   screen registers**:
 
   ```lua

--- a/lua/docs/manual/settings.md
+++ b/lua/docs/manual/settings.md
@@ -16,7 +16,27 @@ under `ez.storage.set_pref`, so changes survive reboots.
 - Screensaver: pick a timeout (Off / 1 min / 2 min / 5 min /
   10 min / 30 min). After that long without input the device draws
   an animated pixel-exerciser overlay on top of the current screen,
-  dismissed by any keypress.
+  dismissed by any keypress. Setting the timeout to Off disables
+  the dim and panel-off stages below too.
+- Auto-dim: on by default. About 30 s before the screensaver fires
+  the LCD steps down to the "Screensaver brightness" level below,
+  as a heads-up that the screen is about to blank. Turn off if you
+  want the display to stay at full brightness right up to the
+  screensaver edge. Skipped automatically when the screensaver
+  timeout is shorter than the pre-dim lead so the dim never lands
+  on top of the screensaver itself.
+- Screensaver brightness: 10-100 %, default 30. The level both the
+  auto-dim stage and the screensaver overlay clamp the LCD to.
+  Lower values save more power; pick the lowest value that's still
+  comfortable to glance at in your usual lighting.
+- Turn off screen after: Never / 1 / 2 / 5 / 15 / 30 min, default
+  5. How long after the screensaver fires the device takes the
+  next step: backlight to 0 and the render loop suspended until
+  input arrives or a notification posts. Any key, touch, or
+  incoming high-priority notification (DM, file transfer, low
+  battery, OTA available) restores the screen. Set to Never to
+  keep the screensaver running indefinitely without ever blanking
+  the panel.
 
 ## Sound
 

--- a/lua/ezui/screen.lua
+++ b/lua/ezui/screen.lua
@@ -145,8 +145,15 @@ local function ensure_toast_subscribed()
         -- An incoming notification is a "high-priority" wake signal:
         -- if the panel is off or dim the user should see the toast
         -- without having to touch the device. notify_input() handles
-        -- restoring brightness + clearing the idle stage.
-        screen.notify_input()
+        -- restoring brightness + clearing the idle stage. Gate on
+        -- idle_stage so dismiss()/dismiss_source()/mark_all_read()
+        -- (which fire the same bus event) don't wake the panel from
+        -- background subscribers -- e.g. the OTA flow calling
+        -- dismiss_source("ota") after an update would otherwise pull
+        -- the device out of stage 3 every time.
+        if screen.idle_stage ~= 0 then
+            screen.notify_input()
+        end
     end)
     _toast_subscribed = true
 end
@@ -497,6 +504,12 @@ end
 
 function screen.release_wakelock(tag)
     if not tag then return end
+    -- Releasing a tag that was never acquired must be a no-op: file
+    -- transfer's early-fail paths (key-derivation failure, AP-start
+    -- failure, OFFER undelivered) post `file/error` before any
+    -- `file/progress`, so the subscriber on file/error would otherwise
+    -- silently reset the user's idle countdown on every such failure.
+    if screen._wakelocks[tag] == nil then return end
     screen._wakelocks[tag] = nil
     -- Restart the idle countdown from the release moment. Without
     -- this, last_input_time stays frozen at whenever the user last
@@ -508,16 +521,23 @@ function screen.release_wakelock(tag)
     screen.last_input_time = ez.system.millis()
 end
 
+local _prev_recording = false
 local function _wakelocks_held()
     for _ in pairs(screen._wakelocks) do return true end
     -- Implicit wakelock: audio recording in progress. The voice-notes
     -- and signal-test screens flip ez.audio.is_recording() and may
     -- run unattended; blanking the panel mid-capture is confusing
     -- (and stops the user from seeing the "Recording... N s" timer).
-    if ez.audio and ez.audio.is_recording and ez.audio.is_recording() then
-        return true
+    local recording = ez.audio and ez.audio.is_recording and ez.audio.is_recording() or false
+    -- Falling edge: capture just ended. Restart the idle countdown so
+    -- the next update() tick doesn't see an idle_s already past
+    -- ss_timeout + disp_off_delay*60 and jump straight to panel-off.
+    -- Mirrors the explicit release_wakelock() behaviour.
+    if _prev_recording and not recording then
+        screen.last_input_time = ez.system.millis()
     end
-    return false
+    _prev_recording = recording
+    return recording
 end
 
 -- Restore the LCD backlight to the user's stored brightness, or to

--- a/lua/ezui/screen.lua
+++ b/lua/ezui/screen.lua
@@ -498,6 +498,14 @@ end
 function screen.release_wakelock(tag)
     if not tag then return end
     screen._wakelocks[tag] = nil
+    -- Restart the idle countdown from the release moment. Without
+    -- this, last_input_time stays frozen at whenever the user last
+    -- touched the device before acquiring the wakelock; a long-held
+    -- wakelock (e.g. a multi-minute file transfer) would then make
+    -- the next update() tick see an idle_s already past
+    -- ss_timeout + disp_off_delay*60 and jump straight to stage 3
+    -- with no dim or screensaver in between.
+    screen.last_input_time = ez.system.millis()
 end
 
 local function _wakelocks_held()
@@ -532,12 +540,17 @@ end
 -- ezui/touch_input.lua's on_down/move/up.
 function screen.notify_input()
     screen.last_input_time = ez.system.millis()
-    local was_dim_or_off = (screen.idle_stage == 1 or screen.idle_stage == 3)
+    -- Any non-zero stage clamped the LCD backlight (stage 1 dim,
+    -- stage 2 screensaver-active, stage 3 panel off), so restoring
+    -- on wake has to cover all three. Excluding stage 2 here would
+    -- leave the LCD pinned at ss_bright after the key press that
+    -- dismisses the screensaver, since ss.stop() only restores the
+    -- keyboard backlight.
+    local was_dim_or_off = (screen.idle_stage ~= 0)
     if was_dim_or_off then
         _restore_brightness()
         screen.dirty = true
     end
-    local prev_stage = screen.idle_stage
     screen.idle_stage = 0
     local ss_ok, ss = pcall(require, "screens.tools.screensaver")
     if ss_ok and ss.is_active() then
@@ -548,7 +561,7 @@ function screen.notify_input()
     -- Treat a wake from dim or panel-off as a "swallow this input"
     -- event too: a tap to wake shouldn't also click whatever sat
     -- under the finger.
-    return was_dim_or_off or prev_stage == 2
+    return was_dim_or_off
 end
 
 function screen.handle_input()

--- a/lua/ezui/screen.lua
+++ b/lua/ezui/screen.lua
@@ -39,6 +39,20 @@ screen.status_last = -10000    -- negative so the first update() runs the poll i
 -- is exactly the scenario the screensaver is designed for.
 screen.last_input_time = ez.system.millis()  -- millis() of last keypress (or boot)
 
+-- Idle ladder: dim -> screensaver -> panel-off. Driven from screen.update()
+-- by comparing now - last_input_time against ss_timeout and disp_off_delay.
+-- Stage 0 = active, 1 = dim, 2 = screensaver (existing behaviour), 3 = panel
+-- off (backlight 0, render loop suspended). Wakelocks held in `_wakelocks`
+-- keep the ladder pinned to stage 0; an empty table means "no inhibitors".
+screen.idle_stage = 0
+screen._normal_brightness = nil  -- cached on first dim, restored on wake
+screen._wakelocks = {}
+
+-- Pre-dim lead time: ramp to dim brightness this many ms BEFORE the
+-- screensaver fires. The issue spec calls this out as 30 s; tunable
+-- via ss_predim pref (seconds, 0 disables the dim stage).
+screen.predim_lead_default = 30
+
 -- Node reused every frame to render the global status bar. Keeping one
 -- instance avoids a garbage-generating allocation per frame.
 local _status_node = { type = "status_bar" }
@@ -128,8 +142,38 @@ local function ensure_toast_subscribed()
         if list and list[1] then
             screen.show_toast(list[1])
         end
+        -- An incoming notification is a "high-priority" wake signal:
+        -- if the panel is off or dim the user should see the toast
+        -- without having to touch the device. notify_input() handles
+        -- restoring brightness + clearing the idle stage.
+        screen.notify_input()
     end)
     _toast_subscribed = true
+end
+
+-- Wire bus events that should hold a wakelock for the duration of an
+-- activity. Lazy for the same reason as the toast subscriber: ez.bus
+-- must be live. The tags are namespaced so multiple subsystems can
+-- coexist without one releasing another's lock.
+local _wakelock_subscribed = false
+local function ensure_wakelock_subscribed()
+    if _wakelock_subscribed then return end
+    if not (ez and ez.bus and ez.bus.subscribe) then return end
+
+    -- File transfer in progress: hold a wakelock from the first
+    -- progress event (which fires on connect/transferring) until
+    -- file/done or file/error.
+    ez.bus.subscribe("file/progress", function(_t, _d)
+        screen.acquire_wakelock("file_transfer")
+    end)
+    ez.bus.subscribe("file/done", function(_t, _d)
+        screen.release_wakelock("file_transfer")
+    end)
+    ez.bus.subscribe("file/error", function(_t, _d)
+        screen.release_wakelock("file_transfer")
+    end)
+
+    _wakelock_subscribed = true
 end
 
 function screen._draw_toast(d)
@@ -437,6 +481,49 @@ end
 screen.last_pop_time = 0
 screen.pop_cooldown_ms = 500
 
+-- Wakelock API: any non-nil tag in screen._wakelocks pins the idle
+-- ladder at stage 0. Use this for foreground actions that need the
+-- display alive (file transfers in progress, audio recording, etc.).
+-- Releasing the same tag clears it; the next idle tick re-evaluates.
+function screen.acquire_wakelock(tag)
+    if not tag then return end
+    screen._wakelocks[tag] = true
+    if screen.idle_stage ~= 0 then
+        -- Pretend the user just touched the device so the ladder
+        -- unwinds via the same path as a real wake.
+        screen.notify_input()
+    end
+end
+
+function screen.release_wakelock(tag)
+    if not tag then return end
+    screen._wakelocks[tag] = nil
+end
+
+local function _wakelocks_held()
+    for _ in pairs(screen._wakelocks) do return true end
+    -- Implicit wakelock: audio recording in progress. The voice-notes
+    -- and signal-test screens flip ez.audio.is_recording() and may
+    -- run unattended; blanking the panel mid-capture is confusing
+    -- (and stops the user from seeing the "Recording... N s" timer).
+    if ez.audio and ez.audio.is_recording and ez.audio.is_recording() then
+        return true
+    end
+    return false
+end
+
+-- Restore the LCD backlight to the user's stored brightness, or to
+-- the value cached when we first started dimming. Either way, idempotent.
+local function _restore_brightness()
+    if screen._normal_brightness then
+        ez.display.set_brightness(screen._normal_brightness)
+        screen._normal_brightness = nil
+    else
+        local b = tonumber(ez.storage.get_pref("screen_bright", 200)) or 200
+        ez.display.set_brightness(b)
+    end
+end
+
 -- Reset the idle timer and, if the screensaver is currently up,
 -- dismiss it. Returns true when the screensaver was just dismissed
 -- so the caller can swallow the originating event (key or touch) --
@@ -445,13 +532,23 @@ screen.pop_cooldown_ms = 500
 -- ezui/touch_input.lua's on_down/move/up.
 function screen.notify_input()
     screen.last_input_time = ez.system.millis()
+    local was_dim_or_off = (screen.idle_stage == 1 or screen.idle_stage == 3)
+    if was_dim_or_off then
+        _restore_brightness()
+        screen.dirty = true
+    end
+    local prev_stage = screen.idle_stage
+    screen.idle_stage = 0
     local ss_ok, ss = pcall(require, "screens.tools.screensaver")
     if ss_ok and ss.is_active() then
         ss.stop()
         screen.dirty = true
         return true
     end
-    return false
+    -- Treat a wake from dim or panel-off as a "swallow this input"
+    -- event too: a tap to wake shouldn't also click whatever sat
+    -- under the finger.
+    return was_dim_or_off or prev_stage == 2
 end
 
 function screen.handle_input()
@@ -596,20 +693,86 @@ function screen.update()
     -- Wire up the notifications -> toast subscription on the first
     -- frame, when ez.bus is guaranteed to be live.
     ensure_toast_subscribed()
+    ensure_wakelock_subscribed()
 
     -- Drain all pending input
     while screen.handle_input() do end
 
-    -- Screensaver: activate overlay after idle timeout.
-    -- Dismissed on any keypress in handle_input above.
+    -- Idle ladder: dim -> screensaver -> panel-off.
+    --
+    -- Stage transitions are evaluated against the screensaver timeout
+    -- (the existing `ss_timeout` pref, seconds, 0 disables the whole
+    -- ladder). Stage 1 ramps brightness down a configurable lead time
+    -- before the screensaver kicks in; stage 2 is the existing
+    -- screensaver overlay; stage 3 turns the backlight off entirely
+    -- after `disp_off_delay` minutes past the screensaver fire.
+    --
+    -- A held wakelock pins the ladder at stage 0 regardless of
+    -- timeout. Bus subscribers below wire file_transfer / audio
+    -- recording into the wakelock table so foreground activity
+    -- doesn't get blanked mid-transfer.
+    local panel_off = false
     do
         local timeout = tonumber(ez.storage.get_pref("ss_timeout", 0)) or 0
-        if timeout > 0 and screen.last_input_time > 0 then
+        if timeout > 0 and screen.last_input_time > 0
+                and not _wakelocks_held() then
+            local idle_s = (ez.system.millis() - screen.last_input_time) / 1000
+            local autodim = (ez.storage.get_pref("ss_autodim", "1") == "1")
+            local predim_lead = autodim and screen.predim_lead_default or 0
+            local off_delay_min = tonumber(
+                ez.storage.get_pref("disp_off_delay", 5)) or 5
+            local off_at_s = (off_delay_min > 0)
+                and (timeout + off_delay_min * 60) or nil
+
             local ss_ok2, ss2 = pcall(require, "screens.tools.screensaver")
-            if ss_ok2 and not ss2.is_active() then
-                local idle = ez.system.millis() - screen.last_input_time
-                if idle >= timeout * 1000 then
+
+            -- Stage 3: panel off (latest, so check first).
+            if off_at_s and idle_s >= off_at_s then
+                if screen.idle_stage ~= 3 then
+                    if not screen._normal_brightness then
+                        screen._normal_brightness = tonumber(
+                            ez.storage.get_pref("screen_bright", 200)) or 200
+                    end
+                    ez.display.set_brightness(0)
+                    screen.idle_stage = 3
+                end
+                panel_off = true
+
+            -- Stage 2: screensaver firing.
+            elseif idle_s >= timeout then
+                if ss_ok2 and not ss2.is_active() then
+                    local ss_bright_pct = tonumber(
+                        ez.storage.get_pref("ss_bright", 30)) or 30
+                    if not screen._normal_brightness then
+                        screen._normal_brightness = tonumber(
+                            ez.storage.get_pref("screen_bright", 200)) or 200
+                    end
+                    local clamped = math.floor(
+                        screen._normal_brightness * ss_bright_pct / 100)
+                    if clamped < 10 then clamped = 10 end
+                    ez.display.set_brightness(clamped)
                     ss2.start()
+                end
+                screen.idle_stage = 2
+
+            -- Stage 1: pre-dim before screensaver. Skip when the
+            -- screensaver timeout is shorter than the lead -- the
+            -- dim stage only makes sense as a chain ahead of the
+            -- screensaver, never coincident with it or earlier.
+            elseif predim_lead > 0 and timeout > predim_lead
+                    and idle_s >= (timeout - predim_lead) then
+                if screen.idle_stage ~= 1 then
+                    if not screen._normal_brightness then
+                        screen._normal_brightness = tonumber(
+                            ez.storage.get_pref("screen_bright", 200)) or 200
+                    end
+                    local ss_bright_pct = tonumber(
+                        ez.storage.get_pref("ss_bright", 30)) or 30
+                    local dimmed = math.floor(
+                        screen._normal_brightness * ss_bright_pct / 100)
+                    if dimmed < 10 then dimmed = 10 end
+                    ez.display.set_brightness(dimmed)
+                    screen.idle_stage = 1
                 end
             end
         end
@@ -624,7 +787,12 @@ function screen.update()
         inst:update()
     end
 
-    screen.render()
+    -- Stage 3: backlight is off, skip the render path entirely so the
+    -- panel keeps the framebuffer it already had and the CPU stops
+    -- driving SPI. The next notify_input() re-enables both.
+    if not panel_off then
+        screen.render()
+    end
 end
 
 return screen

--- a/lua/screens/settings/display_settings.lua
+++ b/lua/screens/settings/display_settings.lua
@@ -76,11 +76,27 @@ local SCREENSAVER_OPTIONS = {
     { label = "30 min",  value = 1800 },
 }
 
+-- Panel-off delay is added AFTER the screensaver fires, so the user-
+-- visible "turn off screen after" is ss_timeout + this. 0 disables.
+local DISPLAY_OFF_OPTIONS = {
+    { label = "Never",   value = 0 },
+    { label = "1 min",   value = 1 },
+    { label = "2 min",   value = 2 },
+    { label = "5 min",   value = 5 },
+    { label = "15 min",  value = 15 },
+    { label = "30 min",  value = 30 },
+}
+
 function Display.initial_state()
     local ss_val = tonumber(ez.storage.get_pref("ss_timeout", 0)) or 0
     local ss_idx = 1
     for i, opt in ipairs(SCREENSAVER_OPTIONS) do
         if opt.value == ss_val then ss_idx = i break end
+    end
+    local off_val = tonumber(ez.storage.get_pref("disp_off_delay", 5)) or 5
+    local off_idx = 4  -- default to "5 min"
+    for i, opt in ipairs(DISPLAY_OFF_OPTIONS) do
+        if opt.value == off_val then off_idx = i break end
     end
     local wp_val = ez.storage.get_pref("wp_rotate", "boot")
     local wp_idx = 1
@@ -91,6 +107,9 @@ function Display.initial_state()
         brightness   = tonumber(ez.storage.get_pref("screen_bright", 200)) or 200,
         kb_backlight = tonumber(ez.storage.get_pref("kb_backlight", 0)) or 0,
         screensaver  = ss_idx,
+        autodim      = (ez.storage.get_pref("ss_autodim", "1") == "1"),
+        ss_bright    = tonumber(ez.storage.get_pref("ss_bright", 30)) or 30,
+        disp_off     = off_idx,
         wp_rotate    = wp_idx,
     }
 end
@@ -161,6 +180,49 @@ function Display:build(state)
         ui.text_widget(
             "Cycles animated patterns to exercise all subpixels and "
             .. "prevent LCD image persistence.",
+            { wrap = true, color = "TEXT_MUTED", font = "small_aa" })
+    )
+
+    content[#content + 1] = ui.padding({ 8, 6, 2, 6 },
+        ui.toggle("Auto-dim before screensaver", state.autodim, {
+            on_change = function(on)
+                state.autodim = on
+                ez.storage.set_pref("ss_autodim", on and "1" or "0")
+            end,
+        })
+    )
+
+    content[#content + 1] = ui.padding({ 2, 6, 2, 6 },
+        ui.slider({
+            label = "Screensaver brightness %",
+            value = state.ss_bright,
+            min = 10, max = 100, step = 5,
+            on_change = function(val)
+                ez.storage.set_pref("ss_bright", val)
+                state.ss_bright = val
+            end,
+        })
+    )
+
+    content[#content + 1] = ui.padding({ 8, 8, 2, 8 },
+        ui.text_widget("Turn off screen after",
+            { color = "TEXT", font = "small_aa" })
+    )
+    content[#content + 1] = ui.padding({ 2, 6, 2, 6 },
+        ui.dropdown(DISPLAY_OFF_OPTIONS, {
+            value = state.disp_off,
+            on_change = function(idx)
+                local val = DISPLAY_OFF_OPTIONS[idx].value
+                ez.storage.set_pref("disp_off_delay", val)
+                state.disp_off = idx
+            end,
+        })
+    )
+    content[#content + 1] = ui.padding({ 2, 8, 4, 8 },
+        ui.text_widget(
+            "Added on top of the screensaver timeout. The backlight "
+            .. "turns fully off and the display stops rendering until "
+            .. "input or a notification wakes it.",
             { wrap = true, color = "TEXT_MUTED", font = "small_aa" })
     )
 

--- a/lua/services/prefs_registry.lua
+++ b/lua/services/prefs_registry.lua
@@ -30,6 +30,15 @@ local ENTRIES = {
       description = "Keyboard backlight brightness (0-255)" },
     { key = "accent_color",       type = "int32", default = 0,
       description = "Accent colour (RGB565; 0 uses the first preset)" },
+    { key = "ss_timeout",         type = "int32", default = 0, min = 0, max = 1800,
+      description = "Seconds of idle before the screensaver fires (0 disables)" },
+    { key = "ss_autodim",         type = "string", default = "1",
+      options = { "0", "1" },
+      description = "Pre-dim the display ~30s before the screensaver fires" },
+    { key = "ss_bright",          type = "int32", default = 30, min = 10, max = 100,
+      description = "Screensaver / pre-dim brightness, percent of normal" },
+    { key = "disp_off_delay",     type = "int32", default = 5, min = 0, max = 60,
+      description = "Minutes after screensaver before backlight turns off (0 = never)" },
 
     -- ---- Wallpaper --------------------------------------------------
     { key = "wallpaper",      type = "string", default = "synthwave",


### PR DESCRIPTION
## Summary

Extend the existing screensaver gate into a three-stage idle ladder:

| Stage | When | What happens |
|---|---|---|
| 1. Pre-dim | 30 s before screensaver fires | Backlight drops to `ss_bright` % of normal |
| 2. Screensaver | `ss_timeout` (unchanged) | Existing animation; backlight clamped to same `ss_bright` % |
| 3. Panel off | `ss_timeout + disp_off_delay` min | Backlight 0, render loop suspended until input or notification |

New prefs (all registered in `prefs_registry`):

- `ss_timeout`  - seconds before the screensaver fires (existing, now registered)
- `ss_autodim`  - `"0"` / `"1"`, default on; disables stage 1 only
- `ss_bright`   - 10-100 %, default 30
- `disp_off_delay` - minutes after the screensaver before backlight goes to 0; default 5; never / 1 / 2 / 5 / 15 / 30 in the UI

Settings -> Display picks them up via a toggle, slider and dropdown directly under the existing screensaver dropdown.

### Wakelocks

`screen.acquire_wakelock(tag)` / `screen.release_wakelock(tag)` pin the ladder at stage 0 regardless of timeout. Wired:

- Bus subscriptions for `file/progress` (acquire) and `file/done` / `file/error` (release) -- in-progress file transfers stay lit.
- Implicit poll of `ez.audio.is_recording()` inside `_wakelocks_held()` -- the voice-notes / signal-test recording paths stay lit without touching those screens.

### Notifications wake the panel

The existing `notifications/changed` bus subscriber (which already drives the toast) now also calls `screen.notify_input()`, so an incoming high-priority notification restores brightness and resumes rendering. The existing wake-event guard means the tap that dismisses the toast still doesn't click through.

### Edge cases

- `ss_timeout = 0` (Off) disables the whole ladder -- no dim, no panel-off.
- `disp_off_delay = 0` (Never) keeps the screensaver running indefinitely; the existing behaviour.
- Stage 1 is skipped when `ss_timeout < predim_lead` so the dim never lands coincident with or earlier than the screensaver.

## Test plan
- [x] `pio run` clean -- RAM 26.2 %, flash 58.3 %.
- [x] Flashed to T-Deck Plus.
- [x] With `ss_timeout=35, disp_off_delay=1`: device walks 0 -> 1 (idle 5 s) -> 2 (idle 35 s, screensaver on, brightness clamped) -> 3 (idle 95 s, stage `idle_stage=3`, render loop suspended).
- [x] ENTER press → stage 0, screensaver dismissed, brightness restored to `screen_bright` pref.
- [x] `acquire_wakelock('test')` pins stage 0 across the screensaver threshold; `release_wakelock('test')` lets the ladder evaluate again next tick.
- [x] Settings -> Display renders the new toggle / slider / dropdown without layout regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)