### PR TITLE
feat(files): grid view with thumbnails + image viewer paging

### DIFF
--- a/lua/screens/tools/file_manager.lua
+++ b/lua/screens/tools/file_manager.lua
@@ -1,12 +1,16 @@
 -- File Manager: Browse and manage files on LittleFS and SD card
 -- TAB: switch storage, ENTER: open/actions (images: view),
 -- M: actions menu for current item, BACKSPACE: go up, Q: quit
--- Hovering an image for ~400ms previews it in the bottom-right corner.
+-- Two layouts: list (default, hover-preview the image bottom-right) and
+-- grid (icons + inline image thumbnails). The active layout is persisted
+-- in the `fm_view` NVS pref and toggled via the Alt+M global menu.
 
 local ui = require("ezui")
 local theme = require("ezui.theme")
 local node_mod = require("ezui.node")
 local screen_mod = require("ezui.screen")
+local focus_mod = require("ezui.focus")
+local icons = require("ezui.icons")
 local apps = require("services.apps")
 
 local FileMgr = { title = "Files" }
@@ -14,6 +18,11 @@ local FileMgr = { title = "Files" }
 local function is_image_name(name)
     local l = name:lower()
     return l:match("%.jpe?g$") ~= nil or l:match("%.png$") ~= nil
+end
+
+local function get_ext(name)
+    local ext = name:match("%.([^./]+)$")
+    return ext and ext:upper() or ""
 end
 
 -- Shared hover-preview state. A single file manager instance lives at a time
@@ -67,6 +76,294 @@ if not node_mod.handler("thumb_overlay") then
                 d.draw_jpeg(dx, dy, preview_data, scale, scale)
             end
             d.clear_clip_rect()
