### PR TITLE
fix(chat): show reactions on the DM sender's side

### DIFF
--- a/lua/screens/chat/dm_conversation.lua
+++ b/lua/screens/chat/dm_conversation.lua
@@ -16,6 +16,19 @@ require("screens.chat.chat_common")  -- registers chat_bubble node type
 
 local screen_mod = require("ezui.screen")
 
+-- Returns the unix-seconds timestamp the *peer* will hash against. Self-
+-- sent bubbles store the radio's millis() value in `msg.timestamp` for
+-- ordering / display / dedup, but the wire plaintext (and therefore the
+-- receiver's stored `msg.timestamp`) carries unix seconds in `wire_ts`.
+-- Reactions hash over the wire value so both peers agree; inbound bubbles
+-- don't have `wire_ts` because `msg.timestamp` already IS the wire value.
+local function reaction_ts(msg)
+    if msg.is_self and msg.wire_ts and msg.wire_ts > 0 then
+        return msg.wire_ts
+    end
+    return msg.timestamp
+end
+
 -- Build the share-specific menu items for an inbound message whose
 -- text contains an ezme.sh share URL. Returns a list of list_item
 -- nodes, possibly empty. Self-sent shares get a non-actionable status
@@ -160,7 +173,7 @@ local function show_context_menu(self, key, msg, msg_index)
             local target_sender = msg.is_self
                 and ez.mesh.get_public_key_hex() or key
             local target_hash = reactions_svc.compute_msg_hash(
-                target_sender, msg.timestamp, msg.text)
+                target_sender, reaction_ts(msg), msg.text)
             if target_hash then
                 actions[#actions + 1] = ui.list_item({
                     title = "React...",
@@ -450,7 +463,7 @@ function DMConversation:build(state)
             local share_sender = msg.is_self and self_pub or key
             local target_sender = msg.is_self and self_pub or key
             local target_hash = reactions_svc.compute_msg_hash(
-                target_sender, msg.timestamp, msg.text)
+                target_sender, reaction_ts(msg), msg.text)
             local reaction_list = target_hash
                 and reactions_svc.compress(key, target_hash) or nil
             -- Drop the array when empty so the bubble renderer's


### PR DESCRIPTION
## Summary

Two related bugs in the DM reaction / read-receipt path. The user-visible symptom was: "I see the reaction on the sending side but not the receiving side". Both root causes had to be fixed to make reactions round-trip reliably.

### 1. `dm_conversation.lua` hashed self-sent bubbles against `msg.timestamp` (millis), not `msg.wire_ts` (unix s)

Self-sent bubbles store `ez.system.millis()` in `msg.timestamp` for ordering/display/dedup. The wire plaintext carries unix seconds (`wire_ts`), which is what the *peer* hashes against when they react. The conversation screen was feeding millis into `compute_msg_hash`, so the bucket lookup missed and the pill never painted. Mirrors the existing read-receipt pattern at `direct_messages.lua:881-883`.

### 2. `pack_u32le` lost precision because the runtime is `LUA_32BITS=1`

`direct_messages.lua` and `channels.lua` both packed u32 timestamps with float division:

```lua
math.floor(v / 256) % 256
```

The firmware compiles Lua with `LUA_32BITS=1`, so the runtime uses single-precision floats. At the magnitude of current unix-second timestamps (~1.78e9) the float32 ULP is 128, so `v / 256` is wrong by enough that `math.floor` returns the wrong quotient for many inputs. Empirically:

| wire_ts    | bytes after pack | decoded value |
| ---------- | ---------------- | ------------- |
| 1778934420 | 94 62 08 6A      | 1778934420    |
| 1778934654 | 7E 63 08 6A      | 1778934654    |
| 1778935001 | D9 65 08 6A      | 1778935257 (+256) |
| 1778935511 | D7 67 08 6A      | 1778935767 (+256) |

So even after fix #1, ~half of all DMs would silently land on the receiver with `ts` shifted by +256 s, breaking every cross-peer hash (ACK match, read receipts, reactions). The receive-side decoder uses integer arithmetic on small bytes, so it correctly decoded whatever bytes were on the wire -- the byte sequence itself was wrong. Channel GRP_TXT inner timestamps had the same bug.

Fix: switch to integer bitwise ops, which stay in the int subtype and are exact. `v & 0xFFFFFFFF` preserves the historical wrap-negatives-into-u32 behaviour.

## How I verified

Two T-Decks over USB (`/dev/ttyACM0` = Node-A2EF60, `/dev/ttyACM1` = Node-65AE39):

1. **Bug #1 reproduced.** A sent DM, B reacted "+1". A's reactions store had the entry under hash `A966E0A2` (computed from wire_ts), but A's UI computed `86D1EBFD` from `msg.timestamp` (millis) -- lookup missed, no pill.
2. **Fix #1 applied.** A's UI shows the `<3` pill below the bubble. Confirmed via `--text` capture.
3. **Bug #2 reproduced.** A sent `drift-A2B-1778935511`; B stored it as `ts = 1778935767`, exactly +256 s.
4. **Fix #2 applied.** Re-sent: wire_ts and stored ts agree to the second in both A->B and B->A directions. Reverse-direction reaction (A reacts on a bubble B sent) now lights up B's `+1` pill, confirming the symmetric case is healed.

## Test plan

- [x] `pio run` clean
- [x] Flash both T-Decks
- [x] A->B DM + B reacts -> pill on A
- [x] B->A DM + A reacts -> pill on B (was previously broken by both bugs)
- [x] DM wire_ts == stored ts for a value previously corrupted by pack_u32le
- [ ] Channel send: not exercised in this session; same fix applied to `channels.lua` by symmetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)