### PR TITLE
fix(dm): prefer ROUTE_DIRECT for ACKs when return path is cached

### DIFF
--- a/lua/services/direct_messages.lua
+++ b/lua/services/direct_messages.lua
@@ -354,7 +354,7 @@ local function try_decrypt_pending(id, pending, candidate_pub_key_hex)
     local sender_pub = hex_to_bytes(candidate_pub_key_hex)
     if sender_pub then
         local ack_hash = compute_ack_hash(plaintext, sender_pub)
-        send_ack(ack_hash)
+        send_ack(ack_hash, candidate_pub_key_hex)
     end
     return true
 end
@@ -449,10 +449,18 @@ end
 -- that arrived via DIRECT (path already known). Payload is exactly the
 -- 4-byte ack hash the original sender is expecting; sender matches it
 -- against its pre-computed `expected_ack`.
-local function send_ack(ack_hash)
+--
+-- Mirrors BaseChatMesh::sendAckTo: prefer ROUTE_DIRECT with the cached
+-- return path when we have one, fall back to FLOOD otherwise. A flaky
+-- FLOOD ACK in the reverse direction would otherwise cause the sender
+-- to evict its (good) forward-path cache when retries time out.
+local function send_ack(ack_hash, sender_pub_hex)
     if not ez.mesh.is_initialized() then return end
     if not ack_hash or #ack_hash ~= ACK_HASH_SIZE then return end
-    local pkt = ez.mesh.build_packet(ROUTE_FLOOD, PAYLOAD_ACK, ack_hash)
+    local rp = sender_pub_hex and return_paths[sender_pub_hex]
+    local path = rp and rp.bytes
+    local route = (path and #path > 0) and ROUTE_DIRECT or ROUTE_FLOOD
+    local pkt = ez.mesh.build_packet(route, PAYLOAD_ACK, ack_hash, path)
     if pkt then
         ez.mesh.queue_send(pkt)
     end
@@ -821,7 +829,7 @@ function dm.init()
                                             ack_hash
                                         )
                                     else
-                                        send_ack(ack_hash)
+                                        send_ack(ack_hash, candidate.pub_key_hex)
                                     end
                                 end
                                 return


### PR DESCRIPTION
## Summary
- `send_ack()` now consults `return_paths[sender_pub_hex]` and goes out as `ROUTE_DIRECT` with the cached path when available, falling back to `ROUTE_FLOOD` otherwise -- mirrors `BaseChatMesh::sendAckTo` upstream.
- Both callers (`try_decrypt_pending` retroactive ACK and the live RX `DIRECT` ACK branch) pass the sender's pubkey hex through.
- `send_path_return()` deliberately untouched: PATH_RETURN exists to *teach* the sender a route, so FLOOD is correct there.

## Why
A FLOOD-routed ACK on the reverse direction can be lost (congested mesh, sleeping relays) even when the forward DIRECT path is healthy. Today that loss makes the sender retry, mark the DM `unconfirmed`, and evict a perfectly good cached return path. Using the cached path for the ACK shrinks that failure window and cuts airtime.

## Test plan
- [ ] Two T-Decks A and B with a relay in between.
- [ ] A sends B a DM (FLOOD) and B replies (FLOOD); both now have cached return paths.
- [ ] A sends a second DM (goes DIRECT). Verify B's ACK now goes DIRECT (`ez_remote.py --primitives` or log the ACK route type).
- [ ] Drop the cached path on B (e.g. wait for TTL or use `dm.clear_return_path`) and confirm the ACK falls back to FLOOD.

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)