+        end,
+    })
+end
+
+-- ---------------------------------------------------------------------------
+-- Grid view: thumbnail cache and file_tile node
+-- ---------------------------------------------------------------------------
+
+-- Tile metrics. Tuned for a 4-column grid on a 320 px screen with 4 px
+-- padding either side -- 4 * 72 = 288 + 3 * 8 (gaps) = 312, leaving the
+-- last 8 px for the scrollbar track. The icon area is the top square of
+-- the tile; the label occupies the remaining strip below it.
+local GRID_COLS    = 4
+local TILE_W       = 72
+local TILE_ICON    = 48
+local TILE_H       = 76
+local TILE_GAP_X   = 8
+local TILE_GAP_Y   = 6
+local TILE_PAD_X   = 4
+
+-- LRU sprite cache for image thumbnails. Sprites live in PSRAM so the
+-- cap is set by how many we want resident at once (~6 KB per 48x48 RGB565
+-- sprite). 12 entries cover one full screen of the 4x3 visible grid plus
+-- a few off-screen tiles the user just scrolled past.
+local THUMB_CAP = 12
+local thumb_cache = {}    -- path -> { sprite, w, h, last_used }
+local thumb_loading = {}  -- path -> true while async_read is in flight
+local thumb_failed = {}   -- path -> true if decode failed (don't retry every frame)
+
+local function thumb_evict_oldest()
+    local oldest_path, oldest_t
+    for p, e in pairs(thumb_cache) do
+        if not oldest_t or e.last_used < oldest_t then
+            oldest_path, oldest_t = p, e.last_used
+        end
+    end
+    if oldest_path then
+        local sp = thumb_cache[oldest_path].sprite
+        if sp then sp:destroy() end
+        thumb_cache[oldest_path] = nil
+    end
+end
+
+local function thumb_cache_count()
+    local n = 0
+    for _ in pairs(thumb_cache) do n = n + 1 end
+    return n
+end
+
+-- Returns the cached sprite for `path` (touching its LRU stamp) or nil.
+-- A nil return kicks off an async decode -- the caller is expected to
+-- render a placeholder this frame and rely on screen_mod.invalidate() in
+-- the loader to redraw once the sprite lands. Already-failed paths short-
+-- circuit so a bad image doesn't block the worker on every paint.
+local function request_thumb(path)
+    if not path or path == "" then return nil end
+    local entry = thumb_cache[path]
+    if entry then
+        entry.last_used = ez.system.millis()
+        return entry
+    end
+    if thumb_loading[path] or thumb_failed[path] then return nil end
+    thumb_loading[path] = true
+
+    local async = require("ezui.async")
+    async.task(function()
+        local data = async_read(path)
+        if not data or #data == 0 then
+            thumb_loading[path] = nil
+            thumb_failed[path] = true
+            return
+        end
+        local w, h = ez.display.get_image_size(data)
+        if not w or not h or w <= 0 or h <= 0 then
+            thumb_loading[path] = nil
+            thumb_failed[path] = true
+            return
+        end
+        local scale = math.min(TILE_ICON / w, TILE_ICON / h)
+        if scale > 1 then scale = 1 end  -- never upscale a small image
+        local sw = math.max(1, math.floor(w * scale))
+        local sh = math.max(1, math.floor(h * scale))
+        local sp = ez.display.create_sprite(sw, sh)
+        if not sp then
+            thumb_loading[path] = nil
+            thumb_failed[path] = true
+            return
+        end
+        local ok
+        if path:lower():match("%.png$") then
+            ok = sp:draw_png(0, 0, data, scale, scale)
+        else
+            ok = sp:draw_jpeg(0, 0, data, scale, scale)
+        end
+        if not ok then
+            sp:destroy()
+            thumb_loading[path] = nil
+            thumb_failed[path] = true
+            return
+        end
+        while thumb_cache_count() >= THUMB_CAP do
+            thumb_evict_oldest()
+        end
+        thumb_cache[path] = {
+            sprite    = sp,
+            w         = sw,
+            h         = sh,
+            last_used = ez.system.millis(),
+        }
+        thumb_loading[path] = nil
+        screen_mod.invalidate()
+    end)
+    return nil
+end
+
+local function clear_thumb_cache()
+    for _, e in pairs(thumb_cache) do
+        if e.sprite then e.sprite:destroy() end
+    end
+    thumb_cache = {}
+    thumb_loading = {}
+    thumb_failed = {}
+end
+
+-- Extension-badge colors so the tile gives a hint about the file type
+-- without needing a full icon set. Falls back to a neutral grey for the
+-- long tail of less-common extensions.
+local EXT_COLORS = {
+    -- text-like
+    TXT = 0x7BCF, MD = 0x7BCF, LOG = 0x7BCF, JSON = 0x7BCF, CSV = 0x7BCF,
+    -- code
+    LUA = 0x4ED4, C = 0x4ED4, H = 0x4ED4, CPP = 0x4ED4, PY = 0x4ED4, SH = 0x4ED4,
+    -- audio
+    WAV = 0xFBE0, MP3 = 0xFBE0, OGG = 0xFBE0,
+    -- archive
+    ZIP = 0xC618, GZ = 0xC618, TAR = 0xC618,
+    -- binary / firmware
+    BIN = 0x4208, ELF = 0x4208, FW = 0x4208,
+    -- maps / app-specific
+    TDMAP = 0x07E0, EZTRACK = 0x07E0,
+}
+
+-- `file_tile` is the focusable grid cell. It carries enough metadata in
+-- its node table for on_press / on_long_press / draw to dispatch without
+-- closing over per-frame state (the grid rebuilds on every set_state, so
+-- closures here would create garbage on each scroll).
+if not node_mod.handler("file_tile") then
+    node_mod.register("file_tile", {
+        focusable = true,
+
+        measure = function(n, mw, mh) return TILE_W, TILE_H end,
+
+        draw = function(n, d, x, y, w, h)
+            local focused = n._focused
+            local accent = theme.color("ACCENT")
+
+            -- Selection plate behind the whole tile. SURFACE_ALT keeps
+            -- the focus mark readable on both dark and light themes
+            -- without painting an opaque block.
+            if focused then
+                d.fill_round_rect(x, y, w, h, 6, theme.color("SURFACE_ALT"))
+                d.draw_round_rect(x, y, w, h, 6, accent)
+            end
+
+            -- Icon area: TILE_ICON x TILE_ICON, centered horizontally
+            -- near the top of the tile.
+            local icon_x = x + math.floor((w - TILE_ICON) / 2)
+            local icon_y = y + 4
+            local kind = n._kind
+
+            if kind == "dir" then
+                local icon = icons.folder
+                if icon and icon.lg then
+                    local plate = icon.color or theme.color("ACCENT_DIM")
+                    local inset = icons._plate_inset or 4
+                    local pw = icons._plate_size or (TILE_ICON - 2 * inset)
+                    d.fill_round_rect(icon_x + inset - 1, icon_y + inset - 1,
+                                      pw + 2, pw + 2,
+                                      icons._plate_radius or 8, plate)
+                    d.draw_png(icon_x, icon_y, icon.lg)
+                    if icons._shim then
+                        d.draw_png(icon_x, icon_y, icons._shim)
+                    end
+                end
+            elseif kind == "image" then
+                local thumb = request_thumb(n._file_path)
+                -- Background plate behind the thumbnail so transparent /
+                -- letterboxed images don't blend into the screen bg.
+                d.fill_round_rect(icon_x, icon_y, TILE_ICON, TILE_ICON,
+                                  4, theme.color("SURFACE"))
+                d.draw_round_rect(icon_x, icon_y, TILE_ICON, TILE_ICON,
+                                  4, theme.color("BORDER"))
+                if thumb and thumb.sprite then
+                    local tx = icon_x + math.floor((TILE_ICON - thumb.w) / 2)
+                    local ty = icon_y + math.floor((TILE_ICON - thumb.h) / 2)
+                    thumb.sprite:push(tx, ty)
+                else
+                    -- Loading or failed placeholder: dotted dashes
+                    -- centered so the user knows a thumb is coming.
+                    theme.set_font("tiny_aa")
+                    local msg = thumb_failed[n._file_path] and "?" or "..."
+                    local tw = theme.text_width(msg)
+                    d.draw_text(icon_x + math.floor((TILE_ICON - tw) / 2),
+                                icon_y + math.floor(TILE_ICON / 2) - 4,
+                                msg, theme.color("TEXT_MUTED"))
+                end
+            else
+                -- Extension badge: rounded rect with the upper-case
+                -- extension. Long extensions are truncated to 4 chars
+                -- so the label still fits horizontally inside the plate.
+                local ext = n._ext or ""
+                if #ext > 4 then ext = ext:sub(1, 4) end
+                local plate = EXT_COLORS[ext] or theme.color("BORDER")
+                local inset = icons._plate_inset or 4
+                local pw = icons._plate_size or (TILE_ICON - 2 * inset)
+                d.fill_round_rect(icon_x + inset, icon_y + inset,
+                                  pw, pw,
+                                  icons._plate_radius or 8, plate)
+                if ext ~= "" then
+                    theme.set_font("tiny_aa", "bold")
+                    local tw = theme.text_width(ext)
+                    local fh = theme.font_height()
+                    d.draw_text(
+                        icon_x + math.floor((TILE_ICON - tw) / 2),
+                        icon_y + math.floor((TILE_ICON - fh) / 2),
+                        ext, theme.color("TEXT"))
+                end
+            end
+
+            -- Label below the icon. Two-line max via wrap-then-truncate
+            -- so file extensions don't get hidden when names are long.
+            theme.set_font("tiny_aa", focused and "bold" or "regular")
+            local label = n._label or ""
+            local fh = theme.font_height()
+            local label_y = y + 4 + TILE_ICON + 2
+            local max_w = w - 4
+            -- Truncate with ellipsis if the name doesn't fit a single
+            -- line at the tiny font size. The tile is too narrow to
+            -- justify a second line + the focused state already widens
+            -- the label slightly via the bold weight.
+            local lw = theme.text_width(label)
+            if lw > max_w then
+                local trimmed = label
+                while #trimmed > 1 and theme.text_width(trimmed .. "...") > max_w do
+                    trimmed = trimmed:sub(1, #trimmed - 1)
+                end
+                label = trimmed .. "..."
+                lw = theme.text_width(label)
+            end
+            local lx = x + math.floor((w - lw) / 2)
+            d.draw_text(lx, label_y, label, theme.color("TEXT"))
+        end,
+
+        on_activate = function(n, key)
+            if n.on_press then n.on_press() end
+            return "handled"
+        end,
+
+        on_long_press = function(n)
+            if n.on_long_press then n.on_long_press() end
+            return "handled"
+        end,
+
+        on_press = function(n)
+            if n.on_press then n.on_press() end
+            return "handled"
+        end,
+
+        -- Grid navigation. LEFT/RIGHT step one tile; UP/DOWN step a full
+        -- row (GRID_COLS tiles). The focus chain is built in row-major
+        -- order so a fixed stride is correct as long as every row is
+        -- full -- when the last row is short, UP/DOWN clamp at the
+        -- chain ends, which is the same behaviour as a list.
+        on_key = function(n, key)
+            if key.special == "LEFT" then
+                focus_mod.prev()
+                return "handled"
+            elseif key.special == "RIGHT" then
+                focus_mod.next()
+                return "handled"
+            elseif key.special == "UP" then
+                for _ = 1, GRID_COLS do focus_mod.prev() end
+                return "handled"
+            elseif key.special == "DOWN" then
+                for _ = 1, GRID_COLS do focus_mod.next() end
+                return "handled"
+            end
+            return nil
         end,
     })
 end
@@ -312,6 +609,193 @@ local function show_dir_menu(mgr, path, dir_name)
     screen_mod.push(inst)
 end
 
+-- Activate the file under `f` in `path`. Shared between list and grid
+-- so the press/activate semantics match across both views: image files
+-- open the viewer, registered app handlers take precedence over the
+-- context menu, and unknown extensions fall through to the menu.
+local function activate_file(mgr, path, f)
+    local full = path .. f.name
+    if is_image_name(f.name) then
+        local IV = require("screens.tools.image_viewer")
+        screen_mod.push(screen_mod.create(IV, IV.initial_state(full)))
+    elseif apps.open(full) then
+        -- A registered app handled the open. The registry is
+        -- responsible for pushing the relevant screen.
+    else
+        show_file_menu(mgr, path, f)
+    end
+end
+
+-- ---------------------------------------------------------------------------
+-- List view: original layout, hover-preview an image in the bottom-right
+-- ---------------------------------------------------------------------------
+
+local function build_list_content(self, path, files)
+    local content_items = {}
+
+    -- Parent directory entry (when not at root)
+    if path ~= "/fs/" and path ~= "/sd/" then
+        content_items[#content_items + 1] = ui.list_item({
+            title = "..",
+            compact = true,
+            on_press = function()
+                self:set_state({ path = get_parent(path) })
+            end,
+        })
+    end
+
+    -- New folder action
+    content_items[#content_items + 1] = ui.list_item({
+        title = "+ New Folder",
+        compact = true,
+        on_press = function()
+            prompt_name("New Folder", "", function(name)
+                ez.storage.mkdir(path .. name)
+                self:set_state({ path = path })
+            end)
+        end,
+    })
+
+    if files then
+        for _, f in ipairs(files) do
+            if f.is_dir then
+                content_items[#content_items + 1] = ui.list_item({
+                    title = f.name .. "/",
+                    compact = true,
+                    on_press = function()
+                        self:set_state({ path = path .. f.name .. "/" })
+                    end,
+                    on_long_press = function()
+                        show_dir_menu(self, path, f.name)
+                    end,
+                })
+            else
+                local full = path .. f.name
+                local image = is_image_name(f.name)
+                content_items[#content_items + 1] = ui.list_item({
+                    title = f.name,
+                    trailing = format_size(f.size),
+                    compact = true,
+                    -- Extra fields read by FileMgr:update() to drive the hover preview
+                    _file_path = full,
+                    _is_image  = image,
+                    on_press = function() activate_file(self, path, f) end,
+                    on_long_press = function() show_file_menu(self, path, f) end,
+                })
+            end
+        end
+    end
+
+    if not files or #files == 0 then
+        content_items[#content_items + 1] = ui.padding({ 20, 10, 10, 10 },
+            ui.text_widget("Empty directory", {
+                color = "TEXT_MUTED",
+                text_align = "center",
+            })
+        )
+    end
+
+    return ui.vbox({ gap = 0 }, content_items)
+end
+
+-- ---------------------------------------------------------------------------
+-- Grid view: 4-column tile layout with folder icons and image thumbnails
+-- ---------------------------------------------------------------------------
+
+-- Build a single row hbox of `tiles` padded with empty spacers to keep
+-- the row width consistent when the last row isn't full. Letting an
+-- incomplete row collapse to its natural width would make the trailing
+-- column of tiles ride against the right edge instead of staying in the
+-- grid alignment.
+local function build_grid_row(tiles, cols)
+    local children = {}
+    for i = 1, cols do
+        if tiles[i] then
+            children[#children + 1] = tiles[i]
+        else
+            children[#children + 1] = { type = "spacer", w = TILE_W, grow = 0 }
+        end
+    end
+    return ui.padding({ 0, TILE_PAD_X, 0, TILE_PAD_X },
+        ui.hbox({ gap = TILE_GAP_X, w_grow = 0 }, children)
+    )
+end
+
+local function build_grid_content(self, path, files)
+    -- Linearise every interactive entry into a flat list first, then
+    -- chunk it into rows. Building rows in one pass would couple
+    -- ".."/folder/file handling to row boundaries and make adding new
+    -- entry types in the future surgery instead of an append.
+    local tiles = {}
+
+    if path ~= "/fs/" and path ~= "/sd/" then
+        tiles[#tiles + 1] = {
+            type       = "file_tile",
+            _label     = "..",
+            _kind      = "dir",
+            on_press   = function()
+                self:set_state({ path = get_parent(path) })
+            end,
+        }
+    end
+
+    if files then
+        for _, f in ipairs(files) do
+            if f.is_dir then
+                local name = f.name
+                local sub  = path .. name .. "/"
+                tiles[#tiles + 1] = {
+                    type       = "file_tile",
+                    _label     = name,
+                    _kind      = "dir",
+                    on_press   = function() self:set_state({ path = sub }) end,
+                    on_long_press = function()
+                        show_dir_menu(self, path, name)
+                    end,
+                }
+            else
+                local full  = path .. f.name
+                local image = is_image_name(f.name)
+                tiles[#tiles + 1] = {
+                    type        = "file_tile",
+                    _label      = f.name,
+                    _kind       = image and "image" or "file",
+                    _ext        = get_ext(f.name),
+                    _file_path  = full,
+                    _is_image   = image,
+                    on_press    = function() activate_file(self, path, f) end,
+                    on_long_press = function() show_file_menu(self, path, f) end,
+                }
+            end
+        end
+    end
+
+    if #tiles == 0 then
+        return ui.padding({ 20, 10, 10, 10 },
+            ui.text_widget("Empty directory", {
+                color = "TEXT_MUTED",
+                text_align = "center",
+            })
+        )
+    end
+
+    local rows = {}
+    for r = 1, math.ceil(#tiles / GRID_COLS) do
+        local row_tiles = {}
+        for c = 1, GRID_COLS do
+            local idx = (r - 1) * GRID_COLS + c
+            row_tiles[c] = tiles[idx]
+        end
+        rows[#rows + 1] = build_grid_row(row_tiles, GRID_COLS)
+    end
+
+    return ui.vbox({ gap = TILE_GAP_Y }, rows)
+end
+
+-- ---------------------------------------------------------------------------
+-- FileMgr:build: shell + dispatch to list_view or grid_view
+-- ---------------------------------------------------------------------------
+
 function FileMgr:build(state)
     local path = state.path or "/fs/"
     local items = {}
@@ -338,95 +822,37 @@ function FileMgr:build(state)
         ui.text_widget(info_text, { color = "TEXT_MUTED", font = "tiny_aa" })
     )
 
-    local content_items = {}
-
-    -- Parent directory entry (when not at root)
-    if path ~= "/fs/" and path ~= "/sd/" then
-        content_items[#content_items + 1] = ui.list_item({
-            title = "..",
-            compact = true,
-            on_press = function()
-                self:set_state({ path = get_parent(path) })
-            end,
-        })
-    end
-
-    -- New folder action
-    content_items[#content_items + 1] = ui.list_item({
-        title = "+ New Folder",
-        compact = true,
-        on_press = function()
-            prompt_name("New Folder", "", function(name)
-                ez.storage.mkdir(path .. name)
-                self:set_state({ path = path })
-            end)
-        end,
-    })
-
-    -- List directory contents
+    -- List directory contents (sort directories first, then alphabetically).
+    -- Both views share the same sort + filter so toggling preserves order.
     local files = ez.storage.list_dir(path)
     if files then
-        -- Sort: directories first, then files alphabetically
         table.sort(files, function(a, b)
             if a.is_dir ~= b.is_dir then return a.is_dir end
             return a.name < b.name
         end)
-
-        for _, f in ipairs(files) do
-            if f.is_dir then
-                content_items[#content_items + 1] = ui.list_item({
-                    title = f.name .. "/",
-                    compact = true,
-                    on_press = function()
-                        self:set_state({ path = path .. f.name .. "/" })
-                    end,
-                    on_long_press = function()
-                        show_dir_menu(self, path, f.name)
-                    end,
-                })
-            else
-                local full = path .. f.name
-                local image = is_image_name(f.name)
-                content_items[#content_items + 1] = ui.list_item({
-                    title = f.name,
-                    trailing = format_size(f.size),
-                    compact = true,
-                    -- Extra fields read by FileMgr:update() to drive the hover preview
-                    _file_path = full,
-                    _is_image  = image,
-                    on_press = function()
-                        if image then
-                            local IV = require("screens.tools.image_viewer")
-                            screen_mod.push(screen_mod.create(IV, IV.initial_state(full)))
-                        elseif apps.open(full) then
-                            -- A registered app handled the open. The
-                            -- registry is responsible for pushing the
-                            -- relevant screen.
-                        else
-                            show_file_menu(self, path, f)
-                        end
-                    end,
-                })
-            end
-        end
     end
 
