### PR TITLE
docs(map): rewrite "All chat nodes" rationale (clutter, not privacy)

### DIFF
--- a/lua/docs/manual/settings/map.md
+++ b/lua/docs/manual/settings/map.md
@@ -17,10 +17,10 @@ Three independent toggles pick which peer categories appear as pins:
   contacts. Off if you would rather not see them on the map even
   though you have their key.
 - **All chat nodes** (default off). Every chat node we have ever
-  heard from with a location. Off by default for privacy: turning
-  it on exposes the rough position of every node within radio
-  range that has chosen to advertise its location, which may not
-  be what they expect a passing receiver to do.
+  heard from with a location. Off by default to keep the map
+  uncluttered -- on a busy mesh this can be dozens of pins, most
+  of which you don't have a relationship with. Turn it on when
+  you want a full view of who's around.
 
 A node only renders when its ADVERT carried a location. Nodes
 without a location are never drawn regardless of the toggles.


### PR DESCRIPTION
## Summary

- The bullet for the Settings -- Map "All chat nodes" toggle justified the default-off as a privacy measure for other peers.
- A node that broadcasts its location in its ADVERT has already chosen to publish it; the receiver drawing it on a map isn't a leak.
- Reframe the default-off as a clutter / signal-to-noise concern -- a busy mesh has dozens of locatable chat nodes the user has no relationship with, and the default keeps the high-signal pins (infrastructure + own contacts) on top.

## Test plan

- [ ] Read \`lua/docs/manual/settings/map.md\` rendered on-device via the docs viewer to confirm the bullet still flows.
- [ ] Confirm no other doc / commit text in the tree still uses "other peers' privacy" framing for this toggle.