### PR TITLE
feat(notifications): trigger-word list for Mentions-only channels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,7 +380,15 @@ NVS (default `"1"` = on). Setting `notify_dm = "0"`, for instance,
 silences every DM toast without touching the wiring. The namespace
 is meant for a future Settings panel; pref keys must stay under
 NVS's 15-character limit, so source tags should be short
-(`dm`, `file`, `battery`, `sd`, `ota`, `channel`, `system`).
+(`dm`, `file`, `battery`, `sd`, `ota`, `channel`, `system`). Note
+that `notify_words` lives in the same `notify_*` keyspace but is
+NOT a mute pref -- it holds the comma-separated trigger-word list
+for "Mentions only" channels (see `matches_trigger_words()` /
+`get_trigger_words()` / `set_trigger_words()` on the service).
+The `channel/message` subscriber in `boot.lua` ORs a trigger-word
+match against the existing node-name mention check, so a trigger
+hit behaves identically to a name mention (gates the DND
+`dnd_mention` exemption too).
 
 Do Not Disturb (issue #116): `notifications.post()` also evaluates a
 time-window DND mode after the source-mute check. When the manual

--- a/lua/boot.lua
+++ b/lua/boot.lua
@@ -439,6 +439,10 @@ local function boot_sequence()
         if my and my ~= "" and msg.text then
             is_mention = msg.text:lower():find(my:lower(), 1, true) ~= nil
         end
+        if not is_mention and msg.text then
+            -- Trigger-word list from Settings -> Notifications.
+            is_mention = notifications.matches_trigger_words(msg.text)
+        end
         if mode == "mentions" and not is_mention then return end
         notifications.post_unless_focused({
             title  = name,

--- a/lua/docs/manual/settings/notifications.md
+++ b/lua/docs/manual/settings/notifications.md
@@ -44,6 +44,24 @@ fires its toast/wake as normal during quiet hours. Off by default
 -- DMs from starred contacts will be similarly exempt once
 favourites land on `services.contacts`.
 
+## Trigger words
+
+A comma-separated list of words that, in addition to your node
+name, mark a channel message as a "mention" for the per-channel
+notify_mode. Useful when you put a channel on "Mentions only" but
+still want to ring through on specific topics -- e.g. a "Lost dog"
+alert channel can stay on Mentions only but you set a trigger
+word "dog" or "missing" so those messages still wake you.
+
+Matching is case-insensitive substring, so "storm" matches "Big
+storm coming in", you don't need to think about word boundaries.
+An empty list disables the feature; your node name remains a
+trigger either way.
+
+The list is shared across every "Mentions only" channel; it is
+not per-channel. Edit it from Settings -- Notifications --
+Trigger words.
+
 ## Clock-unset fallback
 
 If the device clock is unset (year < 2020 -- typical right after a

--- a/lua/screens/chat/channel_settings.lua
+++ b/lua/screens/chat/channel_settings.lua
@@ -73,8 +73,9 @@ function ChannelSettings:build(state)
         }))
     content[#content + 1] = ui.padding({ 2, 8, 4, 8 },
         ui.text_widget(
-            "Mentions match your node name as a substring of the "
-            .. "message text.",
+            "Mentions match your node name (or any trigger word "
+            .. "from Settings -> Notifications) as a substring of "
+            .. "the message text.",
             { wrap = true, color = "TEXT_MUTED", font = "small_aa" }))
 
     -- ---- Hide ----

--- a/lua/screens/settings/notifications.lua
+++ b/lua/screens/settings/notifications.lua
@@ -12,7 +12,8 @@
 -- under each slider re-renders on change so the user sees the
 -- HH:MM, not the raw minute count.
 
-local ui = require("ezui")
+local ui            = require("ezui")
+local notifications = require("services.notifications")
 
 local Notifications = { title = "Notifications" }
 
@@ -43,6 +44,14 @@ local function fmt_hhmm(minutes)
     return string.format("%02d:%02d", math.floor(m / 60), m % 60)
 end
 
+local function trigger_summary()
+    local words = notifications.get_trigger_words()
+    if #words == 0 then return "None" end
+    local joined = table.concat(words, ", ")
+    if #joined > 40 then return joined:sub(1, 37) .. "..." end
+    return joined
+end
+
 function Notifications.initial_state()
     return {
         enabled      = pref_bool("dnd_enabled", false),
@@ -51,6 +60,12 @@ function Notifications.initial_state()
         allow_ments  = pref_bool("dnd_mentions", false),
         manual       = pref_bool("dnd_manual", false),
     }
+end
+
+function Notifications:on_enter()
+    -- Trigger-words editor may have changed the list while we were
+    -- pushed underneath. Force a rebuild so the summary is fresh.
+    self:set_state({})
 end
 
 function Notifications:build(state)
@@ -141,6 +156,29 @@ function Notifications:build(state)
                 { wrap = true, color = "TEXT_MUTED", font = "small_aa" })
         )
     end