-    if not files or #files == 0 then
-        content_items[#content_items + 1] = ui.padding({ 20, 10, 10, 10 },
-            ui.text_widget("Empty directory", {
-                color = "TEXT_MUTED",
-                text_align = "center",
-            })
-        )
+    local view = state.view or "list"
+    local content
+    if view == "grid" then
+        content = build_grid_content(self, path, files)
+    else
+        content = build_list_content(self, path, files)
     end
 
-    local content = ui.vbox({ gap = 0 }, content_items)
     local scroller = ui.scroll({ grow = 1, scroll_offset = state.scroll or 0 }, content)
-    -- zstack: list scrolls underneath, thumbnail overlay sits on top
-    items[#items + 1] = ui.zstack({ grow = 1 }, {
-        scroller,
-        { type = "thumb_overlay" },
-    })
+    if view == "grid" then
+        -- Grid view does its own per-tile thumbnails; no bottom-right
+        -- hover preview is needed (and it would partially occlude the
+        -- last row of tiles).
+        items[#items + 1] = scroller
+    else
+        -- List view: thumbnail overlay sits on top of the scroller.
+        items[#items + 1] = ui.zstack({ grow = 1 }, {
+            scroller,
+            { type = "thumb_overlay" },
+        })
+    end
 
     return ui.vbox({ gap = 0, bg = "BG" }, items)
 end
