### PR TITLE
chore(security): prefer esp_fill_random over math.random for crypto-adjacent values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -775,6 +775,45 @@ RGB565 literals so the value can flow through both palettes.
 
 ## C++ Binding Safety Rules
 
+### RNG choice for crypto-adjacent values
+
+`math.random` in Lua 5.x is a non-cryptographic PRNG with weak
+seeding (we call `math.randomseed(ez.system.millis())` at most
+points; an observer who watches a peer come online can narrow the
+seed to a millisecond). It is fine for games (board shuffles,
+spawn positions, snake apple placement) but **must not** be used
+for anything that another node could try to predict or replay:
+
+- invite-token nonces
+- packet sequence / id values
+- file-transfer ids
+- any value passed to a hash that another peer will see
+- random delays that gate retransmit / dedup logic
+
+For those, use:
+
+- `ez.crypto.random_bytes(n)` -- n raw hardware-seeded bytes (1..256).
+  Backed by `esp_fill_random()` -> ESP32-S3 hardware RNG.
+- `ez.crypto.random_int(lo, hi)` -- uniformly distributed integer in
+  the inclusive range `[lo, hi]`, rejection-sampled on top of
+  `esp_fill_random`. Use this when the call site wants a bounded
+  integer (transfer ids, sequence numbers, etc.).
+
+C++ code already does the right thing in most places: `esp_random()`
+is used directly in `wifi_bindings.cpp`, `ota_bindings.cpp`, and
+`Identity::generateKeyPair` via RadioLib's `RNGClass::rand()`.
+Anything new on the C++ side should follow the same pattern -- never
+call `rand()` or `random()` from `<stdlib.h>` for security-sensitive
+output.
+
+Caveat: `esp_fill_random` returns deterministic values **before
+WiFi or BT is initialized**. We init the radio early enough that
+this isn't a problem for steady-state use; for boot-time crypto
+(identity key generation in `Identity::generateKeyPair`) we already
+seed via RadioLib which mixes in hardware noise from the LoRa
+modem. New code that runs before the first `WiFi.begin()` should be
+aware of the constraint.
+
 ### Dangling lua_State* Pointer Bug
 
 **CRITICAL:** Never store a `lua_State* L` parameter in a static/global variable when

--- a/lua/services/custom_packets.lua
+++ b/lua/services/custom_packets.lua
@@ -360,8 +360,7 @@ end
 -- ---------------------------------------------------------------------------
 
 local function random_u32_bytes()
-    local r = math.random(0, 0x7FFFFFFF)
-    return string.char(r & 0xFF, (r >> 8) & 0xFF, (r >> 16) & 0xFF, (r >> 24) & 0xFF)
+    return ez.crypto.random_bytes(4)
 end
 
 -- Send a PING to `pub_key_hex`. The peer's installed PING handler

--- a/lua/services/file_transfer.lua
+++ b/lua/services/file_transfer.lua
@@ -441,7 +441,7 @@ function M.send(pub_key_hex, path)
     local name = basename(path)
     if #name > 255 then return nil, "name too long" end
 
-    local xfer_id = math.random(1, 0x7FFFFFFF)
+    local xfer_id = ez.crypto.random_int(1, 0x7FFFFFFF)
 
     tx[xfer_id] = {
         pub_key_hex = pub_key_hex,

--- a/lua/services/sharing.lua
+++ b/lua/services/sharing.lua
@@ -104,14 +104,11 @@ end
 -- longer track redemption, the only job is to make repeat invites for
 -- the same channel produce different tokens (otherwise re-sharing the
 -- same channel would emit byte-identical URLs and chat dedup would
--- collapse them). millis() + math.random + our pubkey hashed through
--- SHA-256 is plenty for that.
+-- collapse them). esp_fill_random gives us 8 hardware-seeded bytes
+-- directly, so the prior SHA-256 wrap of millis() + math.random + our
+-- pubkey is no longer needed.
 local function random_nonce()
-    local seed = string.format("%d:%d:%s",
-        ez.system.millis(),
-        math.random(0, 0x7FFFFFFF),
-        ez.mesh.get_public_key_hex() or "")
-    return ez.crypto.sha256(seed):sub(1, NONCE_SIZE)
+    return ez.crypto.random_bytes(NONCE_SIZE)
 end
 
 -- =========================================================================

--- a/src/lua/bindings/crypto_bindings.cpp
+++ b/src/lua/bindings/crypto_bindings.cpp
@@ -329,6 +329,51 @@ LUA_FUNCTION(l_crypto_random_bytes) {
     return 1;
 }
 
