### PR TITLE
fix(display): raise idle-dim floor from 10 to 30

### DIFF
--- a/lua/ezui/screen.lua
+++ b/lua/ezui/screen.lua
@@ -890,7 +890,7 @@ function screen.update()
                     end
                     local clamped = math.floor(
                         screen._normal_brightness * ss_bright_pct / 100)
-                    if clamped < 10 then clamped = 10 end
+                    if clamped < 30 then clamped = 30 end
                     ez.display.set_brightness(clamped)
                     ss2.start()
                     -- Session lockscreen (issue #119): arm the lock
@@ -917,7 +917,7 @@ function screen.update()
                         ez.storage.get_pref("ss_bright", 30)) or 30
                     local dimmed = math.floor(
                         screen._normal_brightness * ss_bright_pct / 100)
-                    if dimmed < 10 then dimmed = 10 end
+                    if dimmed < 30 then dimmed = 30 end
                     ez.display.set_brightness(dimmed)
                     screen.idle_stage = 1
                 end


### PR DESCRIPTION
## Summary

- Bump the brightness floor used by the pre-dim (stage 1) and screensaver-active (stage 2) stages from `10/255` to `30/255` in `lua/ezui/screen.lua`.
- At low `screen_bright` or low `ss_bright` % the dim stages were landing on the 10/255 floor, which is dark enough to look like the panel is already off. 30/255 keeps the display legibly visible while still clearly dimmed.
- Panel-off (stage 3) is unchanged.

## Test plan

- [ ] `pio run` clean (verified locally)
- [ ] needs hardware QA: set `screen_bright` low, let the device idle past `predim_lead` — screen should dim but stay visibly lit, not look fully off
- [ ] needs hardware QA: let the screensaver fire — same expectation while the screensaver overlay is up
- [ ] needs hardware QA: continue idling past `disp_off_delay` — panel still goes fully off

🤖 Generated with [Claude Code](https://claude.com/claude-code)