### PR TITLE
feat(mesh): broadcast a user-picked home location in ADVERTs

### DIFF
--- a/lua/docs/manual/maps.md
+++ b/lua/docs/manual/maps.md
@@ -35,3 +35,41 @@ repaints tiles in the same frame -- no archive reload required.
 A `.tdmap` archive bakes one rasterization. To show a different layer
 mix (e.g. without buildings), generate a new archive with a different
 config and pick it from the loader.
+
+## Broadcast home location
+
+Other nodes can see a coarse location for your device on their own
+maps and in the Network screen, but only if you tell ezOS what point
+to publish. There is no live GPS broadcast and no automatic update --
+the value is a deliberate "approximately me" coordinate that you
+author once.
+
+To set it: open Map, pan with the trackball / arrow keys so the
+centre of the screen sits on the point you want to publish, then
+press Alt+M and pick "Set as broadcast home". Alt+M -> "Clear
+broadcast home" removes it.
+
+What gets broadcast:
+
+- The exact coordinate you chose, every time your device sends an
+  ADVERT. No randomization, no fuzz radius, no live updates from GPS.
+- The location bit is added to the ADVERT app_data (MeshCore
+  protocol). Anyone receiving your ADVERT sees this coordinate in
+  cleartext.
+
+Privacy guidance:
+
+- Pick a point that is **deliberately approximate**. Your town
+  centre, a nearby park, or any landmark a few hundred metres from
+  where you actually are. Not your home, not your office.
+- The broadcast home only controls what you **announce**. A
+  determined adversary with multiple LoRa receivers can still
+  triangulate your real transmitter position from signal strength
+  regardless of what this field says.
+- For sharing your precise current location with a specific contact,
+  use a share-location card from the chat compose menu instead --
+  that goes encrypted, point-to-point, and is opt-in per recipient.
+
+The setting persists across reboots. There is no on-map indicator of
+the current broadcast home (yet); re-set it the same way to change
+it.

--- a/lua/screens/tools/map.lua
+++ b/lua/screens/tools/map.lua
@@ -224,6 +224,80 @@ function Map:handle_key(key)
     return nil
 end
 
+-- Alt+M actions on the Map.
+--
+-- "Set as broadcast home" is the issue #127 entry point: there is no
+-- Settings entry and no dedicated picker screen. The user pans the map
+-- so the centre crosshair sits on their authored "approximately me"
+-- point (town centre, a nearby park -- not their actual home), then
+-- commits via this menu. We write decimal-e6 strings into
+-- `adv_home_lat` / `adv_home_lon` and `MeshCore::sendAnnounce()`
+-- (C++ side) picks them up on the next outgoing ADVERT.
+--
+-- The "Clear" entry only shows when at least one half is set so the
+-- menu doesn't grow useless entries in the default case.
+local function home_is_set()
+    local lat = ez.storage.get_pref("adv_home_lat", "")
+    local lon = ez.storage.get_pref("adv_home_lon", "")
+    return (lat ~= "" and lat ~= nil) or (lon ~= "" and lon ~= nil)
+end
+
+function Map:menu()
+    local notifications = require("services.notifications")
+    local items = {}
+
+    items[#items + 1] = {
+        title    = "Set as broadcast home",
+        subtitle = "Broadcast this point in every ADVERT",
+        on_press = function()
+            local s = self._state
+            local lat = s.center_lat
+            local lon = s.center_lon
+            if type(lat) ~= "number" or type(lon) ~= "number" then
+                notifications.post({
+                    title  = "Broadcast home not set",
+                    body   = "Pan the map first so the centre is on a point.",
+                    source = "system",
+                })
+                return
+            end
+            -- Decimal-e6 string keeps Lua-side and C++-side parsers
+            -- agreed on encoding; the C++ ADVERT path packs the same
+            -- integer into the wire format.
+            local lat_e6 = math.floor(lat * 1000000 + (lat >= 0 and 0.5 or -0.5))
+            local lon_e6 = math.floor(lon * 1000000 + (lon >= 0 and 0.5 or -0.5))
+            ez.storage.set_pref("adv_home_lat", tostring(lat_e6))
+            ez.storage.set_pref("adv_home_lon", tostring(lon_e6))
+            notifications.post({
+                title  = "Broadcast home set",
+                body   = string.format(
+                    "%.4f, %.4f -- this is broadcast in cleartext to " ..
+                    "every node that hears your adverts. Treat it as " ..
+                    "public.", lat, lon),
+                source = "system",
+            })
+        end,
+    }
+
+    if home_is_set() then
+        items[#items + 1] = {
+            title    = "Clear broadcast home",
+            subtitle = "Stop including a location in ADVERTs",
+            on_press = function()
+                ez.storage.set_pref("adv_home_lat", "")
+                ez.storage.set_pref("adv_home_lon", "")
+                notifications.post({
+                    title  = "Broadcast home cleared",
+                    body   = "Your ADVERTs no longer include a location.",
+                    source = "system",
+                })
+            end,
+        }
+    end
+
+    return items
+end
+
 -- Clip a ray from (cx, cy) through (px, py) to the rectangle [x, x+w] × [y, y+h].
 -- Returns the (edge_x, edge_y) where the ray exits the rectangle. Only called
 -- when (px, py) is known to be OUTSIDE the rectangle, so a valid exit always

