### PR TITLE
feat(mesh): persist known nodes across reboots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -689,6 +689,44 @@ After making a fix:
 - `!RF` indicator means radio failed to initialize
 - Check LoRa module wiring if this appears
 
+### Node Store (persisted ADVERT cache)
+- Storage path: `/sd/nodes.bin` when SD is mounted, otherwise NVS blob
+  `nodes` in the existing `meshcore` namespace (factory reset wipes the
+  blob alongside the identity keys).
+- Header: `[magic:4 'EZNS' / 0x534E5A45][version:2 LE][count:2 LE]`.
+  `kVersion = 1` -- bump in lockstep with any layout change so older
+  firmware loading a newer blob fails fast.
+- Per-node record: `[pathHash:1][role:1][flags:1][nameLen:1]
+  [advertTimestamp:4 LE][lastSeenUnix:4 LE]
+  [pubKey:32 if flags&0x01]
+  [lat:f32 LE][lon:f32 LE if flags&0x02]
+  [name:nameLen]`. Flags: bit 0 = `hasPublicKey`, bit 1 = `hasLocation`.
+- Caps: 128 entries on SD, 64 on NVS. On overflow at save time,
+  oldest-by-`advertTimestamp` entries are evicted from the *written*
+  set (the in-memory vector is left untouched).
+- Aging: entries with a `lastSeenUnix` more than 7 days behind the
+  current wall clock are dropped at load time. Skipped when the
+  system clock is unset (year < 2020), so a cold boot before NTP/GPS
+  sync doesn't wipe the list.
+- Save policy: `_nodesDirty` flips true the first time `updateNode()`
+  changes a persisted field (new node, name, pubkey, role, location,
+  advert timestamp). `MeshCore::update()` flushes once
+  `millis() - _nodesDirtyAt >= 30000`. The dirty timestamp is *not*
+  re-armed on subsequent changes so a steady ADVERT stream still
+  gets persisted promptly.
+- What is NOT persisted: `lastRssi`, `lastSnr`, `hopCount` describe
+  the last *packet*, not the node, and would be stale and misleading
+  after a reboot. They are zeroed on restore and refilled by the next
+  ADVERT.
+- SD writes are atomic: written to `/sd/nodes.bin.tmp`, then renamed
+  over `/sd/nodes.bin`. A power loss mid-save loses the *previous*
+  save, never corrupts the active blob.
+- Names are sanitized to printable ASCII at the deserialise boundary
+  (`?` substituted for any byte outside `0x20..0x7E`) so hand-edited
+  blobs or older-firmware saves can't poison `draw_text` callers.
+  Live ADVERT names still flow unsanitized through `updateNode()`;
+  fixing that seam is out of scope.
+
 ## Theming
 
 `lua/ezui/theme.lua` is the single source of truth for colors and fonts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -702,8 +702,11 @@ After making a fix:
   [lat:f32 LE][lon:f32 LE if flags&0x02]
   [name:nameLen]`. Flags: bit 0 = `hasPublicKey`, bit 1 = `hasLocation`.
 - Caps: 128 entries on SD, 64 on NVS. On overflow at save time,
-  oldest-by-`advertTimestamp` entries are evicted from the *written*
-  set (the in-memory vector is left untouched).
+  oldest-by-`lastSeen` (local millis() observation time) entries are
+  evicted from the *written* set (the in-memory vector is left
+  untouched). Deliberately not `advertTimestamp` -- that field is
+  peer-chosen and a node with a future-dated or wrap-around ADVERT
+  would always survive truncation over genuinely-fresh observations.
 - Aging: entries with a `lastSeenUnix` more than 7 days behind the
   current wall clock are dropped at load time. Skipped when the
   system clock is unset (year < 2020), so a cold boot before NTP/GPS

--- a/src/mesh/meshcore.cpp
+++ b/src/mesh/meshcore.cpp
@@ -36,6 +36,15 @@ bool MeshCore::init() {
     Serial.printf("Node ID: %s\n", fullId);
     Serial.printf("Node Name: %s\n", _identity.getNodeName());
 
+    // Load persisted node list from /sd/nodes.bin (or NVS fallback) so
+    // the Map screen / "browse nodes" UI shows last-known peers
+    // immediately after a cold boot, instead of waiting up to 15 min
+    // for the next ADVERT round. See node_store.h for the rationale.
+    if (_nodeStore.load(_nodes)) {
+        Serial.printf("Mesh: restored %u known nodes\n",
+                      (unsigned)_nodes.size());
+    }
+
     // Channel management is now handled by Lua (scripts/services/channels.lua)
     // The Lua Channels service will call on_group_packet() to receive raw packets
     // and send_group_packet() to transmit encrypted messages
@@ -107,6 +116,21 @@ void MeshCore::update() {
         if (now - _lastAnnounce >= _announceInterval) {
             _lastAnnounce = now;
             sendAnnounce();
+        }
+    }
+
+    // Debounced node-list persistence. Save once the dirty window has
+    // been quiet for kNodesSaveDebounceMs; a steady ADVERT stream
+    // doesn't extend the window because _nodesDirtyAt is only stamped
+    // on the *first* unsaved change (see updateNode()).
+    if (_nodesDirty &&
+        (millis() - _nodesDirtyAt) >= kNodesSaveDebounceMs) {
+        if (_nodeStore.save(_nodes)) {
+            _nodesDirty = false;
+        } else {
+            // Defer the next attempt by another debounce window rather
+            // than spinning on a flaky backend (e.g. SD pulled out).
+            _nodesDirtyAt = millis();
         }
     }
 }
@@ -464,34 +488,58 @@ void MeshCore::updateNode(uint8_t pathHash, const char* name, const uint8_t* pub
                           const RxMetadata& meta, uint8_t hops, uint8_t role,
                           uint32_t advertTimestamp, bool hasLocation,
                           float latitude, float longitude) {
+    // Helper: stamp the dirty flag the first time a save-worthy change
+    // happens, but leave _nodesDirtyAt alone if we're already dirty so
+    // the 30 s debounce in update() measures from the first change.
+    auto markDirty = [&]() {
+        if (!_nodesDirty) {
+            _nodesDirty = true;
+            _nodesDirtyAt = millis();
+        }
+    };
+
     // Look for existing node
     for (auto& node : _nodes) {
         if (node.pathHash == pathHash) {
             if (name && strlen(name) > 0) {
-                strncpy(node.name, name, MAX_NODE_NAME);
-                node.name[MAX_NODE_NAME] = '\0';
+                if (strncmp(node.name, name, MAX_NODE_NAME) != 0) {
+                    strncpy(node.name, name, MAX_NODE_NAME);
+                    node.name[MAX_NODE_NAME] = '\0';
+                    markDirty();
+                }
             }
             if (publicKey) {
-                memcpy(node.publicKey, publicKey, ED25519_PUBLIC_KEY_SIZE);
-                node.hasPublicKey = true;
+                if (!node.hasPublicKey ||
+                    memcmp(node.publicKey, publicKey, ED25519_PUBLIC_KEY_SIZE) != 0) {
+                    memcpy(node.publicKey, publicKey, ED25519_PUBLIC_KEY_SIZE);
+                    node.hasPublicKey = true;
+                    markDirty();
+                }
             }
             node.lastSeen = meta.timestamp;
             node.lastRssi = meta.rssi;
             node.lastSnr = meta.snr;
             node.hopCount = hops;
             // Update role if we got a valid one
-            if (role != ROLE_UNKNOWN) {
+            if (role != ROLE_UNKNOWN && role != node.role) {
                 node.role = role;
+                markDirty();
             }
             // Store Unix timestamp from ADVERT if provided
-            if (advertTimestamp > 0) {
+            if (advertTimestamp > 0 && advertTimestamp != node.advertTimestamp) {
                 node.advertTimestamp = advertTimestamp;
+                markDirty();
             }
             // Update location if provided
             if (hasLocation) {
-                node.hasLocation = true;
-                node.latitude = latitude;
-                node.longitude = longitude;
+                if (!node.hasLocation ||
+                    node.latitude != latitude ||
+                    node.longitude != longitude) {
+                    node.hasLocation = true;
+                    node.latitude = latitude;
+                    node.longitude = longitude;
+                    markDirty();
+                }
             }
 
             if (_onNode) {
@@ -530,6 +578,7 @@ void MeshCore::updateNode(uint8_t pathHash, const char* name, const uint8_t* pub
     node.longitude = longitude;
 
     _nodes.push_back(node);
+    markDirty();
 
     if (_onNode) {
         _onNode(node);

--- a/src/mesh/meshcore.h
+++ b/src/mesh/meshcore.h
@@ -5,6 +5,7 @@
 #include "../hardware/radio.h"
 #include "packet.h"
 #include "identity.h"
+#include "node_store.h"
 
 // Node role constants (matches MeshCore ADV_TYPE values)
 enum NodeRole : uint8_t {
@@ -134,6 +135,17 @@ private:
 
     std::vector<NodeInfo> _nodes;
     std::vector<Message> _messages;
+
+    // Persistence: see node_store.h. _nodesDirty flips true the moment
+    // updateNode() makes a user-visible change to a persisted field;
+    // _nodesDirtyAt records when that happened so the 30 s debounce
+    // window is measured from the *first* unsaved change, not the
+    // latest one. Without that, a steady stream of ADVERTs could
+    // re-arm the timer indefinitely and we'd never save.
+    NodeStore _nodeStore;
+    bool _nodesDirty = false;
+    uint32_t _nodesDirtyAt = 0;
+    static constexpr uint32_t kNodesSaveDebounceMs = 30 * 1000;
 
     MessageCallback _onMessage;
     NodeCallback _onNode;

--- a/src/mesh/node_store.cpp
+++ b/src/mesh/node_store.cpp
@@ -124,16 +124,19 @@ std::vector<uint8_t> NodeStore::serialize(const std::vector<NodeInfo>& nodes,
 
         // lastSeenUnix is derived from "how long ago lastSeen was" in
         // millis() and the current wall clock. If the wall clock is
-        // unset, we still want a coherent ordering across this single
-        // save batch, so use advertTimestamp as the fallback (it's the
-        // best lower bound for "the node existed at unix t").
+        // unset, persist 0 -- deserialize()'s aging check skips entries
+        // with lastSeenUnix == 0, so they survive across reboots until
+        // a synced-clock save can re-stamp them. Falling back to
+        // n.advertTimestamp here would be wrong: the peer-stamped
+        // value is unrelated to when *we* last heard the node, so on
+        // the next boot with a synced clock the 7-day aging check
+        // could evict a freshly-heard node whose peer happened to
+        // stamp an old ADVERT.
         uint32_t lastSeenUnix = 0;
         if (nowUnix > 0) {
             uint32_t ageMs = millis() - n.lastSeen;
             uint32_t ageSec = ageMs / 1000;
             lastSeenUnix = (nowUnix > ageSec) ? (nowUnix - ageSec) : 0;
-        } else {
-            lastSeenUnix = n.advertTimestamp;
         }
 
         buf.push_back(n.pathHash);

--- a/src/mesh/node_store.cpp
+++ b/src/mesh/node_store.cpp
@@ -1,0 +1,364 @@
+#include "node_store.h"
+#include "meshcore.h"
+#include "../hardware/sd_manager.h"
+
+#include <Arduino.h>
+#include <Preferences.h>
+#include <SD.h>
+#include <FS.h>
+
+#include <algorithm>
+#include <cstring>
+#include <ctime>
+
+namespace {
+
+// time(NULL) returns seconds since 1970 from the system clock. Before
+// NTP/GPS sync, the clock sits in 1970 (tm_year < 70 / 120). We treat
+// "year >= 2020" as the threshold for a trustworthy unix time, matching
+// l_system_get_time_unix in src/lua/bindings/system_bindings.cpp.
+uint32_t currentUnixOrZero() {
+    time_t now;
+    time(&now);
+    struct tm tinfo;
+    gmtime_r(&now, &tinfo);
+    if (tinfo.tm_year < 120) return 0;
+    return static_cast<uint32_t>(now);
+}
+
+// Little-endian writers/readers. ESP32 is LE so memcpy would work, but
+// going through these makes the on-disk format endian-independent
+// should the codebase ever move.
+void writeU16(std::vector<uint8_t>& buf, uint16_t v) {
+    buf.push_back(v & 0xFF);
+    buf.push_back((v >> 8) & 0xFF);
+}
+void writeU32(std::vector<uint8_t>& buf, uint32_t v) {
+    buf.push_back(v & 0xFF);
+    buf.push_back((v >> 8) & 0xFF);
+    buf.push_back((v >> 16) & 0xFF);
+    buf.push_back((v >> 24) & 0xFF);
+}
+void writeF32(std::vector<uint8_t>& buf, float f) {
+    uint32_t u;
+    std::memcpy(&u, &f, sizeof(u));
+    writeU32(buf, u);
+}
+
+bool readU16(const uint8_t*& p, const uint8_t* end, uint16_t& out) {
+    if (end - p < 2) return false;
+    out = uint16_t(p[0]) | (uint16_t(p[1]) << 8);
+    p += 2;
+    return true;
+}
+bool readU32(const uint8_t*& p, const uint8_t* end, uint32_t& out) {
+    if (end - p < 4) return false;
+    out = uint32_t(p[0]) | (uint32_t(p[1]) << 8) |
+          (uint32_t(p[2]) << 16) | (uint32_t(p[3]) << 24);
+    p += 4;
+    return true;
+}
+bool readF32(const uint8_t*& p, const uint8_t* end, float& out) {
+    uint32_t u;
+    if (!readU32(p, end, u)) return false;
+    std::memcpy(&out, &u, sizeof(out));
+    return true;
+}
+
+}  // namespace
+
+NodeStore::Backend NodeStore::chooseBackend() {
+    // ensureMounted() is cheap when the card is already up; on a device
+    // booted without SD it returns false on first call and we fall back
+    // to NVS. The decision is re-made on every save/load to handle
+    // late-insert (the SD takes precedence the moment it appears).
+    return SDManager::ensureMounted() ? Backend::Sd : Backend::Nvs;
+}
+
+std::vector<uint8_t> NodeStore::serialize(const std::vector<NodeInfo>& nodes,
+                                          size_t cap) {
+    // Header: [magic:4][version:2][count:2]
+    // Per node:
+    //   [pathHash:1][role:1][flags:1][nameLen:1]
+    //   [advertTimestamp:4][lastSeenUnix:4]
+    //   [pubKey:32 if hasPublicKey, else absent]
+    //   [lat:4][lon:4 if hasLocation, else absent]
+    //   [name:nameLen]
+    //
+    // flags bit 0 = hasPublicKey, bit 1 = hasLocation. Variable-size
+    // sections keyed off flags keep the per-node footprint small for
+    // the common case (NVS-friendly).
+
+    // Build a working copy of indices sorted newest-first by
+    // lastSeenUnix, so the truncation step keeps the freshest entries.
+    std::vector<size_t> idx;
+    idx.reserve(nodes.size());
+    for (size_t i = 0; i < nodes.size(); ++i) idx.push_back(i);
+    std::sort(idx.begin(), idx.end(),
+              [&](size_t a, size_t b) {
+                  return nodes[a].advertTimestamp > nodes[b].advertTimestamp;
+              });
+    if (idx.size() > cap) idx.resize(cap);
+
+    std::vector<uint8_t> buf;
+    buf.reserve(8 + idx.size() * 64);
+
+    writeU32(buf, kMagic);
+    writeU16(buf, kVersion);
+    writeU16(buf, static_cast<uint16_t>(idx.size()));
+
+    uint32_t nowUnix = currentUnixOrZero();
+
+    for (size_t k : idx) {
+        const NodeInfo& n = nodes[k];
+
+        uint8_t flags = 0;
+        if (n.hasPublicKey) flags |= 0x01;
+        if (n.hasLocation)  flags |= 0x02;
+
+        uint8_t nameLen = static_cast<uint8_t>(strnlen(n.name, MAX_NODE_NAME));
+
+        // lastSeenUnix is derived from "how long ago lastSeen was" in
+        // millis() and the current wall clock. If the wall clock is
+        // unset, we still want a coherent ordering across this single
+        // save batch, so use advertTimestamp as the fallback (it's the
+        // best lower bound for "the node existed at unix t").
+        uint32_t lastSeenUnix = 0;
+        if (nowUnix > 0) {
+            uint32_t ageMs = millis() - n.lastSeen;
+            uint32_t ageSec = ageMs / 1000;
+            lastSeenUnix = (nowUnix > ageSec) ? (nowUnix - ageSec) : 0;
+        } else {
+            lastSeenUnix = n.advertTimestamp;
+        }
+
+        buf.push_back(n.pathHash);
+        buf.push_back(n.role);
+        buf.push_back(flags);
+        buf.push_back(nameLen);
+        writeU32(buf, n.advertTimestamp);
+        writeU32(buf, lastSeenUnix);
+        if (n.hasPublicKey) {
+            buf.insert(buf.end(), n.publicKey,
+                       n.publicKey + ED25519_PUBLIC_KEY_SIZE);
+        }
+        if (n.hasLocation) {
+            writeF32(buf, n.latitude);
+            writeF32(buf, n.longitude);
+        }
+        if (nameLen > 0) {
+            buf.insert(buf.end(),
+                       reinterpret_cast<const uint8_t*>(n.name),
+                       reinterpret_cast<const uint8_t*>(n.name) + nameLen);
+        }
+    }
+
+    return buf;
+}
+
+bool NodeStore::deserialize(const uint8_t* data, size_t len,
+                            std::vector<NodeInfo>& outNodes) {
+    const uint8_t* p = data;
+    const uint8_t* end = data + len;
+
+    uint32_t magic = 0;
+    uint16_t version = 0;
+    uint16_t count = 0;
+    if (!readU32(p, end, magic)) return false;
+    if (magic != kMagic) return false;
+    if (!readU16(p, end, version)) return false;
+    if (version != kVersion) return false;
+    if (!readU16(p, end, count)) return false;
+
+    uint32_t nowUnix = currentUnixOrZero();
+    uint32_t nowMs = millis();
+
+    outNodes.clear();
+    outNodes.reserve(count);
+
+    for (uint16_t i = 0; i < count; ++i) {
+        if (end - p < 12) return false;
+        uint8_t pathHash = *p++;
+        uint8_t role     = *p++;
+        uint8_t flags    = *p++;
+        uint8_t nameLen  = *p++;
+
+        uint32_t advertTimestamp = 0;
+        uint32_t lastSeenUnix = 0;
+        if (!readU32(p, end, advertTimestamp)) return false;
+        if (!readU32(p, end, lastSeenUnix)) return false;
+
+        NodeInfo node{};
+        node.pathHash = pathHash;
+        node.role = role;
+        node.advertTimestamp = advertTimestamp;
+        node.hasPublicKey = (flags & 0x01) != 0;
+        node.hasLocation  = (flags & 0x02) != 0;
+        // Routing metrics describe the last packet, not the node;
+        // explicitly zero them so callers don't see stale numbers
+        // from before the reboot. The next ADVERT will refill them.
+        node.lastRssi = 0.0f;
+        node.lastSnr  = 0.0f;
+        node.hopCount = 0;
+
+        if (node.hasPublicKey) {
+            if (end - p < (int)ED25519_PUBLIC_KEY_SIZE) return false;
+            std::memcpy(node.publicKey, p, ED25519_PUBLIC_KEY_SIZE);
+            p += ED25519_PUBLIC_KEY_SIZE;
+        } else {
+            std::memset(node.publicKey, 0, ED25519_PUBLIC_KEY_SIZE);
+        }
+
+        if (node.hasLocation) {
+            if (!readF32(p, end, node.latitude)) return false;
+            if (!readF32(p, end, node.longitude)) return false;
+        } else {
+            node.latitude = 0.0f;
+            node.longitude = 0.0f;
+        }
+
+        if (end - p < nameLen) return false;
+        size_t copy = nameLen;
+        if (copy > MAX_NODE_NAME) copy = MAX_NODE_NAME;
+        if (copy > 0) std::memcpy(node.name, p, copy);
+        node.name[copy] = '\0';
+        if (nameLen == 0) {
+            // Synthesise a name from the path hash, matching the
+            // updateNode() fallback so downstream code doesn't trip on
+            // empty names.
+            snprintf(node.name, MAX_NODE_NAME, "%02X", pathHash);
+        }
+        p += nameLen;
+
+        // Aging: drop entries older than 7 days. Only enforceable when
+        // the wall clock is trustworthy; if it isn't, keep everything
+        // and let the next save (which will likely have a synced clock)
+        // do the eviction.
+        if (nowUnix > 0 && lastSeenUnix > 0 &&
+            nowUnix > lastSeenUnix &&
+            (nowUnix - lastSeenUnix) > kMaxAgeSeconds) {
+            continue;
+        }
+
+        // Re-stamp lastSeen as a millis() value far enough in the past
+        // to reflect the persisted unix age. Clamp at "0 millis() of
+        // this boot" to avoid wrap-around or future-dated values.
+        if (nowUnix > 0 && lastSeenUnix > 0 && lastSeenUnix <= nowUnix) {
+            uint32_t ageSec = nowUnix - lastSeenUnix;
+            uint64_t ageMs64 = uint64_t(ageSec) * 1000ULL;
+            if (ageMs64 > nowMs) {
+                node.lastSeen = 0;
+            } else {
+                node.lastSeen = nowMs - static_cast<uint32_t>(ageMs64);
+            }
+        } else {
+            // No usable wall clock: push lastSeen to the start of this
+            // boot. Age will then be reported as "uptime", which is the
+            // best honest answer we can give.
+            node.lastSeen = 0;
+        }
+
+        outNodes.push_back(node);
+    }
+
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+// SD backend
+// -----------------------------------------------------------------------------
+
+bool NodeStore::loadFromSd(std::vector<NodeInfo>& nodes) {
+    SDManager::ScopedLock lk;
+    if (!SD.exists(kSdPath)) return false;
+    File f = SDManager::openWithRetry(&SD, kSdPath, FILE_READ);
+    if (!f) return false;
+
+    size_t sz = f.size();
+    if (sz == 0 || sz > 64 * 1024) {  // sanity cap
+        f.close();
+        return false;
+    }
+    std::vector<uint8_t> buf(sz);
+    size_t read = f.read(buf.data(), sz);
+    f.close();
+    if (read != sz) return false;
+
+    return deserialize(buf.data(), sz, nodes);
+}
+
+bool NodeStore::saveToSd(const std::vector<NodeInfo>& nodes) {
+    SDManager::ScopedLock lk;
+    auto buf = serialize(nodes, kSdMaxNodes);
+
+    // Write to a tmp file then rename to make the swap atomic. A
+    // power loss mid-write only loses the *previous* save, never
+    // corrupts the active blob.
+    const char* tmpPath = "/sd/nodes.bin.tmp";
+    File f = SDManager::openWithRetry(&SD, tmpPath, FILE_WRITE);
+    if (!f) return false;
+    size_t wrote = f.write(buf.data(), buf.size());
+    f.close();
+    if (wrote != buf.size()) {
+        SD.remove(tmpPath);
+        return false;
+    }
+
+    // SD library has no rename(); remove-then-rename is the workaround.
+    if (SD.exists(kSdPath)) SD.remove(kSdPath);
+    if (!SD.rename(tmpPath, kSdPath)) {
+        SD.remove(tmpPath);
+        return false;
+    }
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+// NVS backend
+// -----------------------------------------------------------------------------
+
+bool NodeStore::loadFromNvs(std::vector<NodeInfo>& nodes) {
+    Preferences prefs;
+    if (!prefs.begin(kNvsNamespace, true)) return false;
+    size_t sz = prefs.getBytesLength(kNvsKey);
+    if (sz == 0) { prefs.end(); return false; }
+    std::vector<uint8_t> buf(sz);
+    size_t got = prefs.getBytes(kNvsKey, buf.data(), sz);
+    prefs.end();
+    if (got != sz) return false;
+    return deserialize(buf.data(), sz, nodes);
+}
+
+bool NodeStore::saveToNvs(const std::vector<NodeInfo>& nodes) {
+    auto buf = serialize(nodes, kNvsMaxNodes);
+    Preferences prefs;
+    if (!prefs.begin(kNvsNamespace, false)) return false;
+    size_t wrote = prefs.putBytes(kNvsKey, buf.data(), buf.size());
+    prefs.end();
+    return wrote == buf.size();
+}
+
+// -----------------------------------------------------------------------------
+// Public API
+// -----------------------------------------------------------------------------
+
+bool NodeStore::load(std::vector<NodeInfo>& nodes) {
+    switch (chooseBackend()) {
+        case Backend::Sd:
+            if (loadFromSd(nodes)) return true;
+            // SD present but no file (or corrupt) -- try NVS in case
+            // the user moved from NVS-only to SD without copying.
+            return loadFromNvs(nodes);
+        case Backend::Nvs:
+        default:
+            return loadFromNvs(nodes);
+    }
+}
+
+bool NodeStore::save(const std::vector<NodeInfo>& nodes) {
+    switch (chooseBackend()) {
+        case Backend::Sd:  return saveToSd(nodes);
+        case Backend::Nvs:
+        default:           return saveToNvs(nodes);
+    }
+}

--- a/src/mesh/node_store.cpp
+++ b/src/mesh/node_store.cpp
@@ -222,6 +222,18 @@ bool NodeStore::deserialize(const uint8_t* data, size_t len,
         if (copy > MAX_NODE_NAME) copy = MAX_NODE_NAME;
         if (copy > 0) std::memcpy(node.name, p, copy);
         node.name[copy] = '\0';
+        // Names originate in peer-sent ADVERTs and may contain bytes
+        // outside printable ASCII. The on-device bitmap fonts only
+        // render 0x20..0x7E; anything else shows up as a `[]` glyph
+        // box on the Map screen / node browser. Replace at the
+        // deserialise boundary so a hand-edited blob or an older-
+        // firmware save can't poison the rendering pipeline. (The
+        // same fix at the updateNode() seam would catch live ADVERTs
+        // too -- out of scope for this change.)
+        for (size_t i = 0; i < copy; i++) {
+            uint8_t b = static_cast<uint8_t>(node.name[i]);
+            if (b < 0x20 || b > 0x7E) node.name[i] = '?';
+        }
         if (nameLen == 0) {
             // Synthesise a name from the path hash, matching the
             // updateNode() fallback so downstream code doesn't trip on

--- a/src/mesh/node_store.cpp
+++ b/src/mesh/node_store.cpp
@@ -89,14 +89,18 @@ std::vector<uint8_t> NodeStore::serialize(const std::vector<NodeInfo>& nodes,
     // sections keyed off flags keep the per-node footprint small for
     // the common case (NVS-friendly).
 
-    // Build a working copy of indices sorted newest-first by
-    // lastSeenUnix, so the truncation step keeps the freshest entries.
+    // Build a working copy of indices sorted newest-first by lastSeen
+    // (local millis() observation time), so the truncation step keeps
+    // the entries we heard most recently. Deliberately not sorted by
+    // advertTimestamp: that field is peer-chosen and a node with a
+    // future-dated or wrap-around ADVERT would always survive
+    // truncation over genuinely-fresh local observations.
     std::vector<size_t> idx;
     idx.reserve(nodes.size());
     for (size_t i = 0; i < nodes.size(); ++i) idx.push_back(i);
     std::sort(idx.begin(), idx.end(),
               [&](size_t a, size_t b) {
-                  return nodes[a].advertTimestamp > nodes[b].advertTimestamp;
+                  return nodes[a].lastSeen > nodes[b].lastSeen;
               });
     if (idx.size() > cap) idx.resize(cap);
 
@@ -316,7 +320,8 @@ bool NodeStore::saveToSd(const std::vector<NodeInfo>& nodes) {
         return false;
     }
 
-    // SD library has no rename(); remove-then-rename is the workaround.
+    // SD.rename() on FAT cannot overwrite an existing file; remove the
+    // target first, then rename the tmp into place.
     if (SD.exists(kSdPath)) SD.remove(kSdPath);
     if (!SD.rename(tmpPath, kSdPath)) {
         SD.remove(tmpPath);

--- a/src/mesh/node_store.h
+++ b/src/mesh/node_store.h
@@ -1,0 +1,83 @@
+// Persistence layer for the MeshCore known-nodes table.
+//
+// The MeshCore in-memory _nodes vector lives only for the current boot.
+// Without persistence, a cold boot starts with an empty list and the
+// Map screen / "browse nodes" UI shows only the local marker until the
+// next ADVERT round (which on a quiet mesh can be 15+ minutes per peer).
+//
+// NodeStore writes the list to /sd/nodes.bin (SD) or NVS blob (fallback
+// when no SD is present), debounced by the caller, with a 7-day age cap
+// matching STALE_HIDE_AGE in lua/screens/tools/map.lua.
+//
+// Persisted fields are intentionally a subset of NodeInfo: routing
+// metrics (lastRssi/lastSnr/hopCount) describe the most recent received
+// packet, not the node, so reloading them across a reboot would just be
+// stale noise. They are re-derived from the next ADVERT instead.
+#pragma once
+
+#include <vector>
+#include <cstdint>
+
+struct NodeInfo;
+
+class NodeStore {
+public:
+    // SD path (preferred). Survives NVS factory-reset and scales further.
+    static constexpr const char* kSdPath = "/sd/nodes.bin";
+
+    // NVS fallback location -- single blob in the existing "meshcore"
+    // namespace so factory reset wipes it alongside the identity keys.
+    static constexpr const char* kNvsNamespace = "meshcore";
+    static constexpr const char* kNvsKey = "nodes";
+
+    // 7 days, matches STALE_HIDE_AGE in lua/screens/tools/map.lua.
+    static constexpr uint32_t kMaxAgeSeconds = 7 * 24 * 60 * 60;
+
+    // Storage caps. SD has room for many more, but 128 covers the
+    // realistic radius for a single radio and keeps the blob small
+    // enough to write atomically. NVS is intentionally tighter because
+    // every save rewrites the whole blob and NVS wear-levels per entry.
+    static constexpr size_t kSdMaxNodes = 128;
+    static constexpr size_t kNvsMaxNodes = 64;
+
+    // File format magic + version. Bump version on any layout change so
+    // older firmware loading a newer blob fails fast rather than
+    // misinterpreting fields.
+    static constexpr uint32_t kMagic = 0x534E5A45;  // 'EZNS'
+    static constexpr uint16_t kVersion = 1;
+
+    NodeStore() = default;
+
+    // Populate `nodes` from disk. Aging (>7d) is dropped at load time.
+    // `lastSeen` is re-stamped relative to the current millis() so age
+    // calculations downstream stay sane; if the device clock is not yet
+    // synced (time(NULL) returns < 2020), the persisted lastSeenUnix is
+    // trusted as-is and lastSeen is pushed maximally into the past.
+    // Returns true on a successful load (even if zero nodes), false if
+    // no store exists or the file is corrupt.
+    bool load(std::vector<NodeInfo>& nodes);
+
+    // Write the current node list. Returns false on I/O failure.
+    // If the list exceeds the active backend's cap, the oldest entries
+    // by lastSeenUnix are evicted from the *written* set; the in-memory
+    // vector is left untouched (the caller may choose to prune it).
+    bool save(const std::vector<NodeInfo>& nodes);
+
+private:
+    // Which backend save()/load() last picked. Set by chooseBackend().
+    enum class Backend { Sd, Nvs };
+
+    static Backend chooseBackend();
+
+    static bool loadFromSd(std::vector<NodeInfo>& nodes);
+    static bool loadFromNvs(std::vector<NodeInfo>& nodes);
+    static bool saveToSd(const std::vector<NodeInfo>& nodes);
+    static bool saveToNvs(const std::vector<NodeInfo>& nodes);
+
+    // Shared (de)serialisation: writes/reads the binary format into a
+    // contiguous byte buffer so both backends can reuse the same layout.
+    static std::vector<uint8_t> serialize(const std::vector<NodeInfo>& nodes,
+                                          size_t cap);
+    static bool deserialize(const uint8_t* data, size_t len,
+                            std::vector<NodeInfo>& outNodes);
+};


### PR DESCRIPTION
## Summary

Adds a `NodeStore` that serialises the MeshCore `_nodes` vector to
`/sd/nodes.bin` (SD-preferred, NVS fallback). The list is loaded at
`MeshCore::init()` so the Map screen and any "browse nodes" UI show
last-known peers on a cold boot instead of waiting up to 15 minutes
for the next ADVERT round per node.

Mechanics:
- **Save policy:** `updateNode()` flips a dirty flag the first time
  a persisted field actually changes (new node, name change,
  pubkey, role, location, advert timestamp). `MeshCore::update()`
  saves once `millis() - _nodesDirtyAt >= 30000` so a steady ADVERT
  stream doesn't thrash the SD.
- **Aging:** entries older than 7 days (matches `STALE_HIDE_AGE` in
  `lua/screens/tools/map.lua`) are dropped at load time.
- **Eviction:** on overflow at save time, oldest entries by
  `advertTimestamp` are dropped from the *written* set; the
  in-memory vector is left untouched.
- **Caps:** 128 entries on SD, 64 on NVS (each save rewrites the
  whole blob, NVS wears per entry).
- **What's NOT persisted:** `lastRssi`, `lastSnr`, `hopCount` --
  those describe the last *packet*, not the node, and would be
  stale and misleading after a reboot. They are zeroed on restore
  and refilled by the next ADVERT.
- **Atomic writes:** SD writes go through a `.tmp` + rename so a
  power loss mid-save only loses the previous save, never corrupts
  the active blob.
- **Backend fallback:** `chooseBackend()` runs on every save/load
  so a late-inserted SD takes precedence the moment it appears.

No Lua API changes -- `ez.mesh.get_nodes()` keeps the same shape;
the entries it returns are simply pre-populated on boot.

## Test plan

- [x] `pio run` clean (RAM 26.2%, flash 58.5%)
- [ ] On-device: flash, learn N nodes, reboot, verify ≥ N - (any older than 7 d) come back via `ez.mesh.get_nodes()` -- **user to QA on hardware** (per `CLAUDE.local.md` this env doesn't flash).
- [ ] On-device: after boot, Map screen shows pins for persisted peers immediately (subject to existing `map_peer_*` prefs).
- [ ] On-device: synthetic 200-node injection at a 128 cap evicts the oldest 72.

Closes #131