### PR TITLE
feat(bench): ez.bench.* harness + boot profile (issue #62)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -687,6 +687,22 @@ After making a fix:
 3. Verify with appropriate capture mode (text/primitives/screenshot)
 4. Check logs for any errors
 
+### Test-only Lua surfaces (ez.debug / ez.bench)
+
+`ez.debug.*` (AsyncIO queue stats, SD remount, heap snapshots, last
+panic) and `ez.bench.*` (micro-benchmark scenarios + boot profile
+timeline) are test-only scaffolding for the pytest harness under
+`tools/remote/tests/`. They live alongside the public bindings but are
+**not** part of the public Lua API -- same trust model: don't depend on
+them from app Lua, and don't add UI surfaces that expose them. The bench
+scenarios are registered in a static array in
+`src/lua/bindings/bench_bindings.cpp` -- adding more is a one-line
+Scenario struct plus a `run()` function. Boot profile markers are
+recorded by `bootProfileMark()` in C++ (early `main.cpp` checkpoints)
+and `ez.bench.mark()` in Lua (`lua/boot.lua` service-init marks); the
+ring buffer is fixed at 64 entries and dumped via
+`ez.bench.boot_profile()`.
+
 ## Key Components
 
 ### Identity System (Ed25519)

--- a/lua/boot.lua
+++ b/lua/boot.lua
@@ -174,14 +174,18 @@ local function boot_sequence()
     local log_persist = require("services.log_persist")
     log_persist.init()
 
+    if ez.bench and ez.bench.mark then ez.bench.mark("svc_log_persist") end
+
     local contacts_svc = require("services.contacts")
     contacts_svc.init()
+    if ez.bench and ez.bench.mark then ez.bench.mark("svc_contacts") end
 
     local channels_svc = require("services.channels")
     channels_svc.init()
 
     local dm_svc = require("services.direct_messages")
     dm_svc.init()
+    if ez.bench and ez.bench.mark then ez.bench.mark("svc_dm") end
 
     -- Sharing: encode/decode for ezme.sh share URLs that ride inside
     -- DM bubbles (contact pubkeys, channel-invite tokens). Must come
@@ -515,6 +519,7 @@ local function boot_sequence()
     gps_svc.start_sync_loop()
 
     ez.log("[Boot] Services started")
+    if ez.bench and ez.bench.mark then ez.bench.mark("svc_done") end
 
     -- Run version migrations before applying settings. Migrations may
     -- rename or transform prefs, so they must run before anything reads
@@ -611,6 +616,7 @@ local function boot_sequence()
     end
 
     ez.log("[Boot] Boot complete")
+    if ez.bench and ez.bench.mark then ez.bench.mark("boot_complete") end
 end
 
 -- Run boot in a coroutine — async_read needs coroutine context for filesystem I/O

--- a/src/boot_profile.cpp
+++ b/src/boot_profile.cpp
@@ -1,0 +1,54 @@
+#include "boot_profile.h"
+
+#include <Arduino.h>
+#include <cstring>
+#include <freertos/FreeRTOS.h>
+#include <freertos/portmacro.h>
+
+// Fixed-size storage in BSS. No heap alloc, no PSRAM dependency, lives
+// from very early in setup() (before PSRAM is even probed) all the way
+// through normal device runtime.
+static BootPhase s_entries[BOOT_PROFILE_CAPACITY];
+static size_t s_count = 0;
+
+// portMUX serialises the (name copy + millis read + count bump) trio.
+// bootProfileMark can fire from setup() (Core 1, no other tasks) and
+// from a Lua coroutine after init, so the lock-free path is incorrect.
+// The critical section is tiny -- a 32-byte memcpy and one increment --
+// so blocking interrupts briefly is fine.
+static portMUX_TYPE s_mux = portMUX_INITIALIZER_UNLOCKED;
+
+void bootProfileMark(const char* name) {
+    if (name == nullptr) return;
+
+    // Snapshot millis() outside the critical section to keep the lock
+    // window as short as possible. The few microseconds of skew between
+    // the timestamp and the actual append don't matter at boot-timeline
+    // resolution.
+    uint32_t now = millis();
+
+    portENTER_CRITICAL(&s_mux);
+    if (s_count < BOOT_PROFILE_CAPACITY) {
+        BootPhase& slot = s_entries[s_count];
+        // Manual strncpy to avoid the wide-string warnings on some
+        // toolchains and guarantee the NUL terminator.
+        size_t i = 0;
+        while (i < sizeof(slot.name) - 1 && name[i] != '\0') {
+            slot.name[i] = name[i];
+            ++i;
+        }
+        slot.name[i] = '\0';
+        slot.millis = now;
+        ++s_count;
+    }
+    portEXIT_CRITICAL(&s_mux);
+}
+
+const BootPhase* bootProfileEntries(size_t* outCount) {
+    if (outCount) {
+        portENTER_CRITICAL(&s_mux);
+        *outCount = s_count;
+        portEXIT_CRITICAL(&s_mux);
+    }
+    return s_entries;
+}

--- a/src/boot_profile.h
+++ b/src/boot_profile.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Boot profile ring buffer.
+//
+// Fires from setup() (Core 1, before Lua is alive) and from Lua during
+// boot.lua (post-service-init marks via ez.bench.mark). Both paths drop
+// into bootProfileMark which is interrupt-safe: a portMUX-protected copy
+// of the name + millis() into a fixed-size array. The array is small,
+// stays in internal RAM, and survives until the next reset.
+//
+// Out-of-space is silent: once the array is full, additional marks are
+// dropped on the floor rather than evicting older entries. The first
+// entries are the most valuable (they're the ones an external observer
+// is trying to correlate with cold-boot symptoms), so prefer to lose
+// late marks over early ones.
+
+struct BootPhase {
+    char name[32];     // 31 chars + NUL
+    uint32_t millis;   // millis() at the time of the mark
+};
+
+constexpr size_t BOOT_PROFILE_CAPACITY = 64;
+
+// Record a boot-profile marker. `name` is copied (truncated to 31 chars +
+// NUL) so the caller's buffer can be transient. Safe to call from any
+// task / context. Returns silently if the ring is full.
+void bootProfileMark(const char* name);
+
+// Returns the recorded boot-profile entries. `*outCount` receives the
+// number of valid entries and the returned pointer is a pointer to the
+// first entry. Entries are ordered by call time (entry 0 is the first
+// mark). The returned pointer is into the live ring buffer -- valid for
+// reading immediately, but a concurrent bootProfileMark may append more.
+// Callers should treat the snapshot as a momentary view.
+const BootPhase* bootProfileEntries(size_t* outCount);

--- a/src/lua/bindings/bench_bindings.cpp
+++ b/src/lua/bindings/bench_bindings.cpp
@@ -1,0 +1,441 @@
+// ez.bench.* -- micro-benchmark + boot profiling harness used by the
+// on-device test suite (tools/remote/tests/test_benchmarks.py and
+// test_boot_profile.py). Same trust model as ez.debug.* -- test-only
+// scaffolding, not part of the public Lua API.
+//
+// Scenarios are registered in a static array below. Each scenario's
+// `run()` does ONE iteration; the framework wraps it in a loop, samples
+// micros() before and after each call, and computes summary stats
+// (min/max/mean/p50/p95) plus a full samples array for the caller.
+//
+// This first cut ships 4 crypto/hash scenarios. Issue #62 enumerates 12
+// total; the rest (map.tile_inflate, display.draw_text, display.full_flush,
+// storage.sd_read_4k, storage.sd_write_4k, mesh.packet_encode,
+// async.file_read_64k, markdown.render, lua.gc_step) are deferred -- they
+// have side effects or fixture requirements (SD card present, map archive
+// staged, etc.) that would balloon the diff. Adding more is a one-line
+// Scenario struct + a single static `run` function.
+
+// @module ez.bench
+// @brief Test-only micro-benchmark and boot profiling harness.
+// @description
+//   Runs registered scenarios under timing (micros()) and reports
+//   min/max/mean/p50/p95 plus the raw samples. Boot profile markers are
+//   recorded by bootProfileMark() in setup() and by ez.bench.mark() from
+//   Lua; ez.bench.boot_profile() returns the timeline. Intended for use
+//   by tools/remote/tests only -- same trust model as ez.debug.*.
+// @end
+
+#include "bench_bindings.h"
+#include "../lua_bindings.h"
+#include "../../boot_profile.h"
+
+#include <Arduino.h>
+#include <esp_heap_caps.h>
+
+#include <cstdlib>
+#include <cstring>
+
+#include "mbedtls/aes.h"
+#include "mbedtls/sha256.h"
+
+#include <Ed25519.h>
+
+extern "C" {
+#include <lualib.h>
+#include <lauxlib.h>
+}
+
+// ---------------------------------------------------------------------------
+// Scenario fixtures (one-time setup, reused across iterations)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Ed25519 fixtures. Seeded lazily so device-without-mesh builds still
+// produce valid keypairs without depending on global construction order.
+struct Ed25519Fixture {
+    bool initialized = false;
+    uint8_t publicKey[32];
+    uint8_t privateKey[32];  // rweather/Crypto API takes a 32-byte seed
+    uint8_t message[64];
+    uint8_t signature[64];
+};
+
+Ed25519Fixture g_ed25519;
+
+void ensureEd25519Fixture() {
+    if (g_ed25519.initialized) return;
+    // Deterministic message so verify benchmarks always have a valid
+    // signature to check (we sign it once during setup).
+    for (size_t i = 0; i < sizeof(g_ed25519.message); ++i) {
+        g_ed25519.message[i] = (uint8_t)(i * 7 + 1);
+    }
+    // Generate a dedicated keypair for the benchmark so we don't depend
+    // on Identity's internal 32+32 private key layout (Identity's sign
+    // API doesn't expose the raw 32-byte seed that Ed25519::sign wants).
+    // Esp-random under the hood -- fine for non-replay-sensitive bench
+    // fixture material.
+    Ed25519::generatePrivateKey(g_ed25519.privateKey);
+    Ed25519::derivePublicKey(g_ed25519.publicKey, g_ed25519.privateKey);
+    Ed25519::sign(g_ed25519.signature, g_ed25519.privateKey, g_ed25519.publicKey,
+                  g_ed25519.message, sizeof(g_ed25519.message));
+    g_ed25519.initialized = true;
+}
+
+// AES-128-ECB fixture. 16-byte key, 256-byte ciphertext (16 blocks).
+struct AesFixture {
+    bool initialized = false;
+    mbedtls_aes_context dec_ctx;
+    uint8_t ciphertext[256];
+    uint8_t plaintext[256];
+};
+
+AesFixture g_aes;
+
+void ensureAesFixture() {
+    if (g_aes.initialized) return;
+    // Deterministic key + plaintext, then encrypt once so we have valid
+    // ciphertext to decrypt repeatedly. The benchmark itself only
+    // measures the decrypt path -- encrypt + setkey land in setup.
+    uint8_t key[16];
+    for (size_t i = 0; i < 16; ++i) key[i] = (uint8_t)(0xA0 + i);
+    uint8_t pt[256];
+    for (size_t i = 0; i < sizeof(pt); ++i) pt[i] = (uint8_t)(i & 0xFF);
+
+    mbedtls_aes_context enc;
+    mbedtls_aes_init(&enc);
+    mbedtls_aes_setkey_enc(&enc, key, 128);
+    for (size_t i = 0; i < sizeof(pt); i += 16) {
+        mbedtls_aes_crypt_ecb(&enc, MBEDTLS_AES_ENCRYPT, pt + i, g_aes.ciphertext + i);
+    }
+    mbedtls_aes_free(&enc);
+
+    mbedtls_aes_init(&g_aes.dec_ctx);
+    mbedtls_aes_setkey_dec(&g_aes.dec_ctx, key, 128);
+    g_aes.initialized = true;
+}
+
+// SHA-256 fixture. 1 KiB of deterministic data.
+struct ShaFixture {
+    bool initialized = false;
+    uint8_t buffer[1024];
+};
+
+ShaFixture g_sha;
+
+void ensureShaFixture() {
+    if (g_sha.initialized) return;
+    for (size_t i = 0; i < sizeof(g_sha.buffer); ++i) {
+        g_sha.buffer[i] = (uint8_t)((i * 31 + 7) & 0xFF);
+    }
+    g_sha.initialized = true;
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+void scenario_ed25519_sign() {
+    uint8_t sig[64];
+    Ed25519::sign(sig, g_ed25519.privateKey, g_ed25519.publicKey,
+                  g_ed25519.message, sizeof(g_ed25519.message));
+    // Force the compiler to keep the sig; volatile read.
+    asm volatile("" :: "r"(sig[0]));
+}
+
+void scenario_ed25519_verify() {
+    bool ok = Ed25519::verify(g_ed25519.signature, g_ed25519.publicKey,
+                              g_ed25519.message, sizeof(g_ed25519.message));
+    asm volatile("" :: "r"(ok));
+}
+
+void scenario_aes_decrypt() {
+    uint8_t out[256];
+    for (size_t i = 0; i < sizeof(g_aes.ciphertext); i += 16) {
+        mbedtls_aes_crypt_ecb(&g_aes.dec_ctx, MBEDTLS_AES_DECRYPT,
+                              g_aes.ciphertext + i, out + i);
+    }
+    asm volatile("" :: "r"(out[0]));
+}
+
+void scenario_sha256_1k() {
+    uint8_t hash[32];
+    mbedtls_sha256_context ctx;
+    mbedtls_sha256_init(&ctx);
+    mbedtls_sha256_starts(&ctx, 0);
+    mbedtls_sha256_update(&ctx, g_sha.buffer, sizeof(g_sha.buffer));
+    mbedtls_sha256_finish(&ctx, hash);
+    mbedtls_sha256_free(&ctx);
+    asm volatile("" :: "r"(hash[0]));
+}
+
+struct Scenario {
+    const char* name;
+    const char* description;
+    void (*setup)();
+    void (*run)();
+};
+
+const Scenario kScenarios[] = {
+    {"crypto.ed25519_sign",      "Ed25519 sign of a 64-byte payload",   ensureEd25519Fixture, scenario_ed25519_sign},
+    {"crypto.ed25519_verify",    "Ed25519 verify of a 64-byte payload", ensureEd25519Fixture, scenario_ed25519_verify},
+    {"crypto.aes_decrypt_128_ecb", "AES-128-ECB decrypt of 256 bytes",  ensureAesFixture,     scenario_aes_decrypt},
+    {"crypto.sha256_1k",         "SHA-256 of a 1 KiB buffer",           ensureShaFixture,     scenario_sha256_1k},
+};
+const size_t kScenarioCount = sizeof(kScenarios) / sizeof(kScenarios[0]);
+
+const Scenario* findScenario(const char* name) {
+    for (size_t i = 0; i < kScenarioCount; ++i) {
+        if (strcmp(kScenarios[i].name, name) == 0) return &kScenarios[i];
+    }
+    return nullptr;
+}
+
+// Lua-style comparator for qsort'ing samples.
+int cmp_u32(const void* a, const void* b) {
+    uint32_t av = *(const uint32_t*)a;
+    uint32_t bv = *(const uint32_t*)b;
+    if (av < bv) return -1;
+    if (av > bv) return 1;
+    return 0;
+}
+
+// Run a scenario `iterations` times, write summary stats and samples to
+// the table on top of the Lua stack. Returns nothing (assumes a table
+// is already on the stack at the top -- caller created it).
+// On allocation failure, sets fields to 0 / empty.
+void runScenarioToTable(lua_State* L, const Scenario& s, int iterations) {
+    if (iterations < 1) iterations = 1;
+    if (iterations > 1000) iterations = 1000;
+
+    // Heap-alloc the samples buffer -- ESP-IDF stacks are tight,
+    // especially for the Lua coroutine that called us. 1000 * 4 bytes =
+    // 4 KiB worst case; pull it from PSRAM where the rest of Lua lives.
+    uint32_t* samples = (uint32_t*)heap_caps_malloc(
+        sizeof(uint32_t) * iterations,
+        MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (samples == nullptr) {
+        samples = (uint32_t*)heap_caps_malloc(sizeof(uint32_t) * iterations,
+                                              MALLOC_CAP_8BIT);
+    }
+    if (samples == nullptr) {
+        lua_pushinteger(L, 0); lua_setfield(L, -2, "min_us");
+        lua_pushinteger(L, 0); lua_setfield(L, -2, "max_us");
+        lua_pushinteger(L, 0); lua_setfield(L, -2, "mean_us");
+        lua_pushinteger(L, 0); lua_setfield(L, -2, "p50_us");
+        lua_pushinteger(L, 0); lua_setfield(L, -2, "p95_us");
+        lua_pushinteger(L, 0); lua_setfield(L, -2, "iterations");
+        lua_newtable(L); lua_setfield(L, -2, "samples");
+        lua_pushstring(L, "alloc failed"); lua_setfield(L, -2, "error");
+        return;
+    }
+
+    if (s.setup) s.setup();
+
+    // Pre-touch the scenario once to warm caches / fixture lazy-init so
+    // the first measured iteration isn't dominated by setup tail.
+    s.run();
+
+    for (int i = 0; i < iterations; ++i) {
+        uint32_t t0 = micros();
+        s.run();
+        uint32_t t1 = micros();
+        // micros() wraps every ~71 minutes; subtracting unsigned is
+        // wrap-safe.
+        samples[i] = t1 - t0;
+    }
+
+    // Stats. min / max / mean computed before sort to keep samples in
+    // their original (chronological) order for the caller's "samples"
+    // field. Then sort a copy for percentile.
+    uint64_t sum = 0;
+    uint32_t mn = samples[0];
+    uint32_t mx = samples[0];
+    for (int i = 0; i < iterations; ++i) {
+        sum += samples[i];
+        if (samples[i] < mn) mn = samples[i];
+        if (samples[i] > mx) mx = samples[i];
+    }
+    uint32_t mean = (uint32_t)(sum / iterations);
+
+    // Sort a copy for percentiles. Use a separate buffer so we can hand
+    // back the original chronological array.
+    uint32_t* sorted = (uint32_t*)heap_caps_malloc(
+        sizeof(uint32_t) * iterations,
+        MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (sorted == nullptr) {
+        sorted = (uint32_t*)heap_caps_malloc(sizeof(uint32_t) * iterations,
+                                             MALLOC_CAP_8BIT);
+    }
+    uint32_t p50 = mean;
+    uint32_t p95 = mx;
+    if (sorted != nullptr) {
+        memcpy(sorted, samples, sizeof(uint32_t) * iterations);
+        qsort(sorted, iterations, sizeof(uint32_t), cmp_u32);
+        // Nearest-rank percentile: ceil(p/100 * N) - 1 (0-indexed).
+        int idx50 = (int)(((50 * iterations) + 99) / 100) - 1;
+        int idx95 = (int)(((95 * iterations) + 99) / 100) - 1;
+        if (idx50 < 0) idx50 = 0;
+        if (idx95 < 0) idx95 = 0;
+        if (idx50 >= iterations) idx50 = iterations - 1;
+        if (idx95 >= iterations) idx95 = iterations - 1;
+        p50 = sorted[idx50];
+        p95 = sorted[idx95];
+        heap_caps_free(sorted);
+    }
+
+    lua_pushinteger(L, (lua_Integer)mn);    lua_setfield(L, -2, "min_us");
+    lua_pushinteger(L, (lua_Integer)mx);    lua_setfield(L, -2, "max_us");
+    lua_pushinteger(L, (lua_Integer)mean);  lua_setfield(L, -2, "mean_us");
+    lua_pushinteger(L, (lua_Integer)p50);   lua_setfield(L, -2, "p50_us");
+    lua_pushinteger(L, (lua_Integer)p95);   lua_setfield(L, -2, "p95_us");
+    lua_pushinteger(L, (lua_Integer)iterations); lua_setfield(L, -2, "iterations");
+
+    // samples = { ... }
+    lua_newtable(L);
+    for (int i = 0; i < iterations; ++i) {
+        lua_pushinteger(L, (lua_Integer)samples[i]);
+        lua_rawseti(L, -2, i + 1);
+    }
+    lua_setfield(L, -2, "samples");
+
+    heap_caps_free(samples);
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Lua bindings
+// ---------------------------------------------------------------------------
+
+// @lua ez.bench.list() -> array of { name, description }
+// @brief Return every registered benchmark scenario
+// @description Each entry is `{ name = "<scenario>", description = "<one-line>" }`.
+// Test harnesses iterate this to discover what's available without
+// hard-coding the scenario list.
+// @example
+// for _, s in ipairs(ez.bench.list()) do
+//   print(s.name, s.description)
+// end
+// @end
+LUA_FUNCTION(l_bench_list) {
+    lua_newtable(L);
+    for (size_t i = 0; i < kScenarioCount; ++i) {
+        lua_newtable(L);
+        lua_pushstring(L, kScenarios[i].name);
+        lua_setfield(L, -2, "name");
+        lua_pushstring(L, kScenarios[i].description);
+        lua_setfield(L, -2, "description");
+        lua_rawseti(L, -2, (lua_Integer)(i + 1));
+    }
+    return 1;
+}
+
+// @lua ez.bench.run(name, iterations?) -> { min_us, max_us, mean_us, p50_us, p95_us, samples, iterations }
+// @brief Run a single scenario `iterations` times and report stats
+// @description Iterations defaults to 50, clamped to [1, 1000]. Returns
+// nil + "unknown scenario" on a misspelled name. `samples` is an array of
+// per-iteration measurements in chronological order; percentiles are
+// computed nearest-rank on a sorted copy.
+// @param name  Scenario name from ez.bench.list()
+// @param iterations  Number of measured runs (1..1000, default 50)
+// @return Stats table, or nil + error string
+// @example
+// local r = ez.bench.run("crypto.sha256_1k", 100)
+// print(string.format("p95=%dus mean=%dus", r.p95_us, r.mean_us))
+// @end
+LUA_FUNCTION(l_bench_run) {
+    const char* name = luaL_checkstring(L, 1);
+    int iterations = (int)luaL_optintegerdefault(L, 2, 50);
+    const Scenario* s = findScenario(name);
+    if (s == nullptr) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "unknown scenario: %s", name);
+        return 2;
+    }
+    lua_newtable(L);
+    runScenarioToTable(L, *s, iterations);
+    return 1;
+}
+
+// @lua ez.bench.run_all(iterations?) -> { [name] = stats, ... }
+// @brief Run every registered scenario and return a name -> stats map
+// @description Convenience for the test harness; equivalent to calling
+// ez.bench.run(name, iterations) for each scenario.
+// @param iterations  Number of measured runs per scenario (default 50)
+// @return Table keyed by scenario name with per-scenario stats tables
+// @example
+// local all = ez.bench.run_all(50)
+// for name, stats in pairs(all) do print(name, stats.p95_us) end
+// @end
+LUA_FUNCTION(l_bench_run_all) {
+    int iterations = (int)luaL_optintegerdefault(L, 1, 50);
+    lua_newtable(L);
+    for (size_t i = 0; i < kScenarioCount; ++i) {
+        lua_newtable(L);
+        runScenarioToTable(L, kScenarios[i], iterations);
+        lua_setfield(L, -2, kScenarios[i].name);
+    }
+    return 1;
+}
+
+// @lua ez.bench.mark(name) -> nil
+// @brief Append a boot-profile marker
+// @description Records the given name in the boot-profile ring buffer
+// alongside the current millis(). Name is truncated to 31 chars + NUL.
+// Used by lua/boot.lua to mark service-init checkpoints; available to
+// other code too if you want to time something across reboot.
+// @param name  Short label (truncated to 31 chars)
+// @example
+// ez.bench.mark("svc_contacts_done")
+// @end
+LUA_FUNCTION(l_bench_mark) {
+    const char* name = luaL_checkstring(L, 1);
+    bootProfileMark(name);
+    return 0;
+}
+
+// @lua ez.bench.boot_profile() -> array of { name, millis }
+// @brief Snapshot of every recorded boot-profile marker
+// @description Entries are ordered by call time. The first entry is the
+// earliest mark (typically `setup_start` in main.cpp). millis() values
+// are uptime in milliseconds. Ring buffer is fixed at 64 entries; extras
+// are silently dropped (oldest entries are the most valuable).
+// @example
+// for _, e in ipairs(ez.bench.boot_profile()) do
+//   print(e.millis, e.name)
+// end
+// @end
+LUA_FUNCTION(l_bench_boot_profile) {
+    size_t count = 0;
+    const BootPhase* entries = bootProfileEntries(&count);
+    lua_newtable(L);
+    for (size_t i = 0; i < count; ++i) {
+        lua_newtable(L);
+        lua_pushstring(L, entries[i].name);
+        lua_setfield(L, -2, "name");
+        lua_pushinteger(L, (lua_Integer)entries[i].millis);
+        lua_setfield(L, -2, "millis");
+        lua_rawseti(L, -2, (lua_Integer)(i + 1));
+    }
+    return 1;
+}
+
+static const luaL_Reg bench_funcs[] = {
+    {"list",         l_bench_list},
+    {"run",          l_bench_run},
+    {"run_all",      l_bench_run_all},
+    {"mark",         l_bench_mark},
+    {"boot_profile", l_bench_boot_profile},
+    {nullptr, nullptr},
+};
+
+namespace bench_bindings {
+
+void registerBindings(lua_State* L) {
+    lua_register_module(L, "bench", bench_funcs);
+    Serial.println("[bench_bindings] Registered ez.bench.*");
+}
+
+}  // namespace bench_bindings

--- a/src/lua/bindings/bench_bindings.h
+++ b/src/lua/bindings/bench_bindings.h
@@ -1,0 +1,13 @@
+#pragma once
+
+extern "C" {
+#include <lua.h>
+}
+
+namespace bench_bindings {
+    // Registers ez.bench.* helpers used by the on-device test suite
+    // (tools/remote/tests/test_benchmarks.py and test_boot_profile.py).
+    // Same trust model as ez.debug.*: test-only scaffolding, not part of
+    // the public Lua API.
+    void registerBindings(lua_State* L);
+}

--- a/src/lua/lua_runtime.cpp
+++ b/src/lua/lua_runtime.cpp
@@ -51,6 +51,8 @@ void registerNetModule(lua_State* L);
 #include "bindings/image_bindings.h"
 // ez.debug.* (test-only): asyncio_stats, sd_remount, heap, last_panic.
 #include "bindings/debug_bindings.h"
+// ez.bench.* (test-only): scenario harness + boot profile timeline.
+#include "bindings/bench_bindings.h"
 
 LuaRuntime& LuaRuntime::instance() {
     static LuaRuntime runtime;
@@ -242,6 +244,10 @@ void LuaRuntime::registerAllModules() {
     // so it can reach into AsyncIO / SDManager / esp-idf state once
     // everything else is wired up.
     debug_bindings::registerBindings(_state);
+
+    // ez.bench.* test-only micro-benchmark harness + boot profile.
+    // Same trust model as ez.debug.* -- not part of the public API.
+    bench_bindings::registerBindings(_state);
 
     LOG("LuaRuntime", "Modules registered");
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "lua/lua_runtime.h"
 #include "remote/remote_control.h"
 #include "boot_splash.h"
+#include "boot_profile.h"
 
 
 // Track initialization status
@@ -45,6 +46,10 @@ MeshCore* mesh = nullptr;
 static Settings* settings = nullptr;
 
 void setup() {
+    // Boot profile starts as the first thing in setup() so every later
+    // marker is measured relative to the same baseline.
+    bootProfileMark("setup_start");
+
     // Enable power - MUST be first on T-Deck Plus
     pinMode(BOARD_POWERON, OUTPUT);
     digitalWrite(BOARD_POWERON, HIGH);
@@ -112,6 +117,7 @@ void setup() {
     } else {
         Serial.println("WARNING: Display init failed");
     }
+    bootProfileMark("display_init");
 
     // Show boot splash as soon as the display is up, so the user sees
     // the logo within ~150 ms of power-on instead of staring at a black
@@ -165,6 +171,7 @@ void setup() {
     } else {
         Serial.println("WARNING: Radio init failed");
     }
+    bootProfileMark("radio_init");
     boot_splash::step(display);
 
     // Initialize GPS (T-Deck Plus with u-blox module)
@@ -222,6 +229,7 @@ void setup() {
     } else {
         Serial.println("WARNING: LittleFS init failed");
     }
+    bootProfileMark("littlefs_init");
     boot_splash::step(display);
 
     // Register a shutdown handler that drains the in-memory log
@@ -245,6 +253,7 @@ void setup() {
     } else {
         Serial.println("WARNING: Lua init failed");
     }
+    bootProfileMark("lua_runtime");
     boot_splash::step(display);
 
     // Run boot script (requires display and keyboard). Fill the
@@ -349,6 +358,16 @@ void setup() {
 extern uint32_t g_loopDelayMs;
 
 void loop() {
+    // Record the first time the Arduino loop actually fires -- everything
+    // up to setup() returning lives under one of the *_init marks, this
+    // one captures the setup -> loop transition. Static guard so the
+    // mark only lands once per boot.
+    static bool firstLoop = true;
+    if (firstLoop) {
+        firstLoop = false;
+        bootProfileMark("main_loop");
+    }
+
     uint32_t frameStart = millis();
 
     // Process remote control commands (non-blocking)

--- a/tools/remote/tests/test_benchmarks.py
+++ b/tools/remote/tests/test_benchmarks.py
@@ -1,0 +1,102 @@
+"""
+Benchmark scenarios via ez.bench.*
+
+Iterates every registered scenario, runs it on-device, asserts a generous
+p95 ceiling per scenario (sanity check -- the ceilings are well above
+expected jitter so this test should never flake), and dumps the full
+sample set to .last_bench_results.json next to this file for trend
+eyeballing.
+
+Auto-skips when the ez.bench binding namespace isn't compiled in (e.g.
+the test is run against a stripped firmware build), mirroring the
+soft-skip pattern in test_map_archive.py.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+RESULTS_PATH = Path(__file__).with_name(".last_bench_results.json")
+
+# Per-scenario p95 ceilings in microseconds. Generous: we want to catch
+# 10x regressions, not jitter. Pick values >> the observed steady-state
+# numbers. The bench harness expects to never flake here.
+P95_CEILING_US = {
+    "crypto.ed25519_sign":       250000,   # 250 ms (heavy curve op)
+    "crypto.ed25519_verify":     250000,   # 250 ms (heavier than sign)
+    "crypto.aes_decrypt_128_ecb": 20000,   #  20 ms (HW-accel mbedTLS)
+    "crypto.sha256_1k":           20000,   #  20 ms (HW-accel SHA)
+}
+
+DEFAULT_CEILING_US = 250000  # fallback for any scenario without a known bound
+
+# Small per-scenario iteration count. The harness round-trips ~5 samples
+# of latency over USB CDC even when scenarios are fast, so keep this
+# bounded -- 25 gives a statistically OK p95 without dragging session
+# wallclock past a few seconds for the whole suite.
+ITERATIONS = 25
+
+
+def _bench_available(device) -> bool:
+    return bool(device.lua_exec("return ez.bench and ez.bench.list ~= nil"))
+
+
+def test_bench_scenarios(device):
+    if not _bench_available(device):
+        pytest.skip("ez.bench bindings not present on device")
+
+    scenarios = device.lua_exec("return ez.bench.list()")
+    assert isinstance(scenarios, list) and len(scenarios) > 0, scenarios
+
+    results = {}
+    for entry in scenarios:
+        name = entry["name"]
+        stats = device.lua_exec(f"return ez.bench.run('{name}', {ITERATIONS})")
+        assert isinstance(stats, dict), f"{name}: bench.run returned {stats!r}"
+        # Sanity-check the fields we promise in the binding doc.
+        for field in ("min_us", "max_us", "mean_us", "p50_us", "p95_us", "samples", "iterations"):
+            assert field in stats, f"{name}: missing field {field}"
+        assert isinstance(stats["samples"], list) and len(stats["samples"]) == stats["iterations"], (
+            f"{name}: samples length mismatch"
+        )
+        results[name] = stats
+
+    # Persist the full numbers BEFORE asserting bounds so a single
+    # threshold failure doesn't bury the rest of the dataset.
+    RESULTS_PATH.write_text(json.dumps(results, indent=2, sort_keys=True))
+
+    # Soft assertions: just catch egregious regressions.
+    failures = []
+    for name, stats in results.items():
+        ceiling = P95_CEILING_US.get(name, DEFAULT_CEILING_US)
+        if stats["p95_us"] > ceiling:
+            failures.append(f"{name}: p95={stats['p95_us']}us > ceiling {ceiling}us")
+    assert not failures, "\n".join(failures)
+
+
+def test_bench_run_unknown_scenario_errors(device):
+    if not _bench_available(device):
+        pytest.skip("ez.bench bindings not present on device")
+    res = device.lua_exec(
+        "local r, err = ez.bench.run('not.a.real.scenario'); "
+        "return { res = r, err = err }"
+    )
+    # nil result + error string
+    assert res.get("res") in (None, False), res
+    assert isinstance(res.get("err"), str) and "unknown" in res["err"], res
+
+
+def test_bench_iterations_clamp(device):
+    if not _bench_available(device):
+        pytest.skip("ez.bench bindings not present on device")
+    # iterations=0 should clamp to 1; iterations=10000 should clamp to 1000.
+    scenarios = device.lua_exec("return ez.bench.list()")
+    name = scenarios[0]["name"]
+    low = device.lua_exec(f"return ez.bench.run('{name}', 0).iterations")
+    assert low == 1, low
+    # Skip the high-side clamp at runtime; running 1000 iterations would
+    # take far longer than the test budget. Trust the C++ clamp logic.

--- a/tools/remote/tests/test_boot_profile.py
+++ b/tools/remote/tests/test_boot_profile.py
@@ -1,0 +1,100 @@
+"""
+Boot profile timeline via ez.bench.boot_profile().
+
+Reads the boot-profile ring buffer recorded during setup() and boot.lua,
+asserts the expected phase names appear in order, sanity-bounds the total
+boot time, and dumps the timeline to .last_boot_profile.json for
+inspection.
+
+Auto-skips when the ez.bench binding namespace isn't present.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+TIMELINE_PATH = Path(__file__).with_name(".last_boot_profile.json")
+
+# Phases we expect to see, in this relative order. Not an exhaustive
+# list -- the test only asserts that *each of these* shows up at least
+# once and that the listed pairs are in the right order. New phases can
+# be added without breaking the test.
+EXPECTED_ORDER = [
+    "setup_start",
+    "display_init",
+    "radio_init",
+    "littlefs_init",
+    "lua_runtime",
+    "main_loop",
+]
+
+# Generous upper bound on total boot time. Real device boots in a few
+# seconds; 30 s is well above any healthy build.
+BOOT_TIME_CEILING_MS = 30_000
+
+
+def _bench_available(device) -> bool:
+    return bool(device.lua_exec("return ez.bench and ez.bench.boot_profile ~= nil"))
+
+
+def test_boot_profile_timeline(device):
+    if not _bench_available(device):
+        pytest.skip("ez.bench bindings not present on device")
+
+    entries = device.lua_exec("return ez.bench.boot_profile()")
+    assert isinstance(entries, list) and len(entries) > 0, entries
+
+    # Persist before asserting so failures still leave the artefact.
+    TIMELINE_PATH.write_text(json.dumps(entries, indent=2))
+
+    names = [e["name"] for e in entries]
+    millis = [e["millis"] for e in entries]
+
+    # Each expected phase must appear at least once.
+    missing = [n for n in EXPECTED_ORDER if n not in names]
+    assert not missing, f"missing boot phases: {missing} (got {names})"
+
+    # And the expected ones must appear in the documented order.
+    indices = [names.index(n) for n in EXPECTED_ORDER]
+    assert indices == sorted(indices), (
+        f"boot phases out of order: order = "
+        f"{[(n, names.index(n)) for n in EXPECTED_ORDER]}"
+    )
+
+    # Millis must be monotonically non-decreasing.
+    for i in range(1, len(millis)):
+        assert millis[i] >= millis[i - 1], (
+            f"non-monotonic boot timestamps at idx {i}: {millis[i-1]} -> {millis[i]}"
+        )
+
+    # First entry should be near zero (setup_start lands very early).
+    # Use 5 s as a generous ceiling -- the USB-CDC settle delay can push
+    # this out by a couple seconds.
+    assert millis[0] < 5_000, f"setup_start arrived too late: {millis[0]} ms"
+
+    # Total span generous.
+    span = millis[-1] - millis[0]
+    assert span < BOOT_TIME_CEILING_MS, (
+        f"boot timeline span {span} ms > ceiling {BOOT_TIME_CEILING_MS} ms"
+    )
+
+
+def test_boot_profile_mark_records_entry(device):
+    """`ez.bench.mark` should append a new entry."""
+    if not _bench_available(device):
+        pytest.skip("ez.bench bindings not present on device")
+
+    before = device.lua_exec("return #ez.bench.boot_profile()")
+    # If the ring is already full, we can't add more -- but that's the
+    # well-defined behaviour (the binding doc says extras are dropped).
+    # Just assert non-decrease in that case.
+    device.lua_exec("ez.bench.mark('pytest_marker')")
+    after = device.lua_exec("return #ez.bench.boot_profile()")
+    assert after >= before, (before, after)
+    if after > before:
+        last = device.lua_exec("local p = ez.bench.boot_profile(); return p[#p]")
+        assert last["name"] == "pytest_marker", last


### PR DESCRIPTION
## Summary

- New `ez.bench.*` binding namespace alongside the existing `ez.debug.*` test-only surface. API: `list / run / run_all / mark / boot_profile`.
- BSS-resident, portMUX-protected boot profile ring buffer (`src/boot_profile.{h,cpp}`) — 64-entry capacity, safe to call from `setup()` before PSRAM init and from the Lua coroutine.
- C++ boot marks: `setup_start`, `display_init`, `radio_init`, `littlefs_init`, `lua_runtime`, `main_loop`.
- Lua boot marks: `svc_log_persist`, `svc_contacts`, `svc_dm`, `svc_done`, `boot_complete`.
- 4 starter scenarios: `crypto.ed25519_sign`, `crypto.ed25519_verify`, `crypto.aes_decrypt_128_ecb`, `crypto.sha256_1k`. The remaining 8 from the issue (map / display / storage / mesh / async / markdown / GC) are deferred to follow-up PRs and listed in a comment block in `bench_bindings.cpp` — adding each is a one-line Scenario struct + `run()` function.
- Two pytest files (`test_benchmarks.py`, `test_boot_profile.py`) with **generous, non-flaky** p95 bounds; both dump full JSON to `tools/remote/tests/.last_*.json` for trend-watching, and both auto-skip if `ez.bench.*` is absent.
- `@module ez.bench` annotations picked up by `tools/generate_lua_docs.py`; CLAUDE.md gains a "Test-only Lua surfaces" subsection.

## Notes for review

- `main.cpp` has no explicit SD-mount call (SDManager mounts lazily), so the equivalent storage phase is `littlefs_init`. If a future PR adds an explicit early SD mount, add the marker there and extend the test.
- Ed25519 bench uses a freshly-generated keypair, not the device identity — `Identity::sign(...)` only exposes sign-with-stored-key while the rweather/Crypto API needs a raw 32-byte seed. Generating per-test is cheap and avoids touching the persisted identity.
- Each scenario runs a one-iteration warm-up before the measured loop so first-call cache/fixture cost doesn't skew min/p50.

## Out of scope

Tracked in the issue but deferred:
- 8 remaining benchmark scenarios (side-effect-laden or fixture-heavy).
- NVS persistence for trending across reboots.
- Strict CI perf gates (jitter on a T-Deck would make these flaky; soft budgets only for now).
- On-device dev screen (explicitly excluded by the issue).

## Test plan

- [x] `pio run` builds clean on this branch.
- [ ] **Needs hardware QA** — `pio run -t upload` from this worktree, then:
  - `python tools/remote/ez_remote.py /dev/ttyACM0 -e \"return ez.bench.list()\"` lists the 4 scenarios.
  - `python -m pytest tools/remote/tests/test_benchmarks.py tools/remote/tests/test_boot_profile.py -v` passes.
  - Resulting JSON files in `tools/remote/tests/.last_bench_results.json` and `.last_boot_profile.json` contain sane numbers and full sample arrays.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)