### PR TITLE
fix(input): trackball-active touch deadzone at screen bottom

### DIFF
--- a/lua/ezui/touch_input.lua
+++ b/lua/ezui/touch_input.lua
@@ -58,6 +58,21 @@ local MIN_TARGET_H = 32
 -- user; only one finger can have an in-flight tap at a time.
 local _pending = nil
 
+-- Trackball-active touch deadzone at the screen bottom.
+--
+-- The trackball ball sits directly below the touchscreen. While the
+-- user is scrolling with the trackball, the same thumb sometimes
+-- slips off the ball onto the bottom strip of the panel mid-gesture;
+-- that slip lands as a real touch/down and yanks focus to whatever
+-- widget sat at the bottom of the screen. Drop any touch/down whose
+-- y falls inside the bottom DEADZONE_PX while the trackball has been
+-- active within the last DEADZONE_WINDOW_MS. After the window
+-- expires the strip becomes tappable again, so screens that legit
+-- use the bottom edge for actions still work outside of trackball
+-- gestures.
+local DEADZONE_PX        = 24
+local DEADZONE_WINDOW_MS = 1500
+
 -- ---------------------------------------------------------------------------
 -- Mouse mode
 -- ---------------------------------------------------------------------------
@@ -216,6 +231,23 @@ local function on_down(_topic, data)
         _pending = nil
         _mouse_pending = nil
         return