+
+    -- ---- Trigger words ----
+    -- Extends the "Mentions only" channel notify mode beyond the
+    -- node name. See services.notifications for the matcher.
+    content[#content + 1] = ui.padding({ 12, 8, 4, 8 },
+        ui.text_widget("Mentions", { color = "ACCENT", font = "small_aa" })
+    )
+    content[#content + 1] = ui.list_item({
+        title    = "Trigger words",
+        subtitle = trigger_summary(),
+        on_press = function()
+            local screen = require("ezui.screen")
+            local Editor = require("screens.settings.trigger_words")
+            local init = Editor.initial_state and Editor.initial_state() or {}
+            screen.push(screen.create(Editor, init))
+        end,
+    })
+    content[#content + 1] = ui.padding({ 2, 8, 8, 8 },
+        ui.text_widget(
+            "Words that ring through on 'Mentions only' channels in " ..
+            "addition to your node name.",
+            { wrap = true, color = "TEXT_MUTED", font = "small_aa" })
+    )
 
     return ui.vbox({ gap = 0, bg = "BG" }, {
         ui.title_bar("Notifications", { back = true }),

--- a/lua/screens/settings/trigger_words.lua
+++ b/lua/screens/settings/trigger_words.lua
@@ -1,0 +1,87 @@
+-- Settings -> Notifications -> Trigger words.
+--
+-- Lets the user edit the comma-separated list of words that, in
+-- addition to their node name, cause a "Mentions only" channel
+-- message to ring through. The list is stored under the
+-- `notify_words` pref in NVS (services.notifications). See the
+-- "Trigger-word matching" header in lua/services/notifications.lua
+-- for the storage / matching semantics.
+--
+-- One text field, comma-separated. Matching is case-insensitive
+-- substring, so "dog" matches "Lost dog reported at the park";
+-- the user doesn't need to think about word boundaries.
+
+local ui            = require("ezui")
+local notifications = require("services.notifications")
+
+local TriggerWords = { title = "Trigger words" }
+
+function TriggerWords.initial_state()
+    return {
+        text = table.concat(notifications.get_trigger_words(), ", "),
+    }
+end
+
+function TriggerWords:build(state)
+    local items = {}
+
+    items[#items + 1] = ui.title_bar("Trigger words", { back = true })
+
+    local content = {}
+
+    content[#content + 1] = ui.padding({ 8, 8, 4, 8 },
+        ui.text_widget(
+            "Comma-separated list. A channel message on a " ..
+            "'Mentions only' channel that contains any of these " ..
+            "words (case-insensitive) rings through as if it " ..
+            "mentioned you.",
+            { wrap = true, color = "TEXT_MUTED", font = "small_aa" })
+    )
+
+    content[#content + 1] = ui.padding({ 6, 8, 4, 8 },
+        ui.text_widget("Words", { font = "small_aa", color = "TEXT_SEC" })
+    )
+    content[#content + 1] = ui.padding({ 0, 8, 6, 8 },
+        ui.text_input({
+            value = state.text or "",
+            placeholder = "e.g. alert, storm, dog",
+            on_change = function(val)
+                state.text = val
+            end,
+        })
+    )
+
+    content[#content + 1] = ui.padding({ 6, 8, 4, 8 },
+        ui.button("Save", {
+            on_press = function()
+                notifications.set_trigger_words(state.text or "")
+                local screen = require("ezui.screen")
+                screen.pop()
+            end,
+        })
+    )
+
+    content[#content + 1] = ui.padding({ 4, 8, 8, 8 },
+        ui.text_widget(
+            "Leave empty to disable. Your node name is always a " ..
+            "trigger and doesn't need to be listed here.",
+            { wrap = true, color = "TEXT_MUTED", font = "small_aa" })
+    )
+
+    items[#items + 1] = ui.scroll({ grow = 1 }, ui.vbox({ gap = 0 }, content))
+
+    return ui.vbox({ gap = 0, bg = "BG" }, items)
+end
+
+function TriggerWords:handle_key(key)
+    -- Don't pop while the user is typing into the text input.
+    local focus_mod = require("ezui.focus")
+    if not focus_mod.editing then
+        if key.special == "BACKSPACE" or key.special == "ESCAPE" then
+            return "pop"
+        end
+    end
+    return nil
+end
+
+return TriggerWords

--- a/lua/services/notifications.lua
+++ b/lua/services/notifications.lua
@@ -117,6 +117,81 @@ function notifications.dnd_active()
         pref_int("dnd_end",   DND_DEFAULT_END))
 end
 
+-- ---------------------------------------------------------------------------
+-- Trigger-word matching (issue #115)
+-- ---------------------------------------------------------------------------
+-- "Mentions only" channels match the user's node name by default.
+-- Users can extend that to a configurable list of trigger words, so a
+-- "lost dog" alert channel can be on Mentions only and still ring
+-- through on "dog" or "missing", or a watch-list channel can wake the
+-- user on "outage" / "storm" without flooding on everything else.
+--
+-- The list is stored in NVS as a single comma-separated string under
+-- `notify_words` (12 chars, fits under NVS's 15-char key cap). Matching
+-- is a case-insensitive substring search; tokens are trimmed of
+-- surrounding whitespace and empty tokens are skipped. Users edit the
+-- list from Settings -> Notifications -> Trigger words.
+--
+-- The channel/message subscriber in boot.lua ORs this against the
+-- existing node-name match, so a trigger-word match is functionally
+-- identical to a name mention (also gates the DND `opts.dnd_mention`
+-- exemption when "Allow channel mentions" is on).
+
+local function trim(s)
+    return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+function notifications.get_trigger_words()
+    local raw = pref_str("notify_words", "")
+    if type(raw) ~= "string" or raw == "" then return {} end
+    local out = {}
+    for tok in raw:gmatch("[^,]+") do
+        local t = trim(tok)
+        if t ~= "" then out[#out + 1] = t end
+    end
+    return out
+end
+
+-- Store a list (table of strings) or a comma-joined string. Empty
+-- input clears the list. Tokens with embedded commas are split.
+function notifications.set_trigger_words(value)
+    if not (ez and ez.storage and ez.storage.set_pref) then return end
+    local joined
+    if type(value) == "table" then
+        local parts = {}
+        for _, v in ipairs(value) do
+            if type(v) == "string" then
+                local t = trim(v)
+                if t ~= "" then parts[#parts + 1] = t end
+            end
+        end
+        joined = table.concat(parts, ",")
+    elseif type(value) == "string" then
+        local parts = {}
+        for tok in value:gmatch("[^,]+") do
+            local t = trim(tok)
+            if t ~= "" then parts[#parts + 1] = t end
+        end
+        joined = table.concat(parts, ",")
+    else
+        joined = ""
+    end
+    ez.storage.set_pref("notify_words", joined)
+end
+
+-- Returns true when `text` contains any configured trigger word as a
+-- case-insensitive substring. Safe on nil / non-string input.
+function notifications.matches_trigger_words(text)
+    if type(text) ~= "string" or text == "" then return false end
+    local words = notifications.get_trigger_words()
+    if #words == 0 then return false end
+    local lower = text:lower()
+    for _, w in ipairs(words) do
+        if lower:find(w:lower(), 1, true) then return true end
+    end
+    return false
+end
+
 -- A post is exempt from DND when it carries an exception flag the user
 -- has allowed through. Two flags are wired today:
 --   opts.dnd_fav      -- DM from a starred contact (set in boot.lua's


### PR DESCRIPTION
## Summary

A small extension to the per-channel notify_mode wiring shipped under
issue #80 / PR #142: "Mentions only" channels can now ring through on
a user-configured list of trigger words in addition to the user's
node name. Useful when a channel is set to "Mentions only" but the
user still wants alerts on specific topics (e.g. a "Lost dog" channel
where "dog" / "missing" should wake the device).

- New `notify_words` NVS pref (12 chars, under the 15-char cap)
  storing a comma-separated word list.
- `services.notifications.get_trigger_words()` /
  `set_trigger_words()` / `matches_trigger_words()` -- the matcher
  is case-insensitive substring, mirroring the existing node-name
  mention semantics so the user doesn't have to think about word
  boundaries.
- `boot.lua` channel/message subscriber ORs the trigger-word match
  against the existing node-name check. A trigger-word hit is
  functionally identical to a name mention -- it also gates the
  DND `dnd_mention` exemption when "Allow channel mentions" is on.
- New `screens/settings/trigger_words.lua` editor screen reached from
  Settings -> Notifications -> Trigger words. Single text input,
  comma-separated.
- `screens/settings/notifications.lua` gains a "Mentions" section
  with a list_item that shows a short summary of the current list
  and opens the editor on press. An `on_enter()` rebuild keeps the
  summary fresh after the editor pops.
- Channel settings sheet (`screens/chat/channel_settings.lua`) help
  text updated to mention the trigger-words affordance so users
  discover it from the place they pick "Mentions only".
- CLAUDE.md Notifications service section + the user manual page
  at `lua/docs/manual/settings/notifications.md` updated to
  document the new pref and editor.

## What's already in place vs new here

Issue #115's "Storage" section proposed a per-channel JSON blob keyed
by channel-name hash; the per-channel notify_mode plumbing shipped
with #80 (`channels.get_notify_mode` / `set_notify_mode`, the channel
settings sheet) and is already covering the "All / Mentions / None"
state. The remaining gap was the **trigger-words editor across all
"Mentions only" channels** -- that's what this PR adds. Per-contact
mute for DMs is explicitly out of scope per the issue.

## Test plan

- [x] `pio run` builds clean on this branch.
- [ ] **Needs hardware QA** -- flash, open Settings -> Notifications, scroll to Mentions, tap Trigger words. Enter a word (e.g. "ping"), save. Pop back; summary on the row should show that word.
- [ ] **Needs hardware QA** -- pick a non-#Public channel, set it to "Mentions only" via Alt+M -> Channel settings. From another node, send a channel message containing the trigger word (case mixed, e.g. "PING test") and confirm the toast fires. Send another without the trigger and confirm no toast.
- [ ] **Needs hardware QA** -- clear the trigger-words list, confirm "Mentions only" channels still ring through on the node name as before.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)