### PR TITLE
feat(games): add tetris leaderboard screen

### DIFF
--- a/lua/screens/games/tetris.lua
+++ b/lua/screens/games/tetris.lua
@@ -631,7 +631,12 @@ function Game:build(_state)
                     { font = "tiny_aa", color = "TEXT_MUTED",
                       text_align = "center", wrap = true })
             ),
-            ui.padding({ 8, 20, 0, 20 },
+            ui.padding({ 2, 40, 2, 40 },
+                ui.button("Leaderboard", { on_press = function()
+                    ui.push_screen("$screens/games/tetris_leaderboard.lua")
+                end })
+            ),
+            ui.padding({ 6, 20, 0, 20 },
                 ui.text_widget(
                     "LEFT/RIGHT move | UP rotate | DOWN soft drop | SPACE hard drop | Q back",
                     { font = "tiny_aa", color = "TEXT_MUTED",

--- a/lua/screens/games/tetris_leaderboard.lua
+++ b/lua/screens/games/tetris_leaderboard.lua
@@ -1,0 +1,56 @@
+-- Tetris leaderboard.
+--
+-- Shows the top-5 high scores for both Easy and Hard difficulties on a
+-- single screen. The game-over panel inside tetris.lua already prints
+-- one of these lists, but only the board for the difficulty that was
+-- just played and only while the player is still on the over-screen.
+-- This screen makes both boards reachable from the tetris menu at any
+-- time.
+
+local ui         = require("ezui")
+local highscores = require("engine.highscores")
+
+local Screen = { title = "Tetris scores" }
+
+local HS_KEYS = { easy = "tetris_easy", hard = "tetris_hard" }
+
+local function format_row(i, h)
+    return string.format("%d.  %6d   %d lines", i, h.score, h.extra)
+end
+
+local function board_section(label, key)
+    local rows = highscores.format(key, format_row)
+    local children = {
+        ui.text_widget(label, {
+            font = "small_aa", color = "TEXT_SEC",
+        }),
+    }
+    for _, line in ipairs(rows) do
+        children[#children + 1] = ui.text_widget(line, {
+            font = "small_aa", color = "TEXT",
+        })
+    end
+    return ui.padding({ 6, 12, 4, 12 },
+        ui.vbox({ gap = 2 }, children))
+end
+
+function Screen:build(_state)
+    return ui.vbox({ gap = 0, bg = "BG" }, {
+        ui.title_bar("Tetris scores", { back = true }),
+        ui.scroll({ grow = 1 },
+            ui.vbox({ gap = 4 }, {
+                board_section("EASY", HS_KEYS.easy),
+                board_section("HARD", HS_KEYS.hard),
+            })
+        ),
+    })
+end
+
+function Screen:handle_key(key)
+    if key.special == "BACKSPACE" or key.special == "ESCAPE" then
+        return "pop"
+    end
+    return nil
+end
+
+return Screen


### PR DESCRIPTION
## Summary
- New `screens/games/tetris_leaderboard.lua` shows top-5 high scores for both Easy and Hard difficulties on one screen.
- Adds a **Leaderboard** button on the tetris menu so the boards are reachable any time, not only on the post-game over-panel.
- No new persistence — reuses the existing `engine.highscores` keys (`tetris_easy`, `tetris_hard`).

## Notes on level count
Looked into whether tetris has "enough levels". Levels are open-ended (no cap). Drop speed plateaus at the `drop_floor` (easy: ~level 10, hard: ~level 11-12), but the per-line score multiplier `base * (level + 1)` keeps growing — so levels remain meaningful for scoring past the speed plateau. This matches classic Tetris marathon design, and lowering the drop floors further would make the game unplayable. Leaving the level math as-is.

## Test plan
- [x] Build + flash to T-Deck (`pio run -t upload`)
- [x] Open Tetris menu — Leaderboard button visible alongside Easy/Hard
- [x] Press Leaderboard → screen shows EASY and HARD boards (Hard had a prior 9328-pt entry; Easy empty placeholders)
- [x] Back key returns to tetris menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)