@@ -439,10 +865,32 @@ local function clear_preview()
     preview_loading = false
 end
 
+function FileMgr:on_enter()
+    -- Restore the user's last-used view layout. Pref is read once on
+    -- entry so the rebuild that follows a Tab-switch or directory
+    -- change keeps the same layout without re-touching NVS.
+    local saved = ez.storage.get_pref("fm_view", "list")
+    if saved ~= "list" and saved ~= "grid" then saved = "list" end
+    if self._state.view ~= saved then
+        self:set_state({ view = saved })
+    end
+end
+
 function FileMgr:update()
+    -- Hover preview is a list-view-only affordance; the grid renders
+    -- thumbnails inline on each tile, so we skip the hover machinery
+    -- (and avoid stale `preview_path` leaking across a view switch).
+    if (self._state.view or "list") ~= "list" then
+        if self._hover_path then
+            self._hover_path = nil
+            clear_preview()
+            screen_mod.invalidate()
+        end
+        return
+    end
+
     -- Watch the focused node; when it's an image item, kick off an async
     -- load after a short hover delay and invalidate when the data arrives.
-    local focus_mod = require("ezui.focus")
     local n = focus_mod.current()
 
     if n and n._is_image and n._file_path then
@@ -480,18 +928,50 @@ end
 
 function FileMgr:on_exit()
     clear_preview()