--- a/src/mesh/meshcore.cpp
+++ b/src/mesh/meshcore.cpp
@@ -1,6 +1,7 @@
 #include "meshcore.h"
 #include "../lua/bindings/bus_bindings.h"
 #include <Arduino.h>
+#include <Preferences.h>
 #include <cstring>
 #include <vector>
 
@@ -646,6 +647,39 @@ bool MeshCore::sendPacket(MeshPacket& packet) {
     return false;
 }
 
+// Read the user's "broadcast home" lat/lon if set, and only if the
+// user authored both halves. Returns true and fills `lat_e6` / `lon_e6`
+// when valid; false when unset, half-set, or out of range. The values
+// are stored by Lua under `ez.storage.set_pref("adv_home_lat", ...)`
+// in the "lua_storage" NVS namespace as decimal-e6 strings (e.g.
+// "47543968" for 47.543968 deg). See issue #127.
+//
+// We re-read every announce instead of caching: the user may change
+// the home location at runtime and the next ADVERT should pick that
+// up immediately. NVS reads are cheap and ADVERTs are infrequent.
+static bool readBroadcastHome(int32_t& lat_e6, int32_t& lon_e6) {
+    Preferences prefs;
+    if (!prefs.begin("lua_storage", true)) return false;
+    String latStr = prefs.getString("adv_home_lat", "");
+    String lonStr = prefs.getString("adv_home_lon", "");
+    prefs.end();
+    if (latStr.length() == 0 || lonStr.length() == 0) return false;
+    // Decimal-e6 strings come straight from Lua's tostring(math.floor(...)).
+    // strtol caps at LONG_MAX (>= INT32_MAX on this platform); any value
+    // outside the lat/lon range is a user mistake so we reject rather
+    // than clamp.
+    char* endLat = nullptr;
+    char* endLon = nullptr;
+    long lat = strtol(latStr.c_str(), &endLat, 10);
+    long lon = strtol(lonStr.c_str(), &endLon, 10);
+    if (endLat == latStr.c_str() || endLon == lonStr.c_str()) return false;
+    if (lat <  -90000000 || lat >  90000000) return false;
+    if (lon < -180000000 || lon > 180000000) return false;
+    lat_e6 = (int32_t)lat;
+    lon_e6 = (int32_t)lon;
+    return true;
+}
+
 bool MeshCore::sendAnnounce() {
     MeshPacket packet;
     packet.clear();
@@ -664,19 +698,36 @@ bool MeshCore::sendAnnounce() {
     memcpy(packet.payload + offset, &timestamp, 4);
     offset += 4;
 
-    // Build app_data: [flags:1][name:variable]
-    // Flags: 0x81 = has_name (0x80) + client role (0x01)
+    // Build app_data: [flags:1][lat:4 LE][lon:4 LE]?[name:variable]
+    // Flags: 0x81 = has_name (0x80) + client role (0x01), with 0x10
+    // OR'd in when the user has authored a broadcast home location.
+    // Layout follows the MeshCore reference: lat/lon (when present)
+    // sit between the flags byte and the name. See CLAUDE.md "App
+    // Data Structure" + AdvertDataHelpers.h upstream.
     constexpr size_t MAX_ADVERT_DATA = 32;
     uint8_t appData[MAX_ADVERT_DATA];
     size_t appDataLen = 0;
 
-    // Flags byte: 0x81 = client (0x01) + has name (0x80)
-    appData[appDataLen++] = 0x81;
+    int32_t home_lat_e6 = 0, home_lon_e6 = 0;
+    bool hasHome = readBroadcastHome(home_lat_e6, home_lon_e6);
+
+    // Flags byte: 0x81 = client (0x01) + has name (0x80), plus 0x10
+    // when location is included. The 32-byte cap means turning on
+    // location drops the name's max length from 31 to 23, so a long
+    // node name gets truncated.
+    appData[appDataLen++] = hasHome ? (uint8_t)0x91 : (uint8_t)0x81;
+
+    if (hasHome) {
+        memcpy(appData + appDataLen, &home_lat_e6, 4);
+        appDataLen += 4;
+        memcpy(appData + appDataLen, &home_lon_e6, 4);
+        appDataLen += 4;
+    }
 
     // Node name
     const char* name = _identity.getNodeName();
     size_t nameLen = strlen(name);
-    if (nameLen > MAX_ADVERT_DATA - 1) nameLen = MAX_ADVERT_DATA - 1;
+    if (nameLen > MAX_ADVERT_DATA - appDataLen) nameLen = MAX_ADVERT_DATA - appDataLen;
     memcpy(appData + appDataLen, name, nameLen);
     appDataLen += nameLen;
 
@@ -706,8 +757,9 @@ bool MeshCore::sendAnnounce() {
 
     packet.payloadLen = offset;
 
-    MESH_LOG("Sending ADVERT (pathHash=%02X, name=%s, %d bytes)\n",
-                  _identity.getPathHash(), name, (int)offset);
+    MESH_LOG("Sending ADVERT (pathHash=%02X, name=%s, loc=%s, %d bytes)\n",
+                  _identity.getPathHash(), name, hasHome ? "yes" : "no",
+                  (int)offset);
     return sendPacket(packet);
 }
 


### PR DESCRIPTION
## Summary

- C++ `sendAnnounce()` (`src/mesh/meshcore.cpp`) now reads `adv_home_lat` / `adv_home_lon` from the `lua_storage` NVS namespace each call. When both halves are set and in range, it ORs `0x10` into the flags byte and inserts `[lat_e6:4 LE][lon_e6:4 LE]` between the flags and the name in `app_data`. Long node names truncate from 31 -> 23 chars when location is on (the 32-byte `MAX_ADVERT_DATA` cap).
- New Alt+M action on `lua/screens/tools/map.lua`: **"Set as broadcast home"** reads `center_lat` / `center_lon` from the current map view, writes the e6 strings to NVS, and posts a confirmation toast with the honest disclosure text. **"Clear broadcast home"** shows when either pref is set and wipes both.
- No Settings entry, no dedicated picker screen -- the Map app is the picker, panning is how you choose.
- `lua/docs/manual/maps.md` gains a "Broadcast home location" section covering setup, privacy guidance, and the load-bearing caveat that this only controls what we *announce*; multi-receiver RSSI triangulation still works.

## Privacy framing (preserved from the issue)

The broadcast is deterministic on a user-authored point. **No** live GPS, **no** fuzz radius, **no** auto-update -- all of those fall to trajectory averaging / aggregation attacks anyway and dressing it up as "privacy-preserving" would mislead users. The user picks an approximate point (town centre, nearby park) once, owns the disclosure, and that exact value goes out on every ADVERT.

Closes #127

## Test plan

- [ ] **Needs hardware QA** -- `pio run -t upload` from this worktree, then:
  - Open Map, pan to an arbitrary visible point, Alt+M -> "Set as broadcast home". Confirm the confirmation toast lands with the lat/lon in it.
  - From a peer node, confirm the ADVERT now includes location (e.g. via `meshcore-cli` on `/dev/ttyUSB0`, or check that the peer's known-nodes table shows the position).
  - On the originating device, verify the menu now shows "Clear broadcast home" too. Pick it; confirm the toast, then re-check that subsequent ADVERTs drop the location bytes.
  - Edge case: try a very long node name + location on; the name should truncate at 23 chars without crashing or producing an over-32-byte `app_data`.
- [x] Build is clean (`pio run` succeeds, verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)