### PR TITLE
feat(map): observed-coverage overlay using per-peer RSSI samples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,15 @@ Services init in order in `lua/boot.lua`:
     from the Map screen on demand; only the reaper is wired here.
     See the GPS track recordings section below for the on-disk
     format.
-15. **power** -- 30 s battery poll that transitions between Normal /
+15. **link_quality** -- subscribes once to `mesh/node_discovered` and
+    keeps a 16-sample RSSI ring buffer per `pub_key_hex`. The Map
+    screen's "Observed coverage" overlay (issue #121, toggled via
+    Alt+M) reads this via `link_quality.get_quality(pub_key_hex)`
+    to size the rings drawn around each peer. In-memory only --
+    RSSI describes a packet, not a node, so persisting across reboots
+    would leak stale numbers (same reasoning as the Node Store's
+    refusal to persist `lastRssi`).
+16. **power** -- 30 s battery poll that transitions between Normal /
     Frugal / Survival tiers with hysteresis. Other services (`gps`,
     `ntp`, `custom_packets`) consult `power.gps_sync_allowed()` /
     `power.ntp_allowed()` / `power.allow_non_dm()` predicates rather

--- a/lua/boot.lua
+++ b/lua/boot.lua
@@ -602,6 +602,12 @@ local function boot_sequence()
         gps_track.reap_unfinalised()
     end)
 
+    -- Per-peer RSSI ring buffer (issue #121). Subscribes to
+    -- mesh/node_discovered; the map's coverage overlay reads it via
+    -- link_quality.get_quality(pub_key_hex). Passive; in-memory only.
+    local link_quality = require("services.link_quality")
+    link_quality.init()
+
     -- Power policy: poll battery every 30 s and back off radio / GPS /
     -- NTP / display in two tiers as the battery drains. See
     -- lua/services/power.lua for the truth table. Starts after the

--- a/lua/docs/manual/maps.md
+++ b/lua/docs/manual/maps.md
@@ -97,13 +97,14 @@ power toggle, so disabling GPS mid-session simply stops sampling.
 ## Observed coverage overlay
 
 The Map screen can draw coarse rings around each known peer (repeaters,
-room servers, contacts) sized by the radio signal you have actually
-heard from them. Toggle it from Alt+M -> "Show observed coverage" /
-"Hide observed coverage".
+room servers, contacts) at the empirical distance from your current
+GPS fix to the peer, styled by the radio signal you have actually
+heard from that peer. Toggle it from Alt+M -> "Show observed coverage"
+/ "Hide observed coverage".
 
 This is an honest, observed heuristic -- not a prediction. The ring
-sits at the empirical distance between your current GPS fix and the
-peer's advertised location. The style depends on the signal bucket:
+sits at the user-to-peer distance, centred on the peer pin. The style
+depends on the signal bucket:
 
 - Solid ring (good link, RSSI better than -90 dBm). Two extra dashed /
   dotted rings extend outward as a "where you might reach" envelope.

--- a/lua/docs/manual/maps.md
+++ b/lua/docs/manual/maps.md
@@ -94,6 +94,27 @@ offers Open / Stats / Delete actions behind Alt+M.
 Nothing is transmitted automatically. The recorder respects the GPS
 power toggle, so disabling GPS mid-session simply stops sampling.
 
+## Observed coverage overlay
+
+The Map screen can draw coarse rings around each known peer (repeaters,
+room servers, contacts) sized by the radio signal you have actually
+heard from them. Toggle it from Alt+M -> "Show observed coverage" /
+"Hide observed coverage".
+
+This is an honest, observed heuristic -- not a prediction. The ring
+sits at the empirical distance between your current GPS fix and the
+peer's advertised location. The style depends on the signal bucket:
+
+- Solid ring (good link, RSSI better than -90 dBm). Two extra dashed /
+  dotted rings extend outward as a "where you might reach" envelope.
+- Dashed ring (marginal link, -90 to -110 dBm). No outer rings -- we
+  cannot honestly project further.
+- Dotted ring (poor link, below -110 dBm).
+
+Peers with fewer than four RSSI samples in the last hour are hidden,
+so a single stale ADVERT will not paint a misleading ring. The overlay
+is off by default and requires a current GPS fix to anchor the rings.
+
 ## Sharing a one-off location
 
 Two share paths exist alongside the broadcast home. Both ride inside