+    -- The grid's thumbnail sprites live in PSRAM; release them when the
+    -- file manager goes away. A return to file manager will repopulate
+    -- the cache from the visible tiles -- cheap because async_read +
+    -- decode happen off the main thread.
+    clear_thumb_cache()
 end
 
 -- Global menu (Alt+M). Keeps menu items tied to the file-manager's
 -- current folder, so "Receive file here" lands the incoming file
--- in whichever directory is visible.
+-- in whichever directory is visible. The view toggle lives here too
+-- so it's discoverable without stealing a single-letter key.
 function FileMgr:menu()
     local path = self._state.path or "/fs/"
+    local view = self._state.view or "list"
     local ft = require("services.file_transfer")
     local armed, armed_path = ft.is_armed()
     local armed_here = armed and armed_path == path
 
     local items = {}
+
+    items[#items + 1] = {
+        title    = view == "grid" and "Switch to list view"
+                   or "Switch to grid view",
+        subtitle = view == "grid"
+                   and "Show a single column with file sizes"
+                   or "Show icons and image thumbnails in a 4-column grid",
+        on_press = function()
+            local next_view = view == "grid" and "list" or "grid"
+            ez.storage.set_pref("fm_view", next_view)
+            self:set_state({ view = next_view, scroll = 0 })
+        end,
+    }
+
+    items[#items + 1] = {
+        title    = "New folder",
+        subtitle = "Create a folder in " .. path,
+        on_press = function()
+            prompt_name("New Folder", "", function(name)
+                ez.storage.mkdir(path .. name)
+                self:set_state({ path = path })
+            end)
+        end,
+    }
+
     items[#items + 1] = {
         title    = armed_here and "Stop receiving" or "Receive file here",
         subtitle = armed_here and armed_path
@@ -541,7 +1021,6 @@ function FileMgr:handle_key(key)
     -- M: show the actions menu for the focused item (primary way to reach
     -- rename/delete/wallpaper for images, since ENTER now opens the viewer).
     if key.character == "m" then
-        local focus_mod = require("ezui.focus")
         local n = focus_mod.current()
         if n and n._file_path then
             local p = self._state.path or "/fs/"

--- a/lua/screens/tools/image_viewer.lua
+++ b/lua/screens/tools/image_viewer.lua
@@ -1,5 +1,7 @@
 -- Image Viewer: pan and zoom a JPEG/PNG from storage.
--- Arrows pan, z/x zoom in/out, r resets, q/ESC quits.
+-- Arrows pan when the image extends beyond the viewport; otherwise
+-- LEFT / RIGHT step to the previous / next image in the same folder.
+-- z/x zoom in/out, r resets, q/ESC quits.
 
 local ui = require("ezui")
 local theme = require("ezui.theme")
@@ -15,6 +17,39 @@ local VIEW_TOP = 18  -- leave room for title bar
 -- Per-instance state lives on the instance; these locals are just used by the
 -- custom node for the currently-active viewer.
 local active_data, active_state
+
+local function is_image_name(name)
+    local l = name:lower()
+    return l:match("%.jpe?g$") ~= nil or l:match("%.png$") ~= nil
+end
+
+-- Split "/dir/file.jpg" into ("/dir/", "file.jpg"). Roots ("/fs/", "/sd/")
+-- keep their trailing slash so callers can append a filename without a
+-- separate check. Returns nil for malformed input so the caller can fall
+-- back gracefully.
+local function split_path(p)
+    if not p or p == "" then return nil, nil end
+    local dir, name = p:match("^(.*/)([^/]+)$")
+    if not dir then return nil, p end
+    return dir, name
+end
+
+-- List sibling images in `dir`, sorted alphabetically. Excludes
+-- subdirectories so the prev/next navigation stays a horizontal stroll
+-- through the visible JPEGs/PNGs the user just saw in the file manager.
+local function list_siblings(dir)
+    if not dir or dir == "" then return {} end
+    local entries = ez.storage.list_dir(dir)
+    if not entries then return {} end
+    local out = {}
+    for _, f in ipairs(entries) do
+        if not f.is_dir and is_image_name(f.name) then
+            out[#out + 1] = f.name
+        end
+    end
+    table.sort(out)
+    return out
+end
 
 if not node_mod.handler("image_canvas") then
     node_mod.register("image_canvas", {
@@ -76,6 +111,8 @@ if not node_mod.handler("image_canvas") then
 end
 
 function Viewer.initial_state(path)
+    -- siblings + index are populated in on_enter so set_state doesn't
+    -- have to re-scan the directory on every prev/next.
     return {
         path     = path,
         data     = nil,
@@ -87,16 +124,26 @@ function Viewer.initial_state(path)
         pan_y    = 0,
         loading  = true,
         error    = nil,
+        dir      = nil,
+        siblings = nil,
+        index    = nil,
     }
 end
 
 function Viewer:build(state)
     active_data = state.data
     active_state = state
-    local short = state.path or ""
-    if #short > 28 then short = "..." .. short:sub(#short - 25) end
+    -- The in-screen title_bar only renders the "Back" affordance plus
+    -- an optional `right` label, so the folder-position indicator goes
+    -- in `right`. The siblings field is populated asynchronously in
+    -- on_enter, so the indicator only lights up once the dir scan
+    -- finishes (single-image folders never show it).
+    local right
+    if state.siblings and state.index and #state.siblings > 1 then
+        right = string.format("%d / %d", state.index, #state.siblings)
+    end
     return ui.vbox({ gap = 0, bg = "BG" }, {
-        ui.title_bar(short, { back = true }),
+        ui.title_bar(state.path or "", { back = true, right = right }),
         { type = "image_canvas", grow = 1 },
     })
 end
@@ -112,14 +159,33 @@ local function fit_to_screen(state)
     state.pan_y = 0
 end
 
-function Viewer:on_enter()
-    local state = self._state
+-- Load the file at `state.path` into `state.data` + dimensions, then
+-- fit to screen. Used by on_enter for the first image and by navigate()
+-- for every subsequent prev/next step. The path-stale check after the
+-- async read means rapid LEFT/RIGHT presses don't paint the wrong image
+-- when reads complete out of order.
+local function load_image(state)
+    state.loading = true
+    state.error   = nil
+    state.data    = nil
+    state.img_w   = 0
+    state.img_h   = 0
+    state.is_png  = state.path and state.path:lower():match("%.png$") ~= nil
+    -- Show a "Loading..." placeholder immediately on the current canvas.
+    active_data  = nil
+    active_state = state
+    screen_mod.invalidate()
+
     local async = require("ezui.async")
+    local target_path = state.path
     async.task(function()
-        local data = async_read(state.path)
+        local data = async_read(target_path)
+        -- The user may have stepped to another image while this read
+        -- was in flight; drop the result so we don't clobber the new
+        -- state with stale bytes.
+        if state.path ~= target_path then return end
         if data and #data > 0 then
             state.data = data
-            -- Parse dimensions from JPEG SOF or PNG IHDR header
             local w, h = ez.display.get_image_size(data)
             if w then state.img_w, state.img_h = w, h end
             fit_to_screen(state)
@@ -136,9 +202,55 @@ function Viewer:on_enter()
     end)
 end
 
+function Viewer:on_enter()
+    local state = self._state
+    -- Resolve siblings + the entry's index once, in a background task,
+    -- so the directory listing doesn't block the first paint. The
+    -- viewer is usable for the single current image immediately; the
+    -- prev/next affordance lights up once the scan completes.
+    if not state.siblings then
+        local async = require("ezui.async")
+        async.task(function()
+            local dir, name = split_path(state.path)
+            if not dir then return end
+            local sibs = list_siblings(dir)
+            local idx = 1
+            for i, s in ipairs(sibs) do
+                if s == name then idx = i; break end
+            end
+            -- Drop results if the path moved on under us.
+            if state.path ~= (dir .. (name or "")) then return end
+            state.dir      = dir
+            state.siblings = sibs
+            state.index    = idx
+            screen_mod.invalidate()
+        end)
+    end
+
+    load_image(state)
+end
+
 function Viewer:on_exit()
     active_data = nil
     active_state = nil
+end
+
+-- Step to the previous or next image in the same folder. dir = -1
+-- (prev) or +1 (next). Clamps at the ends so the very first / last
+-- image is a no-op (no wraparound -- it should feel like a tape, not
+-- a carousel). Routed through set_state so the title bar's "N/M"
+-- indicator rebuilds along with the canvas.
+function Viewer:navigate(dir)
+    local state = self._state
+    if not state.siblings or #state.siblings <= 1 then return false end
+    if not state.index then return false end
+    local target = state.index + dir
+    if target < 1 or target > #state.siblings then return false end
+    state.index = target
+    state.path  = (state.dir or "") .. state.siblings[target]
+    self:set_state({ path = state.path, index = target })
+    load_image(state)
+    return true
 end
 
 local PAN_STEP = 24
@@ -164,6 +276,18 @@ local function clamp_pan(state)
     end
 end
 
+-- True when the rendered image is wider/taller than the viewport in
+-- the given axis, so panning is possible. Used to decide whether
+-- LEFT/RIGHT should pan or page to the next image.
+local function can_pan_x(state)
+    local vw = SW
+    return math.floor((state.img_w or 0) * state.scale) > vw
+end
+local function can_pan_y(state)
+    local vh = SH - VIEW_TOP
+    return math.floor((state.img_h or 0) * state.scale) > vh
+end
+
 function Viewer:handle_key(key)
     if key.special == "BACKSPACE" or key.special == "ESCAPE" then
         return "pop"
@@ -173,14 +297,29 @@ function Viewer:handle_key(key)
     local state = self._state
     local changed = false
 
-    if key.special == "UP" then
-        state.pan_y = state.pan_y + PAN_STEP; changed = true
-    elseif key.special == "DOWN" then
-        state.pan_y = state.pan_y - PAN_STEP; changed = true
-    elseif key.special == "LEFT" then
-        state.pan_x = state.pan_x + PAN_STEP; changed = true
+    -- LEFT/RIGHT: pan when the image is wider than the viewport (the
+    -- user is actively framing a region); otherwise page to the
+    -- previous / next sibling image in the folder.
+    if key.special == "LEFT" then
+        if can_pan_x(state) then
+            state.pan_x = state.pan_x + PAN_STEP; changed = true
+        else
+            if self:navigate(-1) then return "handled" end
+        end
     elseif key.special == "RIGHT" then
-        state.pan_x = state.pan_x - PAN_STEP; changed = true
+        if can_pan_x(state) then
+            state.pan_x = state.pan_x - PAN_STEP; changed = true
+        else
+            if self:navigate(1) then return "handled" end
+        end
+    elseif key.special == "UP" then
+        if can_pan_y(state) then
+            state.pan_y = state.pan_y + PAN_STEP; changed = true
+        end
+    elseif key.special == "DOWN" then
+        if can_pan_y(state) then
+            state.pan_y = state.pan_y - PAN_STEP; changed = true
+        end
     elseif key.character == "z" or key.character == "+" or key.character == "=" then
         state.scale = state.scale * ZOOM_STEP
         if state.scale > 8 then state.scale = 8 end


### PR DESCRIPTION
## Summary

- File manager gets a 4-column grid layout alongside the existing list view. Folders use the existing folder icon, images decode an inline thumbnail into a small LRU sprite cache, other files get a typed extension badge (LUA, MD, WAV, BIN, ...).
- Image viewer learns about sibling images in the same folder. LEFT / RIGHT pages between them when the current image fits the viewport; when zoomed past fit, the arrows keep their pan semantics.
- View choice persists across opens in the \`fm_view\` NVS pref. Toggle lives in the Alt+M global menu (\"Switch to grid view\" / \"Switch to list view\"). New Folder also moves into the menu so the grid doesn't need a synthetic \"+\" tile.

## Design notes

- **Thumb cache**: 12 sprites max at 48x48 RGB565 (~6 KB each). Strict LRU on insert, destroy on eviction. Failed decodes are marked so the worker isn't pinned on broken files. \`on_exit\` clears the cache so navigating away returns the PSRAM.
- **Grid navigation**: file_tile's \`on_key\` traps LEFT/RIGHT as single-step focus moves and UP/DOWN as a four-tile stride, matching the row-major chain order.
- **Stale-read guard**: rapid LEFT/RIGHT in the viewer can land out-of-order \`async_read\` completions; each completion checks \`state.path == target_path\` before painting so the canvas can't end up showing the wrong image.
- **Title indicator**: \`title_bar\`'s \`right\` slot renders the \"N / M\" position (the widget doesn't render \`n.title\`). Single-image folders stay quiet.

## Verified on device

- Grid renders folder + image + badge tiles correctly in \`/fs/\` and \`/fs/wallpapers/\`. Focus highlight uses SURFACE_ALT plate + accent border.
- ENTER on an image tile opens the viewer at the right entry (index 1 of 47).
- LEFT / RIGHT inside the viewer paged \`1/47\` -> \`2/47\` -> \`1/47\`, title bar updated each step.
- Zoom-in (z, scale ~1.8) made LEFT pan the image instead of paging; the index stayed put.
- List view unchanged (still default for users who haven't toggled).

## Test plan

- [x] \`pio run\` clean
- [x] Flash + grid renders thumbnails for wallpapers
- [x] LEFT/RIGHT pages images, UP/DOWN strides rows, ENTER opens viewer
- [x] LEFT/RIGHT inside viewer pages (and pans when zoomed in)
- [x] List view still works for users who don't toggle
- [ ] Visual review at the keyboard (Alt+M chord -- the remote tool doesn't always route the alt modifier identically, but the physical key works)

Closes nothing; this is the first pass at grid + paging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)