+    end
+
+    -- Trackball-active bottom deadzone. See DEADZONE_PX comment above.
+    -- Only consults the kbd binding when it's actually present so the
+    -- helper still works on hosts where ez.keyboard is stubbed.
+    if ez and ez.keyboard and ez.keyboard.get_last_trackball_ms then
+        local th = theme()
+        local sh = th.SCREEN_H or 240
+        if data.y >= sh - DEADZONE_PX then
+            local last_tb = ez.keyboard.get_last_trackball_ms() or 0
+            if last_tb > 0
+                    and (ez.system.millis() - last_tb) < DEADZONE_WINDOW_MS then
+                _pending = nil
+                _mouse_pending = nil
+                return
+            end
+        end
     end
 
     if M.mouse_mode then

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -283,6 +283,7 @@ KeyEvent Keyboard::read() {
         interrupts();
 
         if (clickEvent) {
+            _lastTrackballMs = now;
             return KeyEvent::fromSpecial(SpecialKey::ENTER, _shiftHeld, _ctrlHeld, _altHeld, _fnHeld);
         }
 
@@ -326,6 +327,7 @@ KeyEvent Keyboard::read() {
         lastRight = right;
 
         if (clickEvent) {
+            _lastTrackballMs = now;
             return KeyEvent::fromSpecial(SpecialKey::ENTER, _shiftHeld, _ctrlHeld, _altHeld, _fnHeld);
         }
 
@@ -339,18 +341,22 @@ KeyEvent Keyboard::read() {
     // Generate directional keys when threshold reached
     if (_trackballY <= -_trackballThreshold) {
         _trackballY = 0;
+        _lastTrackballMs = now;
         return KeyEvent::fromSpecial(SpecialKey::UP, _shiftHeld, _ctrlHeld, _altHeld, _fnHeld);
     }
     if (_trackballY >= _trackballThreshold) {
         _trackballY = 0;
+        _lastTrackballMs = now;
         return KeyEvent::fromSpecial(SpecialKey::DOWN, _shiftHeld, _ctrlHeld, _altHeld, _fnHeld);
     }
     if (_trackballX <= -_trackballThreshold) {
         _trackballX = 0;
+        _lastTrackballMs = now;
         return KeyEvent::fromSpecial(SpecialKey::LEFT, _shiftHeld, _ctrlHeld, _altHeld, _fnHeld);
     }
     if (_trackballX >= _trackballThreshold) {
         _trackballX = 0;
+        _lastTrackballMs = now;
         return KeyEvent::fromSpecial(SpecialKey::RIGHT, _shiftHeld, _ctrlHeld, _altHeld, _fnHeld);
     }
 

--- a/src/hardware/keyboard.h
+++ b/src/hardware/keyboard.h
@@ -175,6 +175,13 @@ public:
     TrackballMode getTrackballMode() const { return _trackballMode; }
     void setTrackballMode(TrackballMode mode);
 
+    // millis() of the last directional/click event produced by the
+    // trackball. 0 if none yet. Used by the touch bridge to gate a
+    // brief bottom-strip deadzone, since the trackball ball sits right
+    // below the touchscreen and a finger sliding off the ball lands
+    // back on the panel.
+    uint32_t getLastTrackballMs() const { return _lastTrackballMs; }
+
     // Key repeat settings
     bool getKeyRepeatEnabled() const { return _keyRepeatEnabled; }
     void setKeyRepeatEnabled(bool enabled) { _keyRepeatEnabled = enabled; }
@@ -223,6 +230,12 @@ private:
 
     // Trackball mode
     TrackballMode _trackballMode = TrackballMode::POLLING;
+
+    // millis() timestamp of the most recent trackball-originated event
+    // (UP/DOWN/LEFT/RIGHT or click ENTER). Exposed via
+    // getLastTrackballMs() for the touch bridge's bottom-strip
+    // deadzone.
+    uint32_t _lastTrackballMs = 0;
 
     // Key repeat settings — retained as configuration surface but no
     // longer functional. With always-on raw matrix scanning the host

--- a/src/lua/bindings/keyboard_bindings.cpp
+++ b/src/lua/bindings/keyboard_bindings.cpp
@@ -322,6 +322,27 @@ LUA_FUNCTION(l_keyboard_set_trackball_mode) {
     return 0;
 }
 
+// @lua ez.keyboard.get_last_trackball_ms() -> integer
+// @brief Get millis() of the most recent trackball event
+// @description Returns the C++ millis() timestamp of the last UP / DOWN /
+// LEFT / RIGHT or click event produced by the trackball. 0 if the
+// trackball has not fired since boot. The touch bridge uses this to
+// apply a brief deadzone at the bottom of the screen while the
+// trackball is in active use -- the ball sits right under the
+// touchscreen, and a finger sliding off the ball lands on the panel
+// as a spurious touch/down.
+// @return millis() of the last trackball event, or 0 if none yet
+// @example
+// local since = ez.system.millis() - ez.keyboard.get_last_trackball_ms()
+// if since < 1500 then -- trackball was just active
+// end
+// @end
+LUA_FUNCTION(l_keyboard_get_last_trackball_ms) {
+    uint32_t ms = keyboard ? keyboard->getLastTrackballMs() : 0;
+    lua_pushinteger(L, (lua_Integer)ms);
+    return 1;
+}
+
 // @lua ez.keyboard.get_backlight() -> integer
 // @brief Get current keyboard backlight level
 // @description Returns the current keyboard backlight brightness. The T-Deck has
@@ -689,6 +710,7 @@ static const luaL_Reg keyboard_funcs[] = {
     {"set_trackball_sensitivity", l_keyboard_set_trackball_sensitivity},
     {"get_trackball_mode",       l_keyboard_get_trackball_mode},
     {"set_trackball_mode",       l_keyboard_set_trackball_mode},
+    {"get_last_trackball_ms",    l_keyboard_get_last_trackball_ms},
     {"get_backlight",            l_keyboard_get_backlight},
     {"set_backlight",            l_keyboard_set_backlight},
     {"get_repeat_enabled",       l_keyboard_get_repeat_enabled},


### PR DESCRIPTION
## Summary
- Stamp `millis()` on every trackball-originated key event in the C++ keyboard read path (UP/DOWN/LEFT/RIGHT and click ENTER, in both polling and interrupt-driven modes).
- Expose the timestamp via `ez.keyboard.get_last_trackball_ms()`.
- Have the touch bridge drop any `touch/down` whose `y` falls inside the bottom 24 px while the trackball has been active within the last 1500 ms. Outside that window the strip is tappable as before, so screens that legitimately use the bottom edge keep working.

Closes #43

## Test plan
- [ ] **Needs hardware QA** — `pio run -t upload` from this worktree and on a list screen, drive the trackball with one thumb and deliberately slip the thumb off the ball onto the bottom of the screen mid-gesture. The slip should no longer activate the bottom row.
- [ ] Tap a button at the bottom of a screen with no recent trackball activity (e.g. wait a few seconds after scrolling). It activates as before.
- [ ] Build is clean (`pio run` succeeds, verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)