--- a/lua/screens/tools/map.lua
+++ b/lua/screens/tools/map.lua
@@ -401,8 +401,8 @@ function Map:menu()
             and "Hide observed coverage"
             or  "Show observed coverage",
         subtitle = coverage_on
-            and "Stop drawing RSSI-based rings around peers"
-            or  "Draw rings around peers sized by observed signal",
+            and "Stop drawing distance rings around peers"
+            or  "Ring at peer-to-here distance, styled by signal",
         on_press = function()
             ez.storage.set_pref(COVERAGE_PREF, coverage_on and "0" or "1")
             self:set_state({})
@@ -665,20 +665,6 @@ local function make_peers_overlay()
     end
 end
 
--- Haversine distance in metres between two lat/lon points. Used by the
--- coverage overlay to size rings; the precision-vs-cost trade is fine
--- at the scales we draw (kilometre-ish rings on a 320x240 screen).
-local function haversine_m(lat1, lon1, lat2, lon2)
-    local R = 6371000  -- Earth radius (mean) in metres
-    local d2r = math.pi / 180
-    local dlat = (lat2 - lat1) * d2r
-    local dlon = (lon2 - lon1) * d2r
-    local a = math.sin(dlat / 2) ^ 2
-        + math.cos(lat1 * d2r) * math.cos(lat2 * d2r) * math.sin(dlon / 2) ^ 2
-    local c = 2 * math.asin(math.min(1, math.sqrt(a)))
-    return R * c
-end
-
 -- Draw a stippled (dashed / dotted) circle outline. The display
 -- bindings only ship a solid draw_circle, so we walk the angle in
 -- steps and draw / skip pixels by stride. stride 1 = every angle
@@ -749,7 +735,14 @@ local function make_coverage_overlay()
                         -- dot under the pin.
                         local diag = math.sqrt(w * w + h * h)
                         if r >= 6 and r <= diag * 1.2 then
-                            local cx, cy = upx, upy
+                            -- Rings surround each peer at the
+                            -- empirical user-to-peer distance, so the
+                            -- centre is the peer's projected point.
+                            -- Anchoring on the user's GPS dot instead
+                            -- drew every ring as a bullseye through
+                            -- the peer pin, which is not what the
+                            -- "Observed coverage" overlay describes.
+                            local cx, cy = ppx, ppy
                             -- Inner ring: empirical distance, styled
                             -- by the observed bucket.
                             if q.bucket == "good" then

--- a/lua/screens/tools/map.lua
+++ b/lua/screens/tools/map.lua
@@ -9,6 +9,7 @@ local map_view    = require("ezui.widgets.map_view").map_view
 local gps_svc     = require("services.gps")
 local gps_track   = require("services.gps_track")
 local contacts    = require("services.contacts")
+local link_quality = require("services.link_quality")
 
 -- Peer visibility prefs. Defaults intentionally favour "show nearby
 -- infrastructure + my contacts, but not strangers" -- see issue #125.
@@ -17,6 +18,11 @@ local PEER_PREF_REPEATERS = "map_peer_inf"  -- repeaters + room servers
 local PEER_PREF_CONTACTS  = "map_peer_con"  -- chat nodes I've added
 local PEER_PREF_ALL_CHAT  = "map_peer_all"  -- every chat node we've heard
 local PEER_PREF_STALE     = "map_peer_stale" -- include 24h-7d old peers