+// @lua ez.crypto.random_int(min, max) -> integer
+// @brief Generate a cryptographically secure random integer in [min, max]
+// @description Wraps esp_fill_random() and rejection-samples so the
+// result is uniformly distributed across the inclusive range. Use for
+// any id / nonce / dedup value where math.random's weak seeding could
+// hand a peer a guessable token. min and max must both be non-negative
+// 64-bit values with min <= max.
+// @param min Lower bound (inclusive)
+// @param max Upper bound (inclusive)
+// @return Random integer in [min, max], or nil + error on invalid args
+// @example
+// local xfer_id = ez.crypto.random_int(1, 0x7FFFFFFF)
+// local seq    = ez.crypto.random_int(0, 0xFFFFFFFF)
+// @end
+LUA_FUNCTION(l_crypto_random_int) {
+    LUA_CHECK_ARGC(L, 2);
+    lua_Integer lo = luaL_checkinteger(L, 1);
+    lua_Integer hi = luaL_checkinteger(L, 2);
+    if (lo < 0 || hi < lo) {
+        lua_pushnil(L);
+        lua_pushstring(L, "min must be >= 0 and <= max");
+        return 2;
+    }
+    // Unsigned range so we can express up to 2^63 - 1 without sign
+    // surprises. Lua 5.4 integers are 64 bits in our build (LUA_32BITS=1
+    // for luac, but the runtime is 64-bit-aware), so lo/hi already fit.
+    uint64_t range = (uint64_t)(hi - lo) + 1ULL;
+    if (range == 0ULL) {
+        // hi - lo overflowed: caller asked for the entire uint64 space.
+        uint64_t r;
+        esp_fill_random(&r, sizeof(r));
+        lua_pushinteger(L, (lua_Integer)(lo + (lua_Integer)r));
+        return 1;
+    }
+    // Rejection sampling: largest multiple of `range` that fits in 64
+    // bits, retry if we land above it. Keeps the distribution uniform.
+    uint64_t limit = UINT64_MAX - (UINT64_MAX % range);
+    uint64_t r;
+    do {
+        esp_fill_random(&r, sizeof(r));
+    } while (r >= limit);
+    lua_pushinteger(L, (lua_Integer)(lo + (lua_Integer)(r % range)));
+    return 1;
+}
+
 // @lua ez.crypto.channel_hash(key) -> integer
 // @brief Compute channel hash from key (SHA256(key)[0])
 // @description Computes a single-byte channel identifier from a channel key. This
@@ -613,6 +658,7 @@ static const luaL_Reg crypto_funcs[] = {
     {"aes128_ecb_encrypt",  l_crypto_aes128_ecb_encrypt},
     {"aes128_ecb_decrypt",  l_crypto_aes128_ecb_decrypt},
     {"random_bytes",        l_crypto_random_bytes},
+    {"random_int",          l_crypto_random_int},
     {"channel_hash",        l_crypto_channel_hash},
     {"derive_channel_key",  l_crypto_derive_channel_key},
     {"public_channel_key",  l_crypto_public_channel_key},


### PR DESCRIPTION
## Summary
- New binding \`ez.crypto.random_int(lo, hi)\` -- uniformly distributed bounded integer backed by \`esp_fill_random()\` + rejection sampling.
- \`services/sharing.lua\` invite-token nonce now uses \`ez.crypto.random_bytes(8)\` directly. The previous SHA-256 wrap of \`millis() + math.random + our pubkey\` is gone -- \`esp_fill_random\` gives us hardware-seeded bytes outright.
- \`services/custom_packets.lua\` packet seq id now uses \`ez.crypto.random_bytes(4)\`.
- \`services/file_transfer.lua\` transfer id now uses \`ez.crypto.random_int(1, 0x7FFFFFFF)\`.
- CLAUDE.md gains an "RNG choice for crypto-adjacent values" section so future contributors see when \`math.random\` is OK (games) and when it isn't (ids / nonces / dedup values another node sees).

Other \`math.random\` call sites under \`lua/\` are games / paint spray / audio jitter -- intentionally left alone.

Closes #44

## Test plan
- [ ] **Needs hardware QA** — \`pio run -t upload\` from this worktree, then:
  - Share a channel via the Share menu twice in a row and confirm the two invite URLs differ (sanity check that the nonce isn't pinned).
  - Send a custom PING via the dev tools and confirm a PONG comes back (seq id still round-trips).
  - Send a file transfer to a peer and confirm it completes (id collisions, if any, would be rare but visible as a "already in flight" path).
- [x] Build is clean (\`pio run\` succeeds, verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)