+
+-- Observed-coverage overlay toggle (issue #121). Off by default so the
+-- map stays uncluttered for users who don't care; the M-key menu turns
+-- it on. NVS key <= 15 chars.
+local COVERAGE_PREF = "map_coverage"
 
 -- Staleness thresholds (seconds since the peer's last ADVERT).
 local STALE_DIM_AGE = 24 * 60 * 60      -- 24h: dim
@@ -388,6 +394,21 @@ function Map:menu()
         end,
     }
 
+    -- ---- Observed coverage overlay (issue #121) ----
+    local coverage_on = pref_on(COVERAGE_PREF, false)
+    items[#items + 1] = {
+        title    = coverage_on
+            and "Hide observed coverage"
+            or  "Show observed coverage",
+        subtitle = coverage_on
+            and "Stop drawing RSSI-based rings around peers"
+            or  "Draw rings around peers sized by observed signal",
+        on_press = function()
+            ez.storage.set_pref(COVERAGE_PREF, coverage_on and "0" or "1")
+            self:set_state({})
+        end,
+    }
+
     -- Share the current map center (the crosshair) as an ezme.sh
     -- location share. The DM variant encrypts to the recipient; the
     -- channel variant is plaintext. Both flow through the same
@@ -565,11 +586,12 @@ local function gather_peers()
             end
             if include and not ancient and (not stale or show_stale) then
                 out[#out + 1] = {
-                    lat   = n.lat,
-                    lon   = n.lon,
-                    role  = n.role or 0,
-                    name  = ascii_safe(n.name or ""),
-                    stale = stale,
+                    lat         = n.lat,
+                    lon         = n.lon,
+                    role        = n.role or 0,
+                    name        = ascii_safe(n.name or ""),
+                    stale       = stale,
+                    pub_key_hex = n.pub_key_hex,
                 }
             end
         end
@@ -637,6 +659,123 @@ local function make_peers_overlay()
                         d.draw_text(lx,     ly,     label, label_ink)
                     end
                     theme.set_font("medium")
+                end
+            end
+        end
+    end
+end
+
+-- Haversine distance in metres between two lat/lon points. Used by the
+-- coverage overlay to size rings; the precision-vs-cost trade is fine
+-- at the scales we draw (kilometre-ish rings on a 320x240 screen).
+local function haversine_m(lat1, lon1, lat2, lon2)
+    local R = 6371000  -- Earth radius (mean) in metres
+    local d2r = math.pi / 180
+    local dlat = (lat2 - lat1) * d2r
+    local dlon = (lon2 - lon1) * d2r
+    local a = math.sin(dlat / 2) ^ 2
+        + math.cos(lat1 * d2r) * math.cos(lat2 * d2r) * math.sin(dlon / 2) ^ 2
+    local c = 2 * math.asin(math.min(1, math.sqrt(a)))
+    return R * c
+end
+
+-- Draw a stippled (dashed / dotted) circle outline. The display
+-- bindings only ship a solid draw_circle, so we walk the angle in
+-- steps and draw / skip pixels by stride. stride 1 = every angle
+-- sample (solid-ish), 2 = dashed, 3+ = dotted. Keeps the perimeter
+-- pixel-counted so we never burn cycles on offscreen circles.
+local function draw_dashed_circle(d, cx, cy, r, color, stride)
+    if r < 2 then
+        d.draw_circle(math.floor(cx), math.floor(cy), math.floor(r), color)
+        return
+    end
+    -- Sample every ~1px along the circumference. 2*pi*r samples is
+    -- finer than we need at small r and reasonable up to r ~120 px
+    -- (the largest ring we'd ever draw before clipping kicks in).
+    local steps = math.max(16, math.floor(2 * math.pi * r))
+    local two_pi = 2 * math.pi
+    for i = 0, steps - 1 do
+        if (i % stride) == 0 then
+            local a = (i / steps) * two_pi
+            local px = math.floor(cx + r * math.cos(a))
+            local py = math.floor(cy + r * math.sin(a))
+            -- A single pixel reads as a dot at the stride densities
+            -- we use (2 / 3 / 4). fill_rect 1x1 is cheaper than a
+            -- draw_line of length 1 and reuses the rect path.
+            d.fill_rect(px, py, 1, 1, color)
+        end
+    end
+end
+
+-- Coverage overlay (issue #121): for each peer with a recent location
+-- and enough RSSI samples in the link_quality buffer, draw rings at
+-- the observed peer-to-here distance. The bucket determines the inner
+-- ring style; "good" links also draw extrapolated outer rings as the
+-- "where can I probably reach" hint.
+--
+-- Honest about limits: this is an _observed_ heuristic, not a
+-- prediction. Peers with fewer than MIN_RECENT samples in the last
+-- hour are skipped (handled inside link_quality.get_quality).
+local function make_coverage_overlay()
+    return function(d, x, y, w, h, project)
+        if not pref_on(COVERAGE_PREF, false) then return end
+        -- Anchor the rings at the user's current GPS fix. Without a
+        -- fix the "distance peer-to-here" has no meaning, so skip the
+        -- whole overlay rather than guessing.
+        local loc = gps_svc.get_location()
+        if not (loc and loc.valid) then return end
+
+        local accent = theme.color("ACCENT")
+        local muted  = theme.color("TEXT_MUTED")
+
+        local peers = gather_peers()
+        for _, peer in ipairs(peers) do
+            if peer.pub_key_hex then
+                local q = link_quality.get_quality(peer.pub_key_hex)
+                if q then
+                    -- Convert the observed distance into screen pixels
+                    -- via the projector. The peer's projected point and
+                    -- the user's projected point are in the same screen
+                    -- frame, so the pixel delta is the ring radius.
+                    local upx, upy = project(loc.lat, loc.lon)
+                    local ppx, ppy = project(peer.lat, peer.lon)
+                    if upx and ppx then
+                        local dx = ppx - upx
+                        local dy = ppy - upy
+                        local r = math.sqrt(dx * dx + dy * dy)
+                        -- Clip cheaply: bail if even the inner ring is
+                        -- entirely beyond the viewport diagonal, or so
+                        -- small a circle round-trips to a degenerate
+                        -- dot under the pin.
+                        local diag = math.sqrt(w * w + h * h)
+                        if r >= 6 and r <= diag * 1.2 then
+                            local cx, cy = upx, upy
+                            -- Inner ring: empirical distance, styled
+                            -- by the observed bucket.
+                            if q.bucket == "good" then
+                                d.draw_circle(math.floor(cx), math.floor(cy),
+                                    math.floor(r), accent)
+                                -- Extrapolated outer rings only for
+                                -- "good" links: we have confidence
+                                -- to project outward to a marginal /
+                                -- poor envelope.
+                                local r_marg = r * 1.6
+                                local r_poor = r * 2.5
+                                if r_marg <= diag * 1.2 then
+                                    draw_dashed_circle(d, cx, cy, r_marg,
+                                        muted, 2)
+                                end
+                                if r_poor <= diag * 1.2 then
+                                    draw_dashed_circle(d, cx, cy, r_poor,
+                                        muted, 3)
+                                end
+                            elseif q.bucket == "marginal" then
+                                draw_dashed_circle(d, cx, cy, r, accent, 2)
+                            else  -- "poor"
+                                draw_dashed_circle(d, cx, cy, r, muted, 3)
+                            end
+                        end
+                    end
                 end
             end
         end
@@ -766,12 +905,14 @@ function Map:build(state)
         zoom        = state.zoom,
         show_labels = state.show_labels,
         overlay_fn  = (function()
-            -- Peers paint first, then any track polyline (saved or
-            -- in-progress), then the GPS dot on top so the user's
-            -- own position is never occluded by a colocated peer
-            -- pin or by the track head dot.
-            local peers_fn = make_peers_overlay()
-            local gps_fn   = make_gps_overlay()
+            -- Coverage rings paint first (deepest layer), then peer
+            -- pins, then any track polyline (saved or in-progress),
+            -- then the GPS dot on top so the user's own position is
+            -- never occluded by a colocated peer pin, ring sample,
+            -- or the track head dot.
+            local coverage_fn = make_coverage_overlay()
+            local peers_fn    = make_peers_overlay()
+            local gps_fn      = make_gps_overlay()
             -- state.track_overlay is set by track_viewer; the live
             -- in-progress polyline is read fresh every frame via
             -- gps_track.live_points() so newly captured points
@@ -779,6 +920,7 @@ function Map:build(state)
             local viewer_pts = state.track_overlay
             local viewer_fn  = viewer_pts and make_track_overlay(viewer_pts) or nil
             return function(d, x, y, w, h, project)
+                coverage_fn(d, x, y, w, h, project)
                 peers_fn(d, x, y, w, h, project)
                 if viewer_fn then viewer_fn(d, x, y, w, h, project) end
                 local live_pts = gps_track.live_points()

--- a/lua/services/link_quality.lua
+++ b/lua/services/link_quality.lua
@@ -1,0 +1,136 @@
+-- services.link_quality: per-peer RSSI ring buffer used by the map's
+-- "Observed coverage" overlay (issue #121).
+--
+-- Subscribes once to `mesh/node_discovered` and records the rssi field
+-- for each peer keyed by pub_key_hex. The map overlay then asks
+-- `get_quality(pub_key_hex)` for a coarse bucket so it can render
+-- concentric rings sized by the user-to-peer distance.
+--
+-- Deliberately tiny: 16 samples per peer, in-memory only. The signal
+-- describes a packet, not a node, so persisting it across reboots
+-- would just leak stale numbers. Same reasoning as the node store's
+-- decision NOT to persist lastRssi (see Node Store section of
+-- CLAUDE.md).
+
+local M = {}
+
+-- Cap per peer. The issue suggests "start with 16"; 16 is plenty for
+-- a stable median without bloating RAM (we keep this for every peer
+-- we've ever heard, bounded only by what the node table holds).
+local MAX_SAMPLES = 16
+
+-- Time window for "recent" samples. The overlay hides peers with
+-- fewer than MIN_RECENT samples inside this window so a single
+-- ancient ADVERT does not paint a misleading ring.
+local RECENT_WINDOW_MS = 60 * 60 * 1000  -- 1 hour
+local MIN_RECENT       = 4
+
+-- RSSI bucket thresholds (dBm). LoRa link quality is roughly:
+--   >= -90  good          (clear comms, multi-km in open air)
+--   >= -110 marginal      (decodes but loss climbs)
+--   <  -110 poor          (intermittent, near the noise floor)
+-- These are heuristics; we surface them through a coarse bucket
+-- because the underlying number is noisy and meaningless to most
+-- users without context.
+local RSSI_GOOD     = -90
+local RSSI_MARGINAL = -110
+
+-- samples[pub_key_hex] = { { rssi = number, t_ms = millis }, ... }
+local samples = {}
+local subscribed = false
+
+local function now_ms()
+    return ez.system.millis()
+end
+
+-- Insert a sample, dropping the oldest once we hit MAX_SAMPLES.
+local function record(pub_key_hex, rssi)
+    if type(pub_key_hex) ~= "string" or pub_key_hex == "" then return end
+    if type(rssi) ~= "number" then return end
+    -- Filter out the C++ default of 0 dBm (means "no measurement"
+    -- on this code path, not "a perfect packet"). Real LoRa RSSI is
+    -- always negative in our deployment.
+    if rssi >= 0 then return end
+
+    local ring = samples[pub_key_hex]
+    if not ring then
+        ring = {}
+        samples[pub_key_hex] = ring
+    end
+    ring[#ring + 1] = { rssi = rssi, t_ms = now_ms() }
+    if #ring > MAX_SAMPLES then
+        table.remove(ring, 1)
+    end
+end
+
+-- Median of an array of numbers. Stable for short lists (we sort a
+-- copy, so the caller's array is left alone). Returns nil for empty.
+local function median(values)
+    local n = #values
+    if n == 0 then return nil end
+    local sorted = {}
+    for i = 1, n do sorted[i] = values[i] end
+    table.sort(sorted)
+    if n % 2 == 1 then return sorted[(n + 1) // 2] end
+    return (sorted[n // 2] + sorted[n // 2 + 1]) / 2
+end
+
+-- get_quality(pub_key_hex) -> { bucket, rssi, samples } or nil
+--
+-- bucket  "good" | "marginal" | "poor"
+-- rssi    smoothed (median) RSSI in dBm
+-- samples count of samples used (inside RECENT_WINDOW_MS)
+--
+-- Returns nil when the peer is unknown or has fewer than MIN_RECENT
+-- recent samples. The overlay treats nil as "skip this peer".
+function M.get_quality(pub_key_hex)
+    if type(pub_key_hex) ~= "string" then return nil end
+    local ring = samples[pub_key_hex]
+    if not ring then return nil end
+
+    local cutoff = now_ms() - RECENT_WINDOW_MS
+    local recent = {}
+    for _, s in ipairs(ring) do
+        if s.t_ms >= cutoff then
+            recent[#recent + 1] = s.rssi
+        end
+    end
+    if #recent < MIN_RECENT then return nil end
+
+    local r = median(recent)
+    local bucket
+    if r >= RSSI_GOOD then
+        bucket = "good"
+    elseif r >= RSSI_MARGINAL then
+        bucket = "marginal"
+    else
+        bucket = "poor"
+    end
+    return { bucket = bucket, rssi = r, samples = #recent }
+end
+
+-- Test seam: feed a sample manually. Used by host-side bench and the
+-- packet sniffer's signal-test mode; not part of the public surface.
+function M._record(pub_key_hex, rssi)
+    record(pub_key_hex, rssi)
+end
+
+-- Test seam: wipe all state. Not on the public surface either.
+function M._reset()
+    samples = {}
+end
+
+function M.init()
+    if subscribed then return end
+    subscribed = true
+    -- mesh/node_discovered fires on every ADVERT we successfully
+    -- parse. The payload carries pub_key_hex (when the ADVERT
+    -- included a pubkey, which is always for chat/repeater/room
+    -- adverts) and rssi as float dBm.
+    ez.bus.subscribe("mesh/node_discovered", function(_topic, node)
+        if not node then return end
+        record(node.pub_key_hex, node.rssi)
+    end)
+end
+
+return M

--- a/src/lua/bindings/mesh_bindings.cpp
+++ b/src/lua/bindings/mesh_bindings.cpp
@@ -85,6 +85,24 @@
 // end)
 // @end
 
+// @bus mesh/node_discovered
+// @brief Posted on every ADVERT received from a peer node
+// @payload table {path_hash, name, rssi, snr, role, advert_timestamp, age_seconds, last_seen, pub_key_hex?, has_location, lat?, lon?}
+// @description
+// Fires unconditionally on every ADVERT, regardless of whether Lua
+// installed the deprecated ez.mesh.on_node_discovered callback.
+// Published from the default setNodeCallback in src/main.cpp (and from
+// the legacy on_node_discovered registration path, which now routes
+// through the same helper) via postNodeDiscoveredBus() so subscribers
+// like services.link_quality and services.contacts receive ADVERTs
+// reliably. pub_key_hex / lat / lon are present only when the ADVERT
+// carried them (see has_location for the lat/lon case).
+// @example
+// ez.bus.subscribe("mesh/node_discovered", function(node)
+//     print(node.name, node.rssi, node.has_location and node.lat or "?")
+// end)
+// @end
+
 // =============================================================================
 
 // External reference to the global mesh instance

--- a/src/lua/bindings/mesh_bindings.cpp
+++ b/src/lua/bindings/mesh_bindings.cpp
@@ -6,6 +6,7 @@
 #include "../../mesh/meshcore.h"
 #include "../../mesh/identity.h"
 #include "bus_bindings.h"
+#include "mesh_bindings.h"
 #include <deque>
 
 // @module ez.mesh
@@ -513,6 +514,21 @@ static void pushNodeTable(lua_State* L, const NodeInfo& node) {
     }
 }
 
+// Public helper: post a "mesh/node_discovered" event to the global
+// MessageBus with the full node payload. Declared in mesh_bindings.h
+// and called from main.cpp's default setNodeCallback so the topic
+// fires on every ADVERT regardless of whether Lua ever installed the
+// deprecated ez.mesh.on_node_discovered callback. Copies the
+// NodeInfo into the lambda so the publishing thread does not have to
+// keep the caller's reference alive across the bus dispatch.
+void postNodeDiscoveredBus(const NodeInfo& node) {
+    NodeInfo nodeCopy = node;
+    MessageBus::instance().postTable("mesh/node_discovered",
+        [nodeCopy](lua_State* L) {
+            pushNodeTable(L, nodeCopy);
+        });
+}
+
 // Helper: Push group packet info as Lua table onto stack
 static void pushGroupPacketTable(lua_State* L, uint8_t channelHash, const uint8_t* data, size_t dataLen,
                                   uint8_t senderHash, float rssi, float snr,
@@ -607,11 +623,11 @@ LUA_FUNCTION(l_mesh_on_node_discovered) {
                     }
                 }
 
-                // Post table to message bus with full node data
-                NodeInfo nodeCopy = node;
-                MessageBus::instance().postTable("mesh/node_discovered", [nodeCopy](lua_State* L) {
-                    pushNodeTable(L, nodeCopy);
-                });
+                // Post table to message bus with full node data.
+                // Shared helper -- main.cpp's default setNodeCallback
+                // calls this too, so bus subscribers fire whether or
+                // not Lua ever installed this deprecated callback.
+                postNodeDiscoveredBus(node);
             });
         }
     } else if (lua_isnil(L, 1)) {

--- a/src/lua/bindings/mesh_bindings.h
+++ b/src/lua/bindings/mesh_bindings.h
@@ -1,0 +1,21 @@
+// ez.mesh module bindings -- internal interface
+//
+// Most of the mesh binding surface is registered through
+// lua_register_module() in mesh_bindings.cpp. This header exposes the
+// few helpers that have to be reachable from outside that translation
+// unit -- specifically, the bus-publishing helper for ADVERT discovery
+// events, which has to fire from the default C++ setNodeCallback in
+// main.cpp so that bus subscribers (services.link_quality,
+// services.contacts) receive events regardless of whether Lua ever
+// called the deprecated ez.mesh.on_node_discovered binding.
+
+#pragma once
+
+struct NodeInfo;
+
+// Post a "mesh/node_discovered" event to the global MessageBus with
+// the full node payload (the same shape pushNodeTable produces inside
+// mesh_bindings.cpp). Safe to call from any thread / context that
+// MessageBus::postTable supports; it dispatches on the Lua main
+// thread via the bus queue.
+void postNodeDiscoveredBus(const NodeInfo& node);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include "hardware/gps.h"
 #include "hardware/touch.h"
 #include "lua/bindings/touch_bindings.h"
+#include "lua/bindings/mesh_bindings.h"
 #include "mesh/meshcore.h"
 #include "lua/async.h"
 #include "settings.h"
@@ -201,6 +202,13 @@ void setup() {
 
             mesh->setNodeCallback([](const NodeInfo& node) {
                 Serial.printf("Node discovered: %02X (%s)\n", node.pathHash, node.name);
+                // Post to MessageBus so Lua subscribers (link_quality,
+                // contacts, ...) receive every ADVERT. Without this the
+                // "mesh/node_discovered" topic only fired when Lua had
+                // installed the deprecated on_node_discovered callback,
+                // which nothing does in practice -- so bus subscribers
+                // silently never saw a single event.
+                postNodeDiscoveredBus(node);
             });
 
             // Offload X25519 ECDH to the AsyncIO worker (Core 0). The


### PR DESCRIPTION
## Summary

Adds an opt-in map overlay that draws rings around each known peer
(repeater, room server, contact with a saved location) sized by the
empirical distance from the user's current GPS fix to the peer, styled
by the observed RSSI bucket:

- **Solid** ring for a *good* link (>= -90 dBm), plus extrapolated
  **dashed** / **dotted** outer rings as a "where you might reach"
  envelope.
- **Dashed** ring only for a *marginal* link (-90..-110 dBm) -- we
  cannot honestly project further.
- **Dotted** ring only for a *poor* link (below -110 dBm).

The overlay is anchored at the user's current GPS fix, so without a
fix the rings simply do not paint -- the "distance peer-to-here"
heuristic would have no meaning otherwise.

A new `services/link_quality` module subscribes once to
`mesh/node_discovered` and keeps a 16-sample, in-memory ring buffer
per `pub_key_hex`. The overlay reads
`link_quality.get_quality(pub_key_hex)` and skips peers with fewer
than four samples inside the last hour, so a single stale ADVERT
cannot paint a misleading ring.

The toggle lives behind Alt+M -> "Show observed coverage" /
"Hide observed coverage" (NVS key `map_coverage`, off by default).

## Notes on design

- **In-memory only.** RSSI describes a packet, not a node, so
  persisting across reboots would just leak stale numbers. Mirrors
  the Node Store's deliberate refusal to persist `lastRssi`.
- **Labeled "observed", not "predicted".** The issue is explicit
  that this is a heuristic. The doc text and UI strings reflect
  that.
- **Dashed/dotted rings** are emulated by walking the perimeter and
  drawing every Nth pixel (`fill_rect 1x1`). The display bindings
  ship only a solid `draw_circle`; this keeps things in pure Lua
  without a new binding.
- Service init slot 15 in `boot.lua`, between `gps_track` and
  `power`. CLAUDE.md service list and `lua/docs/manual/maps.md`
  updated in the same commit.

## Test plan

- [x] `pio run` builds clean (firmware: 62.2% flash).
- [x] `luac32 -p` parses all touched Lua files.
- [ ] **Needs hardware QA**: flash to a T-Deck, enable the overlay
      from Alt+M, confirm rings render around recently-heard peers
      with locations and a current GPS fix. Confirm rings disappear
      when the toggle is off, when GPS has no fix, and when no peer
      has 4+ samples in the last hour.
- [ ] **Needs hardware QA**: verify ring style maps correctly to
      observed RSSI -- watch a single peer's RSSI move across the
      -90 / -110 dBm boundaries and confirm the inner ring switches
      between solid / dashed / dotted.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)